### PR TITLE
feat: PDF import UI (issue #17)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import Settings, get_settings
 from app.database import build_engine, build_session_factory, close_db, init_db
-from app.routers import health, holdings, htmx, portfolio, stocks
+from app.routers import health, holdings, htmx, import_pdf, portfolio, stocks
 
 __all__ = ["app", "create_app"]
 
@@ -132,6 +132,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(stocks.router)
     app.include_router(holdings.router, prefix="/api/v1")
     app.include_router(htmx.router)
+    app.include_router(import_pdf.router)
     # Future routers (uncomment as implemented):
     # app.include_router(auth.router,       prefix="/api/v1/auth",       tags=["auth"])
     # app.include_router(portfolios.router, prefix="/api/v1/portfolios", tags=["portfolios"])

--- a/app/routers/import_pdf.py
+++ b/app/routers/import_pdf.py
@@ -1,0 +1,127 @@
+"""PDF import UI: upload, preview, and confirm."""
+
+from __future__ import annotations
+
+import tempfile
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Form, Request, UploadFile
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.services.generic_parser import GenericTableParser
+from app.services.import_service import ImportService
+
+router = APIRouter(prefix="/import", tags=["import"])
+
+_TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+
+_DB = Depends(get_async_session)
+_parser = GenericTableParser()
+_service = ImportService()
+
+
+def _render(request: Request, name: str, context: dict) -> HTMLResponse:  # type: ignore[type-arg]
+    context["request"] = request
+    return templates.TemplateResponse(request=request, name=name, context=context)
+
+
+# ---------------------------------------------------------------------------
+# Upload form
+# ---------------------------------------------------------------------------
+
+
+@router.get("/pdf", response_class=HTMLResponse)
+async def import_pdf_page(request: Request) -> HTMLResponse:
+    """Render the PDF upload form."""
+    return _render(request, "import_pdf.html", {"step": "upload"})
+
+
+# ---------------------------------------------------------------------------
+# Parse & preview
+# ---------------------------------------------------------------------------
+
+
+@router.post("/pdf", response_class=HTMLResponse)
+async def import_pdf_preview(
+    request: Request,
+    file: UploadFile,
+) -> HTMLResponse:
+    """Accept a broker PDF, extract holdings, and show a preview."""
+    if not file.filename or not file.filename.lower().endswith(".pdf"):
+        return _render(
+            request,
+            "import_pdf.html",
+            {"step": "upload", "error": "Please upload a valid PDF file."},
+        )
+
+    contents = await file.read()
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+        tmp.write(contents)
+        tmp_path = Path(tmp.name)
+
+    try:
+        pairs = _parser.extract(tmp_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        return _render(
+            request,
+            "import_pdf.html",
+            {"step": "upload", "error": "Unrecognized PDF format or could not parse the file."},
+        )
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    if not pairs:
+        return _render(
+            request,
+            "import_pdf.html",
+            {"step": "upload", "error": "No holdings found in the uploaded PDF."},
+        )
+
+    return _render(
+        request,
+        "import_pdf.html",
+        {"step": "preview", "pairs": pairs},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Confirm & commit
+# ---------------------------------------------------------------------------
+
+
+@router.post("/pdf/confirm", response_class=HTMLResponse)
+async def import_pdf_confirm(
+    request: Request,
+    db: AsyncSession = _DB,
+    tickers: list[str] = Form(...),
+    quantities: list[str] = Form(...),
+) -> HTMLResponse:
+    """Commit the previewed holdings into the database."""
+    pairs: list[tuple[str, Decimal]] = []
+    for ticker, qty_str in zip(tickers, quantities):
+        try:
+            pairs.append((ticker.strip().upper(), Decimal(qty_str)))
+        except InvalidOperation:
+            continue
+
+    if not pairs:
+        return _render(
+            request,
+            "import_pdf.html",
+            {"step": "upload", "error": "No valid holdings to import."},
+        )
+
+    processed = await _service.import_from_holdings(pairs, db)
+
+    return _render(
+        request,
+        "import_pdf.html",
+        {"step": "done", "processed": processed},
+    )

--- a/app/routers/import_pdf.py
+++ b/app/routers/import_pdf.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse
@@ -99,13 +100,13 @@ async def import_pdf_preview(
 @router.post("/pdf/confirm", response_class=HTMLResponse)
 async def import_pdf_confirm(
     request: Request,
+    tickers: Annotated[list[str], Form()],
+    quantities: Annotated[list[str], Form()],
     db: AsyncSession = _DB,
-    tickers: list[str] = Form(...),
-    quantities: list[str] = Form(...),
 ) -> HTMLResponse:
     """Commit the previewed holdings into the database."""
     pairs: list[tuple[str, Decimal]] = []
-    for ticker, qty_str in zip(tickers, quantities):
+    for ticker, qty_str in zip(tickers, quantities, strict=False):
         try:
             pairs.append((ticker.strip().upper(), Decimal(qty_str)))
         except InvalidOperation:

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -40,6 +40,21 @@ class ImportService:
             successfully processed (i.e. had a matching Stock record).
         """
         pairs = parser.extract(pdf_path)
+        return await self.import_from_holdings(pairs, db)
+
+    async def import_from_holdings(
+        self,
+        pairs: list[tuple[str, Decimal]],
+        db: AsyncSession,
+    ) -> list[tuple[str, Decimal]]:
+        """Upsert a list of ``(ticker, quantity)`` pairs into the database.
+
+        Returns
+        -------
+        list[tuple[str, Decimal]]
+            ``(ticker, quantity_added)`` pairs for every ticker that was
+            successfully processed (i.e. had a matching Stock record).
+        """
         processed: list[tuple[str, Decimal]] = []
 
         for ticker, qty in pairs:

--- a/app/templates/import_pdf.html
+++ b/app/templates/import_pdf.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Import Broker PDF</title>
+  <style>
+    body { font-family: sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; }
+    h1 { margin-bottom: 1.5rem; }
+    a { color: #0066cc; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    .card { border: 1px solid #ddd; border-radius: 6px; padding: 1.5rem; background: #fafafa; margin-bottom: 1.5rem; }
+    .card h2 { margin: 0 0 1rem; font-size: 1.1rem; }
+
+    .form-row { margin-bottom: 1rem; }
+    .form-row label { display: block; font-weight: 600; font-size: 0.9rem; margin-bottom: 0.35rem; }
+    .form-row input[type="file"] { font-size: 0.9rem; }
+
+    button { cursor: pointer; border: none; border-radius: 4px; padding: 0.45rem 1.1rem; font-size: 0.9rem; }
+    .btn-primary { background: #0066cc; color: #fff; }
+    .btn-primary:hover { background: #0055aa; }
+    .btn-confirm { background: #2e7d32; color: #fff; }
+    .btn-confirm:hover { background: #256428; }
+    .btn-secondary { background: #eee; color: #333; margin-left: 0.5rem; }
+    .btn-secondary:hover { background: #ddd; }
+
+    .error { color: #c62828; background: #fdecea; border: 1px solid #f9c9c5; border-radius: 4px; padding: 0.7rem 1rem; margin-bottom: 1rem; font-size: 0.9rem; }
+    .success { color: #1b5e20; background: #e8f5e9; border: 1px solid #c8e6c9; border-radius: 4px; padding: 0.7rem 1rem; margin-bottom: 1rem; font-size: 0.9rem; }
+
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1rem; }
+    th, td { padding: 0.55rem 0.9rem; text-align: left; border-bottom: 1px solid #ddd; font-size: 0.9rem; }
+    th { background: #f4f4f4; font-weight: 600; }
+    td.number { text-align: right; }
+    th.number { text-align: right; }
+
+    .actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
+    .note { color: #555; font-size: 0.85rem; margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Import Broker PDF</h1>
+  <p><a href="/">&larr; Back to portfolio</a></p>
+
+  {% if step == "upload" %}
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Upload form                                                          -->
+  <!-- ------------------------------------------------------------------ -->
+  <div class="card">
+    <h2>Upload broker statement</h2>
+    {% if error %}
+    <div class="error">{{ error }}</div>
+    {% endif %}
+    <form method="post" action="/import/pdf" enctype="multipart/form-data">
+      <div class="form-row">
+        <label for="file">PDF file</label>
+        <input type="file" id="file" name="file" accept=".pdf" required>
+      </div>
+      <button type="submit" class="btn-primary">Upload &amp; Preview</button>
+    </form>
+  </div>
+
+  {% elif step == "preview" %}
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Preview extracted holdings before committing                        -->
+  <!-- ------------------------------------------------------------------ -->
+  <div class="card">
+    <h2>Preview extracted holdings</h2>
+    <p class="note">
+      Review the holdings below. Clicking <strong>Confirm Import</strong> will add
+      these quantities to your existing holdings (or create new ones).
+      Tickers not yet tracked in the portfolio will be skipped.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Ticker</th>
+          <th class="number">Quantity</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for ticker, qty in pairs %}
+        <tr>
+          <td>{{ ticker }}</td>
+          <td class="number">{{ qty }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <form method="post" action="/import/pdf/confirm">
+      {% for ticker, qty in pairs %}
+      <input type="hidden" name="tickers" value="{{ ticker }}">
+      <input type="hidden" name="quantities" value="{{ qty }}">
+      {% endfor %}
+      <div class="actions">
+        <button type="submit" class="btn-confirm">Confirm Import</button>
+        <a href="/import/pdf"><button type="button" class="btn-secondary">Cancel</button></a>
+      </div>
+    </form>
+  </div>
+
+  {% elif step == "done" %}
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Success summary                                                      -->
+  <!-- ------------------------------------------------------------------ -->
+  <div class="card">
+    <h2>Import complete</h2>
+    {% if processed %}
+    <div class="success">Successfully imported {{ processed | length }} holding(s).</div>
+    <table>
+      <thead>
+        <tr>
+          <th>Ticker</th>
+          <th class="number">Quantity added</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for ticker, qty in processed %}
+        <tr>
+          <td>{{ ticker }}</td>
+          <td class="number">{{ qty }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <div class="error">No holdings were imported. Make sure the tickers exist in your portfolio.</div>
+    {% endif %}
+    <div class="actions">
+      <a href="/"><button type="button" class="btn-primary">Back to portfolio</button></a>
+      <a href="/import/pdf"><button type="button" class="btn-secondary">Import another PDF</button></a>
+    </div>
+  </div>
+  {% endif %}
+</body>
+</html>

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -65,6 +65,7 @@
     hx-get="/htmx/holdings/add-form"
     hx-target="#add-form-slot"
     hx-swap="innerHTML">+ Add Holding</button>
+  <a href="/import/pdf"><button class="btn-add" style="margin-left:0.5rem;">&#8593; Import PDF</button></a>
 
   <div id="add-form-slot"></div>
 

--- a/tests/test_import_pdf.py
+++ b/tests/test_import_pdf.py
@@ -1,0 +1,237 @@
+"""Tests for the PDF import UI endpoints."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+FIXTURE_PDF = Path(__file__).parent / "fixtures" / "sample_holdings.pdf"
+
+
+# ---------------------------------------------------------------------------
+# GET /import/pdf  — upload form
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_get_renders_upload_form(client: AsyncClient) -> None:
+    response = await client.get("/import/pdf")
+    assert response.status_code == 200
+    assert "Upload broker statement" in response.text
+    assert 'enctype="multipart/form-data"' in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /import/pdf  — preview step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_post_non_pdf_returns_error(client: AsyncClient) -> None:
+    response = await client.post(
+        "/import/pdf",
+        files={"file": ("report.txt", b"not a pdf", "text/plain")},
+    )
+    assert response.status_code == 200
+    assert "valid PDF" in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_post_unreadable_pdf_returns_error(client: AsyncClient) -> None:
+    response = await client.post(
+        "/import/pdf",
+        files={"file": ("bad.pdf", b"garbage data", "application/pdf")},
+    )
+    assert response.status_code == 200
+    assert "Unrecognized PDF" in response.text or "No holdings" in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_post_valid_pdf_shows_preview(client: AsyncClient) -> None:
+    pdf_bytes = FIXTURE_PDF.read_bytes()
+    response = await client.post(
+        "/import/pdf",
+        files={"file": ("holdings.pdf", pdf_bytes, "application/pdf")},
+    )
+    assert response.status_code == 200
+    assert "Preview extracted holdings" in response.text
+    assert "AAPL" in response.text
+    assert "Confirm Import" in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_post_valid_pdf_shows_all_tickers(client: AsyncClient) -> None:
+    pdf_bytes = FIXTURE_PDF.read_bytes()
+    response = await client.post(
+        "/import/pdf",
+        files={"file": ("holdings.pdf", pdf_bytes, "application/pdf")},
+    )
+    assert "AAPL" in response.text
+    assert "MSFT" in response.text
+    assert "GOOGL" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /import/pdf/confirm  — commit step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_confirm_calls_import_service(client: AsyncClient) -> None:
+    processed = [("AAPL", Decimal("10")), ("MSFT", Decimal("5.5"))]
+
+    with patch(
+        "app.routers.import_pdf._service.import_from_holdings",
+        new=AsyncMock(return_value=processed),
+    ):
+        response = await client.post(
+            "/import/pdf/confirm",
+            data={
+                "tickers": ["AAPL", "MSFT"],
+                "quantities": ["10", "5.5"],
+            },
+        )
+
+    assert response.status_code == 200
+    assert "Import complete" in response.text
+    assert "AAPL" in response.text
+    assert "MSFT" in response.text
+    assert "2 holding" in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_confirm_no_processed_shows_warning(client: AsyncClient) -> None:
+    with patch(
+        "app.routers.import_pdf._service.import_from_holdings",
+        new=AsyncMock(return_value=[]),
+    ):
+        response = await client.post(
+            "/import/pdf/confirm",
+            data={
+                "tickers": ["UNKNOWN"],
+                "quantities": ["1"],
+            },
+        )
+
+    assert response.status_code == 200
+    assert "No holdings were imported" in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_confirm_invalid_quantity_skipped(client: AsyncClient) -> None:
+    """Invalid quantity entries are skipped; valid ones are passed through."""
+    processed = [("AAPL", Decimal("5"))]
+
+    with patch(
+        "app.routers.import_pdf._service.import_from_holdings",
+        new=AsyncMock(return_value=processed),
+    ) as mock_import:
+        response = await client.post(
+            "/import/pdf/confirm",
+            data={
+                "tickers": ["AAPL", "MSFT"],
+                "quantities": ["5", "not-a-number"],
+            },
+        )
+
+    assert response.status_code == 200
+    # Only AAPL with valid quantity should have been passed
+    call_pairs = mock_import.call_args[0][0]
+    assert len(call_pairs) == 1
+    assert call_pairs[0] == ("AAPL", Decimal("5"))
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_confirm_all_invalid_returns_error(client: AsyncClient) -> None:
+    response = await client.post(
+        "/import/pdf/confirm",
+        data={
+            "tickers": ["AAPL"],
+            "quantities": ["bad"],
+        },
+    )
+    assert response.status_code == 200
+    assert "No valid holdings" in response.text
+
+
+# ---------------------------------------------------------------------------
+# ImportService.import_from_holdings — unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_from_holdings_creates_new_holding() -> None:
+    from app.services.import_service import ImportService
+
+    stock = MagicMock()
+    stock.id = 1
+
+    stock_result = MagicMock()
+    stock_result.scalar_one_or_none.return_value = stock
+
+    holding_result = MagicMock()
+    holding_result.scalar_one_or_none.return_value = None
+
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.execute = AsyncMock(side_effect=[stock_result, holding_result])
+
+    service = ImportService()
+    result = await service.import_from_holdings([("AAPL", Decimal("5"))], db)
+
+    assert result == [("AAPL", Decimal("5"))]
+    db.add.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_import_from_holdings_increases_existing_holding() -> None:
+    from app.services.import_service import ImportService
+
+    stock = MagicMock()
+    stock.id = 2
+
+    holding = MagicMock()
+    holding.quantity = Decimal("10")
+
+    stock_result = MagicMock()
+    stock_result.scalar_one_or_none.return_value = stock
+
+    holding_result = MagicMock()
+    holding_result.scalar_one_or_none.return_value = holding
+
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.execute = AsyncMock(side_effect=[stock_result, holding_result])
+
+    service = ImportService()
+    result = await service.import_from_holdings([("MSFT", Decimal("3"))], db)
+
+    assert result == [("MSFT", Decimal("3"))]
+    assert holding.quantity == Decimal("13")
+    db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_import_from_pdf_delegates_to_import_from_holdings() -> None:
+    """import_from_pdf should extract pairs and call import_from_holdings."""
+    from app.services.import_service import ImportService
+
+    service = ImportService()
+    pairs = [("AAPL", Decimal("10"))]
+
+    parser = MagicMock()
+    parser.extract.return_value = pairs
+
+    db = AsyncMock()
+
+    with patch.object(
+        service, "import_from_holdings", new=AsyncMock(return_value=pairs)
+    ) as mock_inner:
+        result = await service.import_from_pdf(Path("/fake.pdf"), parser, db)
+
+    mock_inner.assert_called_once_with(pairs, db)
+    assert result == pairs


### PR DESCRIPTION
## Summary

- Add `GET /import/pdf` upload form and `POST /import/pdf` parse+preview endpoint
- Add `POST /import/pdf/confirm` to commit extracted holdings (upsert) to the database
- Refactor `ImportService` to expose `import_from_holdings()` so the confirm step works directly with ticker/quantity pairs (no file re-parse needed)
- Add `app/templates/import_pdf.html` with three steps: upload → preview → done
- Add "Import PDF" button to the portfolio overview page
- Error handling for non-PDF uploads, unrecognized formats, and empty results

## Test plan

- [ ] `GET /import/pdf` renders the upload form
- [ ] `POST /import/pdf` with a non-PDF file returns an error
- [ ] `POST /import/pdf` with garbage PDF data returns "Unrecognized PDF format" error
- [ ] `POST /import/pdf` with the fixture PDF shows the preview with all 3 tickers
- [ ] `POST /import/pdf/confirm` calls `ImportService.import_from_holdings` with the correct pairs
- [ ] `POST /import/pdf/confirm` with no matching stocks shows "No holdings were imported" warning
- [ ] `POST /import/pdf/confirm` skips entries with invalid quantity strings
- [ ] `POST /import/pdf/confirm` with all-invalid quantities shows "No valid holdings" error
- [ ] `ImportService.import_from_holdings` creates a new holding when none exists
- [ ] `ImportService.import_from_holdings` increases quantity of an existing holding
- [ ] `ImportService.import_from_pdf` delegates to `import_from_holdings`
- [ ] All 38 existing tests remain green

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)