### PR TITLE
feat: individual stock detail view (issue #14)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import Settings, get_settings
 from app.database import build_engine, build_session_factory, close_db, init_db
-from app.routers import health, holdings, htmx, portfolio
+from app.routers import health, holdings, htmx, portfolio, stocks
 
 __all__ = ["app", "create_app"]
 
@@ -129,6 +129,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # ------------------------------------------------------------------
     app.include_router(health.router)
     app.include_router(portfolio.router)
+    app.include_router(stocks.router)
     app.include_router(holdings.router, prefix="/api/v1")
     app.include_router(htmx.router)
     # Future routers (uncomment as implemented):

--- a/app/routers/stocks.py
+++ b/app/routers/stocks.py
@@ -1,0 +1,129 @@
+"""Routes for individual stock detail pages."""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+
+import plotly.graph_objects as go
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.requests import Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.models.holding import Holding
+from app.models.price_cache import PriceCache
+from app.models.stock import Stock
+
+router = APIRouter(tags=["stocks"])
+
+_TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+
+_DB = Depends(get_async_session)
+
+
+@dataclass
+class StockDetail:
+    ticker: str
+    name: str
+    currency: str
+    current_price: Decimal | None
+    quantity: Decimal | None
+    current_value: Decimal | None
+
+
+async def _get_stock_or_404(ticker: str, db: AsyncSession) -> Stock:
+    result = await db.execute(select(Stock).where(Stock.ticker == ticker.upper()))
+    stock = result.scalar_one_or_none()
+    if stock is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Stock '{ticker}' not found",
+        )
+    return stock
+
+
+@router.get("/stocks/{ticker}", response_class=HTMLResponse)
+async def stock_detail(
+    ticker: str,
+    request: Request,
+    db: AsyncSession = _DB,
+) -> HTMLResponse:
+    """Render the stock detail page for the given ticker."""
+    stock = await _get_stock_or_404(ticker, db)
+
+    holding_result = await db.execute(select(Holding).where(Holding.stock_id == stock.id))
+    holding = holding_result.scalar_one_or_none()
+
+    quantity: Decimal | None = None
+    current_value: Decimal | None = None
+    if holding is not None:
+        quantity = holding.quantity
+        if stock.current_price is not None:
+            current_value = quantity * stock.current_price
+
+    detail = StockDetail(
+        ticker=stock.ticker,
+        name=stock.name,
+        currency=stock.currency,
+        current_price=stock.current_price,
+        quantity=quantity,
+        current_value=current_value,
+    )
+
+    return templates.TemplateResponse(
+        request=request,
+        name="stock_detail.html",
+        context={"stock": detail},
+    )
+
+
+@router.get("/api/v1/stocks/{ticker}/chart/price-history")
+async def get_price_history_chart(
+    ticker: str,
+    db: AsyncSession = _DB,
+) -> JSONResponse:
+    """Return a Plotly line chart of the stock's 1Y price history as JSON."""
+    await _get_stock_or_404(ticker, db)
+
+    one_year_ago = datetime.date.today() - datetime.timedelta(days=365)
+    price_rows = await db.execute(
+        select(PriceCache.date, PriceCache.close_price)
+        .where(
+            PriceCache.ticker == ticker.upper(),
+            PriceCache.date >= one_year_ago,
+        )
+        .order_by(PriceCache.date)
+    )
+    prices = price_rows.all()
+
+    if not prices:
+        return JSONResponse(content={})
+
+    dates = [str(row.date) for row in prices]
+    values = [float(row.close_price) for row in prices]
+
+    fig = go.Figure(
+        go.Scatter(
+            x=dates,
+            y=values,
+            mode="lines",
+            line={"color": "#0066cc", "width": 2},
+            hovertemplate="%{x}<br>Price: %{y:,.2f}<extra></extra>",
+        )
+    )
+    fig.update_layout(
+        margin={"t": 20, "b": 40, "l": 60, "r": 20},
+        xaxis={"showgrid": False},
+        yaxis={"tickformat": ",.2f", "showgrid": True, "gridcolor": "#eee"},
+        hovermode="x unified",
+        plot_bgcolor="#fff",
+        paper_bgcolor="#fff",
+    )
+    return JSONResponse(content=fig.to_dict())

--- a/app/templates/stock_detail.html
+++ b/app/templates/stock_detail.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ stock.name }} ({{ stock.ticker }})</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    body { font-family: sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; }
+    h1 { margin-bottom: 0.25rem; }
+    .subtitle { color: #555; margin-bottom: 2rem; }
+    a { color: #0066cc; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* Summary card */
+    .summary-card { border: 1px solid #ddd; border-radius: 6px; padding: 1.2rem 1.5rem; margin-bottom: 2rem; background: #fafafa; }
+    .summary-card h2 { margin: 0 0 1rem; font-size: 1rem; font-weight: 600; }
+    .summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; }
+    .summary-item { display: flex; flex-direction: column; }
+    .summary-label { font-size: 0.8rem; color: #777; text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 0.25rem; }
+    .summary-value { font-size: 1.1rem; font-weight: 600; }
+    .na { color: #999; font-weight: normal; }
+
+    /* Chart */
+    .chart-section { margin-bottom: 2rem; }
+    .chart-section h2 { font-size: 1rem; font-weight: 600; margin: 0 0 0.5rem; }
+    .no-data { color: #777; font-style: italic; }
+  </style>
+</head>
+<body>
+  <p><a href="/">&larr; Back to Portfolio</a></p>
+
+  <h1>{{ stock.name }}</h1>
+  <p class="subtitle">{{ stock.ticker }} &middot; {{ stock.currency }}</p>
+
+  <div class="summary-card">
+    <h2>Current Holding</h2>
+    <div class="summary-grid">
+      <div class="summary-item">
+        <span class="summary-label">Quantity</span>
+        <span class="summary-value">
+          {% if stock.quantity is not none %}
+            {{ stock.quantity }}
+          {% else %}
+            <span class="na">Not held</span>
+          {% endif %}
+        </span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Current Price</span>
+        <span class="summary-value">
+          {% if stock.current_price is not none %}
+            {{ "%.2f"|format(stock.current_price) }} {{ stock.currency }}
+          {% else %}
+            <span class="na">N/A</span>
+          {% endif %}
+        </span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Current Value</span>
+        <span class="summary-value">
+          {% if stock.current_value is not none %}
+            {{ "%.2f"|format(stock.current_value) }} {{ stock.currency }}
+          {% else %}
+            <span class="na">N/A</span>
+          {% endif %}
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <div class="chart-section">
+    <h2>Price History (1Y)</h2>
+    <div id="price-history-chart" style="height: 300px;"></div>
+  </div>
+  <script>
+    (async () => {
+      const resp = await fetch('/api/v1/stocks/{{ stock.ticker }}/chart/price-history');
+      const fig = await resp.json();
+      if (fig && fig.data) {
+        Plotly.newPlot('price-history-chart', fig.data, fig.layout, {
+          responsive: true,
+          displayModeBar: false,
+        });
+      } else {
+        document.getElementById('price-history-chart').innerHTML =
+          '<p class="no-data">No price history available yet. Data is refreshed daily.</p>';
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `GET /stocks/{ticker}` page with holding summary (quantity, current price, current value)
- Adds `GET /api/v1/stocks/{ticker}/chart/price-history` returning a Plotly 1Y price chart as JSON
- New template `app/templates/stock_detail.html` matching the existing portfolio page style
- Stock names in the portfolio table already link to `/stocks/{ticker}`

## Test plan
- [ ] Navigate to `/stocks/AAPL` (or any held ticker) — page renders with holding summary and chart
- [ ] Navigate to `/stocks/AAPL` for a ticker not in holdings — page renders with "Not held" in summary
- [ ] Navigate to `/stocks/INVALID` — returns 404
- [ ] Price history chart renders correctly when price cache data is available
- [ ] Chart section shows "No price history available yet" message when cache is empty

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)