### PR TITLE
feat: broker PDF parser implementation (issue #16)

### DIFF
--- a/app/services/generic_parser.py
+++ b/app/services/generic_parser.py
@@ -1,0 +1,40 @@
+"""Generic tabular broker PDF parser."""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+from pathlib import Path
+
+import pdfplumber
+
+from app.services.pdf_parser import BaseBrokerParser
+
+# Matches lines like "AAPL 10.00000000" – a single all-caps ticker followed by
+# a decimal (or integer) quantity.
+_ROW_RE = re.compile(r"^([A-Z]{1,10})\s+([\d]+(?:\.[\d]+)?)$")
+
+
+class GenericTableParser(BaseBrokerParser):
+    """Parser for broker PDFs that contain a plain text table.
+
+    Each data row must have the format::
+
+        <TICKER>   <QUANTITY>
+
+    where *TICKER* is one-to-ten uppercase letters and *QUANTITY* is a decimal
+    number.  Header rows and free-text lines are ignored automatically.
+    """
+
+    def extract(self, pdf_path: Path) -> list[tuple[str, Decimal]]:
+        results: list[tuple[str, Decimal]] = []
+        with pdfplumber.open(pdf_path) as pdf:
+            for page in pdf.pages:
+                text = page.extract_text() or ""
+                for line in text.splitlines():
+                    m = _ROW_RE.match(line.strip())
+                    if m:
+                        ticker = m.group(1).upper()
+                        quantity = Decimal(m.group(2))
+                        results.append((ticker, quantity))
+        return results

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -1,0 +1,66 @@
+"""Service for importing broker PDF statements into the portfolio."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.holding import Holding
+from app.models.stock import Stock
+from app.services.pdf_parser import BaseBrokerParser
+
+
+class ImportService:
+    """Upsert holdings extracted from a broker PDF into the database.
+
+    For each ``(ticker, quantity)`` pair the parser returns:
+
+    * If a :class:`~app.models.holding.Holding` already exists for that
+      ticker its ``quantity`` is **increased** by the extracted amount.
+    * If no holding exists yet, a new one is created.
+    * Tickers without a matching :class:`~app.models.stock.Stock` row are
+      silently skipped.
+    """
+
+    async def import_from_pdf(
+        self,
+        pdf_path: Path,
+        parser: BaseBrokerParser,
+        db: AsyncSession,
+    ) -> list[tuple[str, Decimal]]:
+        """Parse *pdf_path* and upsert the extracted holdings.
+
+        Returns
+        -------
+        list[tuple[str, Decimal]]
+            ``(ticker, quantity_added)`` pairs for every ticker that was
+            successfully processed (i.e. had a matching Stock record).
+        """
+        pairs = parser.extract(pdf_path)
+        processed: list[tuple[str, Decimal]] = []
+
+        for ticker, qty in pairs:
+            stock_row = await db.execute(
+                select(Stock).where(Stock.ticker == ticker)
+            )
+            stock = stock_row.scalar_one_or_none()
+            if stock is None:
+                continue
+
+            holding_row = await db.execute(
+                select(Holding).where(Holding.stock_id == stock.id)
+            )
+            holding = holding_row.scalar_one_or_none()
+
+            if holding is None:
+                db.add(Holding(stock_id=stock.id, quantity=qty))
+            else:
+                holding.quantity += qty
+
+            processed.append((ticker, qty))
+
+        await db.flush()
+        return processed

--- a/tests/fixtures/generate_sample_pdf.py
+++ b/tests/fixtures/generate_sample_pdf.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Generate an anonymised sample broker PDF for use as a test fixture.
+
+Run from the repo root:
+    python tests/fixtures/generate_sample_pdf.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def create_broker_pdf(output_path: Path) -> None:
+    """Write a minimal but valid PDF containing a plain-text holdings table."""
+    lines = [
+        "BROKER PORTFOLIO STATEMENT 2024-01-15",
+        "",
+        "Ticker          Quantity",
+        "AAPL            10.00000000",
+        "MSFT            5.50000000",
+        "GOOGL           2.75000000",
+    ]
+
+    ops: list[str] = ["BT", "/F1 10 Tf", "50 750 Td"]
+    for i, line in enumerate(lines):
+        if i > 0:
+            ops.append("0 -15 Td")
+        escaped = line.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+        ops.append(f"({escaped}) Tj")
+    ops.append("ET")
+    content: bytes = ("\n".join(ops) + "\n").encode()
+
+    body = b"%PDF-1.4\n"
+    offsets: list[int] = []
+
+    def add(obj_bytes: bytes) -> None:
+        nonlocal body
+        offsets.append(len(body))
+        body += obj_bytes
+
+    add(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    add(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+    add(
+        b"3 0 obj\n"
+        b"<< /Type /Page /Parent 2 0 R "
+        b"/Resources << /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> "
+        b"/MediaBox [0 0 612 792] /Contents 4 0 R >>\n"
+        b"endobj\n"
+    )
+    stream_header = f"4 0 obj\n<< /Length {len(content)} >>\nstream\n".encode()
+    add(stream_header + content + b"endstream\nendobj\n")
+
+    xref_offset = len(body)
+    xref = b"xref\n0 5\n0000000000 65535 f \n"
+    for off in offsets:
+        xref += f"{off:010d} 00000 n \n".encode()
+
+    trailer = (
+        f"trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n"
+    ).encode()
+
+    output_path.write_bytes(body + xref + trailer)
+    print(f"Written: {output_path}")
+
+
+if __name__ == "__main__":
+    dest = Path(__file__).parent / "sample_holdings.pdf"
+    create_broker_pdf(dest)

--- a/tests/fixtures/sample_holdings.pdf
+++ b/tests/fixtures/sample_holdings.pdf
@@ -1,0 +1,42 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 247 >>
+stream
+BT
+/F1 10 Tf
+50 750 Td
+(BROKER PORTFOLIO STATEMENT 2024-01-15) Tj
+0 -15 Td
+() Tj
+0 -15 Td
+(Ticker          Quantity) Tj
+0 -15 Td
+(AAPL            10.00000000) Tj
+0 -15 Td
+(MSFT            5.50000000) Tj
+0 -15 Td
+(GOOGL           2.75000000) Tj
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000290 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+587
+%%EOF

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -1,0 +1,134 @@
+"""Tests for the GenericTableParser and ImportService."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.generic_parser import GenericTableParser
+from app.services.import_service import ImportService
+
+FIXTURE_PDF = Path(__file__).parent / "fixtures" / "sample_holdings.pdf"
+
+
+# ---------------------------------------------------------------------------
+# GenericTableParser – pure unit tests (no DB required)
+# ---------------------------------------------------------------------------
+
+
+def test_generic_parser_extracts_all_rows() -> None:
+    parser = GenericTableParser()
+    holdings = parser.extract(FIXTURE_PDF)
+    assert len(holdings) == 3
+
+
+def test_generic_parser_tickers_are_uppercase() -> None:
+    parser = GenericTableParser()
+    for ticker, _ in parser.extract(FIXTURE_PDF):
+        assert ticker == ticker.upper()
+        assert ticker.strip() == ticker
+
+
+def test_generic_parser_quantities() -> None:
+    parser = GenericTableParser()
+    by_ticker = dict(parser.extract(FIXTURE_PDF))
+    assert by_ticker["AAPL"] == Decimal("10.00000000")
+    assert by_ticker["MSFT"] == Decimal("5.50000000")
+    assert by_ticker["GOOGL"] == Decimal("2.75000000")
+
+
+def test_generic_parser_ignores_header_row() -> None:
+    """The 'Ticker  Quantity' header line must not appear in results."""
+    parser = GenericTableParser()
+    tickers = {t for t, _ in parser.extract(FIXTURE_PDF)}
+    assert "Ticker" not in tickers
+    assert "TICKER" not in tickers
+
+
+# ---------------------------------------------------------------------------
+# ImportService – upsert logic (async mocks, no DB required)
+# ---------------------------------------------------------------------------
+
+
+def _make_stock(ticker: str, stock_id: int = 1) -> MagicMock:
+    stock = MagicMock()
+    stock.id = stock_id
+    stock.ticker = ticker
+    return stock
+
+
+def _make_holding(stock_id: int, quantity: Decimal) -> MagicMock:
+    holding = MagicMock()
+    holding.stock_id = stock_id
+    holding.quantity = quantity
+    return holding
+
+
+def _db_with(stock: MagicMock | None, holding: MagicMock | None) -> AsyncMock:
+    """Build a minimal async DB session mock returning *stock* and *holding*."""
+    db = AsyncMock()
+    db.add = MagicMock()  # db.add is synchronous in SQLAlchemy
+
+    stock_result = MagicMock()
+    stock_result.scalar_one_or_none.return_value = stock
+
+    holding_result = MagicMock()
+    holding_result.scalar_one_or_none.return_value = holding
+
+    db.execute = AsyncMock(side_effect=[stock_result, holding_result])
+    return db
+
+
+@pytest.mark.asyncio
+async def test_import_creates_new_holding_when_none_exists() -> None:
+    stock = _make_stock("AAPL", stock_id=42)
+    db = _db_with(stock=stock, holding=None)
+
+    parser = MagicMock()
+    parser.extract.return_value = [("AAPL", Decimal("5"))]
+
+    service = ImportService()
+    result = await service.import_from_pdf(FIXTURE_PDF, parser, db)
+
+    assert result == [("AAPL", Decimal("5"))]
+    db.add.assert_called_once()
+    added: MagicMock = db.add.call_args[0][0]
+    assert added.stock_id == 42
+    assert added.quantity == Decimal("5")
+
+
+@pytest.mark.asyncio
+async def test_import_increases_existing_holding() -> None:
+    stock = _make_stock("MSFT", stock_id=7)
+    holding = _make_holding(stock_id=7, quantity=Decimal("10"))
+    db = _db_with(stock=stock, holding=holding)
+
+    parser = MagicMock()
+    parser.extract.return_value = [("MSFT", Decimal("2.5"))]
+
+    service = ImportService()
+    result = await service.import_from_pdf(FIXTURE_PDF, parser, db)
+
+    assert result == [("MSFT", Decimal("2.5"))]
+    assert holding.quantity == Decimal("12.5")
+    db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_import_skips_unknown_ticker() -> None:
+    db = AsyncMock()
+    no_stock = MagicMock()
+    no_stock.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=no_stock)
+
+    parser = MagicMock()
+    parser.extract.return_value = [("UNKNOWN", Decimal("1"))]
+
+    service = ImportService()
+    result = await service.import_from_pdf(FIXTURE_PDF, parser, db)
+
+    assert result == []
+    db.add.assert_not_called()

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 


### PR DESCRIPTION
## Summary
- Adds `GenericTableParser` — a concrete `BaseBrokerParser` subclass that uses `pdfplumber` to extract `(ticker, quantity)` pairs from plain-text tabular broker PDFs
- Adds `ImportService.import_from_pdf()` — async upsert logic: increases `Holding.quantity` on existing holdings, creates new holdings for unknown tickers, silently skips tickers with no matching `Stock` record
- Adds `tests/fixtures/sample_holdings.pdf` — anonymised 3-row PDF fixture (AAPL, MSFT, GOOGL) with a generator script at `tests/fixtures/generate_sample_pdf.py`

## Test plan
- [x] `test_generic_parser_extracts_all_rows` — fixture yields exactly 3 pairs
- [x] `test_generic_parser_tickers_are_uppercase` — tickers are stripped and upper-cased
- [x] `test_generic_parser_quantities` — decimal values round-trip correctly
- [x] `test_generic_parser_ignores_header_row` — "Ticker Quantity" header is excluded
- [x] `test_import_creates_new_holding_when_none_exists` — new `Holding` is added to the session
- [x] `test_import_increases_existing_holding` — existing quantity is incremented (10 + 2.5 → 12.5)
- [x] `test_import_skips_unknown_ticker` — no DB write when stock doesn't exist

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)