### PR TITLE
fix: eager-load stock relationship to avoid async lazy load error

### DIFF
--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -11,6 +11,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.database import get_async_session
 from app.models.holding import Holding
@@ -39,7 +40,7 @@ async def portfolio_overview(
     db: AsyncSession = _DB,
 ) -> HTMLResponse:
     """Render the portfolio overview page."""
-    rows_result = await db.execute(select(Holding).join(Holding.stock))
+    rows_result = await db.execute(select(Holding).options(selectinload(Holding.stock)))
     holdings = rows_result.scalars().all()
 
     holding_rows: list[HoldingRow] = []


### PR DESCRIPTION
## Summary
- Replaced `.join(Holding.stock)` with `.options(selectinload(Holding.stock))` in the portfolio overview query
- Prevents `sqlalchemy.exc.MissingGreenlet` error caused by SQLAlchemy attempting a synchronous lazy load inside an async context

## Test plan
- [ ] Load the portfolio overview page (`GET /`) and verify it renders without a 500 error
- [ ] Confirm holdings and their stock details display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)