### PR TITLE
feat: portfolio allocation donut chart (issue #12)

### DIFF
--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import plotly.graph_objects as go
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,6 +24,37 @@ async def _get_or_404(holding_id: int, db: AsyncSession) -> Holding:
     if result is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Holding not found")
     return result
+
+
+@router.get("/chart/allocation")
+async def get_allocation_chart(
+    db: AsyncSession = _DB,
+) -> JSONResponse:
+    """Return a Plotly donut chart of portfolio allocation as JSON."""
+    summary = await PortfolioService().get_summary(db)
+    valued = [h for h in summary.holdings if h.current_value is not None]
+
+    if not valued:
+        return JSONResponse(content={})
+
+    fig = go.Figure(
+        go.Pie(
+            labels=[h.ticker for h in valued],
+            values=[float(h.current_value) for h in valued],  # type: ignore[arg-type]
+            hole=0.5,
+            customdata=[h.name for h in valued],
+            hovertemplate=(
+                "<b>%{label}</b> — %{customdata}<br>"
+                "Value: %{value:,.2f}<br>"
+                "%{percent}<extra></extra>"
+            ),
+        )
+    )
+    fig.update_layout(
+        margin={"t": 20, "b": 20, "l": 20, "r": 20},
+        showlegend=True,
+    )
+    return JSONResponse(content=fig.to_dict())
 
 
 @router.get("/summary", response_model=PortfolioSummary)

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Portfolio Overview</title>
   <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
   <style>
     body { font-family: sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; }
     h1 { margin-bottom: 1rem; }
@@ -46,6 +47,10 @@
     .ticker-valid  { color: #2e7d32; font-size: 0.85rem; }
     .ticker-invalid { color: #c62828; font-size: 0.85rem; }
 
+    /* Allocation chart */
+    .chart-section { margin-bottom: 2rem; }
+    .chart-section h2 { font-size: 1rem; font-weight: 600; margin: 0 0 0.5rem; }
+
     /* Inline edit */
     .inline-form { display: flex; align-items: center; gap: 0.5rem; justify-content: flex-end; }
     .qty-input { width: 100px; padding: 0.3rem 0.5rem; border: 1px solid #ccc; border-radius: 4px; font-size: 0.9rem; }
@@ -62,6 +67,25 @@
     hx-swap="innerHTML">+ Add Holding</button>
 
   <div id="add-form-slot"></div>
+
+  {% if total_value is not none %}
+  <div class="chart-section">
+    <h2>Portfolio Allocation</h2>
+    <div id="allocation-chart" style="height: 350px;"></div>
+  </div>
+  <script>
+    (async () => {
+      const resp = await fetch('/api/v1/holdings/chart/allocation');
+      const fig = await resp.json();
+      if (fig && fig.data) {
+        Plotly.newPlot('allocation-chart', fig.data, fig.layout, {
+          responsive: true,
+          displayModeBar: false,
+        });
+      }
+    })();
+  </script>
+  {% endif %}
 
   {% if holdings %}
   <table>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
     # Stock data
     "yfinance>=0.2.40",
 
+    # Charting
+    "plotly>=5.0.0",
+
     # Auth
     "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",
@@ -83,6 +86,10 @@ ignore = []
 python_version = "3.12"
 strict = true
 plugins = ["pydantic.mypy"]
+
+[[tool.mypy.overrides]]
+module = "plotly.*"
+ignore_missing_imports = true
 
 # --- Pytest ---
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/holdings/chart/allocation` endpoint that returns a Plotly donut chart figure as JSON
- Each slice represents one holding sized by current market value; hover shows ticker, name, value, and percentage
- Renders via Plotly.js (CDN) on the portfolio overview page — chart appears when at least one holding has a price

## Changes

- `pyproject.toml`: add `plotly>=5.0.0` dependency; add `[[tool.mypy.overrides]]` to suppress `import-not-found` for untyped plotly package
- `app/routers/holdings.py`: new `get_allocation_chart` endpoint
- `app/templates/portfolio.html`: include Plotly.js CDN, chart container `<div>`, and fetch/render script

## Test plan

- [ ] Confirm all existing tests still pass (`pytest`)
- [ ] Start the app with holdings that have current prices — chart should render above the holdings table
- [ ] Hover over slices to verify ticker, name, value, and percentage appear
- [ ] Confirm chart does not appear when no holdings have prices (no API call made)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)