### PR TITLE
feat: portfolio performance line chart (issue #13)

### DIFF
--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -26,6 +26,39 @@ async def _get_or_404(holding_id: int, db: AsyncSession) -> Holding:
     return result
 
 
+@router.get("/chart/performance")
+async def get_performance_chart(
+    db: AsyncSession = _DB,
+) -> JSONResponse:
+    """Return a Plotly line chart of total portfolio value over the past year."""
+    performance = await PortfolioService().get_performance_history(db)
+
+    if not performance:
+        return JSONResponse(content={})
+
+    dates = [str(d) for d, _ in performance]
+    values = [float(v) for _, v in performance]
+
+    fig = go.Figure(
+        go.Scatter(
+            x=dates,
+            y=values,
+            mode="lines",
+            line={"color": "#0066cc", "width": 2},
+            hovertemplate="%{x}<br>Value: %{y:,.2f}<extra></extra>",
+        )
+    )
+    fig.update_layout(
+        margin={"t": 20, "b": 40, "l": 60, "r": 20},
+        xaxis={"showgrid": False},
+        yaxis={"tickformat": ",.0f", "showgrid": True, "gridcolor": "#eee"},
+        hovermode="x unified",
+        plot_bgcolor="#fff",
+        paper_bgcolor="#fff",
+    )
+    return JSONResponse(content=fig.to_dict())
+
+
 @router.get("/chart/allocation")
 async def get_allocation_chart(
     db: AsyncSession = _DB,

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import datetime
 from decimal import Decimal
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.holding import Holding
+from app.models.price_cache import PriceCache
 from app.schemas.holdings import HoldingSummaryItem, PortfolioSummary
 
 
@@ -44,3 +46,43 @@ class PortfolioService:
             )
 
         return PortfolioSummary(holdings=items, total_value=total_value)
+
+    async def get_performance_history(
+        self, db: AsyncSession
+    ) -> list[tuple[datetime.date, Decimal]]:
+        """Return daily total portfolio values for the past year.
+
+        For each date in PriceCache, the portfolio value is calculated as
+        sum(quantity × close_price) across all holdings that have a cached
+        price on that date.  Dates with no price data are omitted.
+        """
+        rows = await db.execute(select(Holding).join(Holding.stock))
+        holdings = rows.scalars().all()
+
+        if not holdings:
+            return []
+
+        tickers = [h.stock.ticker for h in holdings]
+        qty_by_ticker = {h.stock.ticker: h.quantity for h in holdings}
+
+        one_year_ago = datetime.date.today() - datetime.timedelta(days=365)
+        price_rows = await db.execute(
+            select(PriceCache.ticker, PriceCache.date, PriceCache.close_price)
+            .where(
+                PriceCache.ticker.in_(tickers),
+                PriceCache.date >= one_year_ago,
+            )
+            .order_by(PriceCache.date)
+        )
+
+        prices_by_date: dict[datetime.date, dict[str, Decimal]] = {}
+        for ticker, date, close_price in price_rows:
+            prices_by_date.setdefault(date, {})[ticker] = close_price
+
+        performance: list[tuple[datetime.date, Decimal]] = []
+        for date in sorted(prices_by_date):
+            day_prices = prices_by_date[date]
+            total = sum(qty_by_ticker[t] * p for t, p in day_prices.items())
+            performance.append((date, total))
+
+        return performance

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -82,7 +82,7 @@ class PortfolioService:
         performance: list[tuple[datetime.date, Decimal]] = []
         for date in sorted(prices_by_date):
             day_prices = prices_by_date[date]
-            total = sum(qty_by_ticker[t] * p for t, p in day_prices.items())
+            total = sum((qty_by_ticker[t] * p for t, p in day_prices.items()), Decimal("0"))
             performance.append((date, total))
 
         return performance

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -70,6 +70,23 @@
 
   {% if total_value is not none %}
   <div class="chart-section">
+    <h2>Portfolio Performance (1Y)</h2>
+    <div id="performance-chart" style="height: 300px;"></div>
+  </div>
+  <script>
+    (async () => {
+      const resp = await fetch('/api/v1/holdings/chart/performance');
+      const fig = await resp.json();
+      if (fig && fig.data) {
+        Plotly.newPlot('performance-chart', fig.data, fig.layout, {
+          responsive: true,
+          displayModeBar: false,
+        });
+      }
+    })();
+  </script>
+
+  <div class="chart-section">
     <h2>Portfolio Allocation</h2>
     <div id="allocation-chart" style="height: 350px;"></div>
   </div>


### PR DESCRIPTION
## Summary

- Adds `PortfolioService.get_performance_history()` which queries `PriceCache` for all held tickers over the past year and computes the daily total portfolio value (`sum(quantity × close_price)`)
- Adds `GET /api/v1/holdings/chart/performance` endpoint returning a Plotly `Scatter` line chart as JSON
- Renders the performance chart on the portfolio overview page, above the existing allocation donut chart

## Test plan

- [ ] All existing tests pass (`docker compose run --rm app pytest`)
- [ ] Portfolio overview page shows the "Portfolio Performance (1Y)" line chart when holdings exist
- [ ] Hovering a point on the chart shows the date and formatted value
- [ ] Chart is not rendered when there are no holdings (same guard as allocation chart)
- [ ] Endpoint returns `{}` when no holdings or no price cache data exists

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)