### PR TITLE
fix: use selectinload to prevent MissingGreenlet on async lazy loads

### DIFF
--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.database import get_async_session
 from app.models.holding import Holding
@@ -20,7 +21,7 @@ _DB = Depends(get_async_session)
 
 
 async def _get_or_404(holding_id: int, db: AsyncSession) -> Holding:
-    result = await db.get(Holding, holding_id)
+    result = await db.get(Holding, holding_id, options=[selectinload(Holding.stock)])
     if result is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Holding not found")
     return result
@@ -103,7 +104,7 @@ async def list_holdings(
     db: AsyncSession = _DB,
 ) -> list[HoldingResponse]:
     """Return all holdings with ticker, name, and quantity."""
-    rows = await db.execute(select(Holding).join(Holding.stock))
+    rows = await db.execute(select(Holding).options(selectinload(Holding.stock)))
     holdings = rows.scalars().all()
     return [
         HoldingResponse(

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models.holding import Holding
 from app.models.price_cache import PriceCache
@@ -22,7 +23,7 @@ class PortfolioService:
         Holdings without a ``current_price`` contribute ``None`` for their
         value and are excluded from the ``total_value`` sum.
         """
-        rows = await db.execute(select(Holding).join(Holding.stock))
+        rows = await db.execute(select(Holding).options(selectinload(Holding.stock)))
         holdings = rows.scalars().all()
 
         items: list[HoldingSummaryItem] = []
@@ -56,7 +57,7 @@ class PortfolioService:
         sum(quantity × close_price) across all holdings that have a cached
         price on that date.  Dates with no price data are omitted.
         """
-        rows = await db.execute(select(Holding).join(Holding.stock))
+        rows = await db.execute(select(Holding).options(selectinload(Holding.stock)))
         holdings = rows.scalars().all()
 
         if not holdings:


### PR DESCRIPTION
## Summary
- Replace `.join(Holding.stock)` with `.options(selectinload(Holding.stock))` in `portfolio_service.py` (both `get_summary` and `get_performance_history`)
- Same fix in `holdings.py` for `list_holdings` and `_get_or_404`
- Fixes 500 errors on `/api/v1/holdings/chart/performance` and `/api/v1/holdings/chart/allocation`

## Root cause
`.join()` in SQLAlchemy only affects the SQL query for filtering — it does **not** populate the ORM relationship attribute. Accessing `h.stock.ticker` on the loaded objects triggered lazy loading, which fails with `MissingGreenlet` in an async context.

## Test plan
- [ ] `GET /api/v1/holdings/chart/performance` returns 200 with chart data
- [ ] `GET /api/v1/holdings/chart/allocation` returns 200 with chart data
- [ ] `GET /api/v1/holdings` returns 200
- [ ] `PUT /api/v1/holdings/{id}` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)