### PR TITLE
feat: monthly report generation (issue #19)

### DIFF
--- a/app/services/report_service.py
+++ b/app/services/report_service.py
@@ -1,0 +1,166 @@
+"""Service for generating monthly portfolio wealth reports."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+
+from jinja2 import Environment, PackageLoader, select_autoescape
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.holding import Holding
+from app.models.price_cache import PriceCache
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StockReportLine:
+    """Per-stock data for the monthly report."""
+
+    ticker: str
+    name: str
+    quantity: Decimal
+    price_1st: Decimal | None
+    price_last: Decimal | None
+    value_1st: Decimal | None
+    value_last: Decimal | None
+    delta_eur: Decimal | None
+    delta_pct: Decimal | None
+
+
+@dataclass
+class MonthlyReportData:
+    """Aggregated data for the monthly wealth report."""
+
+    month_label: str  # e.g. "March 2026"
+    period_start: datetime.date
+    period_end: datetime.date
+    lines: list[StockReportLine]
+    total_value_1st: Decimal | None
+    total_value_last: Decimal | None
+    total_delta_eur: Decimal | None
+    total_delta_pct: Decimal | None
+
+
+class ReportService:
+    """Generates the monthly portfolio wealth report."""
+
+    async def generate_monthly_report(
+        self, db: AsyncSession, reference_date: datetime.date | None = None
+    ) -> MonthlyReportData | None:
+        """Build the monthly report for the month preceding *reference_date*.
+
+        Uses prices stored in ``PriceCache`` — no live API calls are made.
+        Returns ``None`` when there are no holdings.
+
+        Args:
+            db: Async database session.
+            reference_date: Date used to determine which month to report on.
+                Defaults to today.
+        """
+        today = reference_date or datetime.date.today()
+        period_end = today.replace(day=1) - datetime.timedelta(days=1)
+        period_start = period_end.replace(day=1)
+
+        rows = await db.execute(select(Holding).options(selectinload(Holding.stock)))
+        holdings = rows.scalars().all()
+
+        if not holdings:
+            return None
+
+        tickers = [h.stock.ticker for h in holdings]
+
+        # Fetch all cached prices for those tickers within the previous month.
+        price_rows = await db.execute(
+            select(PriceCache.ticker, PriceCache.date, PriceCache.close_price)
+            .where(
+                PriceCache.ticker.in_(tickers),
+                PriceCache.date >= period_start,
+                PriceCache.date <= period_end,
+            )
+        )
+
+        # Build {ticker: {date: price}} mapping.
+        prices: dict[str, dict[datetime.date, Decimal]] = {}
+        for ticker, date, close_price in price_rows:
+            prices.setdefault(ticker, {})[date] = close_price
+
+        lines: list[StockReportLine] = []
+        total_value_1st: Decimal | None = None
+        total_value_last: Decimal | None = None
+
+        for h in holdings:
+            ticker = h.stock.ticker
+            ticker_prices = prices.get(ticker, {})
+
+            price_1st: Decimal | None = None
+            price_last: Decimal | None = None
+
+            if ticker_prices:
+                price_1st = ticker_prices[min(ticker_prices)]
+                price_last = ticker_prices[max(ticker_prices)]
+
+            value_1st = h.quantity * price_1st if price_1st is not None else None
+            value_last = h.quantity * price_last if price_last is not None else None
+
+            delta_eur: Decimal | None = None
+            delta_pct: Decimal | None = None
+            if value_1st is not None and value_last is not None:
+                delta_eur = value_last - value_1st
+                if value_1st != Decimal("0"):
+                    delta_pct = (delta_eur / value_1st * Decimal("100")).quantize(
+                        Decimal("0.01")
+                    )
+
+            if value_1st is not None:
+                total_value_1st = (total_value_1st or Decimal("0")) + value_1st
+            if value_last is not None:
+                total_value_last = (total_value_last or Decimal("0")) + value_last
+
+            lines.append(
+                StockReportLine(
+                    ticker=ticker,
+                    name=h.stock.name,
+                    quantity=h.quantity,
+                    price_1st=price_1st,
+                    price_last=price_last,
+                    value_1st=value_1st,
+                    value_last=value_last,
+                    delta_eur=delta_eur,
+                    delta_pct=delta_pct,
+                )
+            )
+
+        total_delta_eur: Decimal | None = None
+        total_delta_pct: Decimal | None = None
+        if total_value_1st is not None and total_value_last is not None:
+            total_delta_eur = total_value_last - total_value_1st
+            if total_value_1st != Decimal("0"):
+                total_delta_pct = (
+                    total_delta_eur / total_value_1st * Decimal("100")
+                ).quantize(Decimal("0.01"))
+
+        return MonthlyReportData(
+            month_label=period_start.strftime("%B %Y"),
+            period_start=period_start,
+            period_end=period_end,
+            lines=lines,
+            total_value_1st=total_value_1st,
+            total_value_last=total_value_last,
+            total_delta_eur=total_delta_eur,
+            total_delta_pct=total_delta_pct,
+        )
+
+    def render_html(self, data: MonthlyReportData) -> str:
+        """Render *data* into an HTML email string using the Jinja2 template."""
+        env = Environment(
+            loader=PackageLoader("app", "templates"),
+            autoescape=select_autoescape(["html"]),
+        )
+        template = env.get_template("email/report.html")
+        return template.render(report=data)

--- a/app/templates/email/report.html
+++ b/app/templates/email/report.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Monthly Portfolio Report – {{ report.month_label }}</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f4f4f7;
+      margin: 0;
+      padding: 0;
+      color: #333333;
+    }
+    .wrapper {
+      max-width: 680px;
+      margin: 32px auto;
+      background-color: #ffffff;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    }
+    .header {
+      background-color: #1a1a2e;
+      color: #ffffff;
+      padding: 32px 40px;
+    }
+    .header h1 {
+      margin: 0 0 4px 0;
+      font-size: 22px;
+      font-weight: 700;
+    }
+    .header p {
+      margin: 0;
+      font-size: 14px;
+      opacity: 0.7;
+    }
+    .summary {
+      padding: 28px 40px;
+      border-bottom: 1px solid #e8e8e8;
+    }
+    .summary h2 {
+      margin: 0 0 16px 0;
+      font-size: 16px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #888888;
+    }
+    .kpi-row {
+      display: flex;
+      gap: 24px;
+      flex-wrap: wrap;
+    }
+    .kpi {
+      flex: 1;
+      min-width: 140px;
+    }
+    .kpi .label {
+      font-size: 12px;
+      color: #888888;
+      margin-bottom: 4px;
+    }
+    .kpi .value {
+      font-size: 22px;
+      font-weight: 700;
+    }
+    .kpi .value.positive { color: #22a06b; }
+    .kpi .value.negative { color: #de350b; }
+    .kpi .value.neutral  { color: #333333; }
+    .breakdown {
+      padding: 28px 40px;
+    }
+    .breakdown h2 {
+      margin: 0 0 16px 0;
+      font-size: 16px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #888888;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+    th {
+      text-align: left;
+      padding: 8px 10px;
+      border-bottom: 2px solid #e8e8e8;
+      color: #888888;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+    td {
+      padding: 10px 10px;
+      border-bottom: 1px solid #f0f0f0;
+      vertical-align: middle;
+    }
+    tr:last-child td { border-bottom: none; }
+    .ticker { font-weight: 700; }
+    .name   { color: #666666; font-size: 13px; }
+    .num    { text-align: right; }
+    .positive { color: #22a06b; }
+    .negative { color: #de350b; }
+    .na       { color: #bbbbbb; }
+    .footer {
+      padding: 20px 40px;
+      background-color: #f4f4f7;
+      font-size: 12px;
+      color: #aaaaaa;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+
+    <div class="header">
+      <h1>Monthly Portfolio Report</h1>
+      <p>{{ report.period_start.strftime("%d %b %Y") }} – {{ report.period_end.strftime("%d %b %Y") }}</p>
+    </div>
+
+    <div class="summary">
+      <h2>Portfolio Overview</h2>
+      <div class="kpi-row">
+
+        <div class="kpi">
+          <div class="label">Value on {{ report.period_start.strftime("%-d %b") }}</div>
+          <div class="value neutral">
+            {% if report.total_value_1st is not none %}
+              €{{ "%.2f"|format(report.total_value_1st) }}
+            {% else %}
+              —
+            {% endif %}
+          </div>
+        </div>
+
+        <div class="kpi">
+          <div class="label">Value on {{ report.period_end.strftime("%-d %b") }}</div>
+          <div class="value neutral">
+            {% if report.total_value_last is not none %}
+              €{{ "%.2f"|format(report.total_value_last) }}
+            {% else %}
+              —
+            {% endif %}
+          </div>
+        </div>
+
+        <div class="kpi">
+          <div class="label">Monthly Delta</div>
+          {% if report.total_delta_eur is not none %}
+            {% set sign = "+" if report.total_delta_eur >= 0 else "" %}
+            {% set css  = "positive" if report.total_delta_eur >= 0 else "negative" %}
+            <div class="value {{ css }}">
+              {{ sign }}€{{ "%.2f"|format(report.total_delta_eur) }}
+            </div>
+          {% else %}
+            <div class="value neutral">—</div>
+          {% endif %}
+        </div>
+
+        <div class="kpi">
+          <div class="label">Delta %</div>
+          {% if report.total_delta_pct is not none %}
+            {% set sign = "+" if report.total_delta_pct >= 0 else "" %}
+            {% set css  = "positive" if report.total_delta_pct >= 0 else "negative" %}
+            <div class="value {{ css }}">{{ sign }}{{ report.total_delta_pct }}%</div>
+          {% else %}
+            <div class="value neutral">—</div>
+          {% endif %}
+        </div>
+
+      </div>
+    </div>
+
+    <div class="breakdown">
+      <h2>Per-Stock Breakdown</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Stock</th>
+            <th class="num">Qty</th>
+            <th class="num">Price 1st</th>
+            <th class="num">Price Last</th>
+            <th class="num">Delta (€)</th>
+            <th class="num">Delta (%)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for line in report.lines %}
+          <tr>
+            <td>
+              <div class="ticker">{{ line.ticker }}</div>
+              <div class="name">{{ line.name }}</div>
+            </td>
+            <td class="num">{{ line.quantity }}</td>
+            <td class="num">
+              {% if line.price_1st is not none %}€{{ "%.2f"|format(line.price_1st) }}{% else %}<span class="na">—</span>{% endif %}
+            </td>
+            <td class="num">
+              {% if line.price_last is not none %}€{{ "%.2f"|format(line.price_last) }}{% else %}<span class="na">—</span>{% endif %}
+            </td>
+            <td class="num">
+              {% if line.delta_eur is not none %}
+                {% set sign = "+" if line.delta_eur >= 0 else "" %}
+                {% set css  = "positive" if line.delta_eur >= 0 else "negative" %}
+                <span class="{{ css }}">{{ sign }}€{{ "%.2f"|format(line.delta_eur) }}</span>
+              {% else %}
+                <span class="na">—</span>
+              {% endif %}
+            </td>
+            <td class="num">
+              {% if line.delta_pct is not none %}
+                {% set sign = "+" if line.delta_pct >= 0 else "" %}
+                {% set css  = "positive" if line.delta_pct >= 0 else "negative" %}
+                <span class="{{ css }}">{{ sign }}{{ line.delta_pct }}%</span>
+              {% else %}
+                <span class="na">—</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="footer">
+      Generated automatically by Stock Portfolio Tracker &middot; {{ report.month_label }}
+    </div>
+
+  </div>
+</body>
+</html>

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -1,0 +1,279 @@
+"""Unit tests for ReportService — uses mocked DB session."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.report_service import MonthlyReportData, ReportService, StockReportLine
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_holding(
+    ticker: str,
+    name: str,
+    quantity: str,
+) -> MagicMock:
+    stock = MagicMock()
+    stock.ticker = ticker
+    stock.name = name
+
+    holding = MagicMock()
+    holding.quantity = Decimal(quantity)
+    holding.stock = stock
+    return holding
+
+
+def _make_db(holdings: list[MagicMock], price_rows: list[tuple]) -> AsyncMock:  # type: ignore[type-arg]
+    """Return an AsyncMock db whose execute() returns holdings on the first call
+    and price rows on the second call."""
+    db = AsyncMock()
+
+    holdings_result = MagicMock()
+    holdings_result.scalars.return_value.all.return_value = holdings
+
+    prices_result = MagicMock()
+    prices_result.__iter__ = MagicMock(return_value=iter(price_rows))
+
+    db.execute = AsyncMock(side_effect=[holdings_result, prices_result])
+    return db
+
+
+# Reference date: 10 Apr 2026 → previous month is March 2026
+_REF = datetime.date(2026, 4, 10)
+_MAR_1 = datetime.date(2026, 3, 1)
+_MAR_31 = datetime.date(2026, 3, 31)
+
+
+# ---------------------------------------------------------------------------
+# Tests: generate_monthly_report
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_no_holdings_returns_none() -> None:
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    db.execute = AsyncMock(return_value=result)
+
+    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+
+    assert report is None
+
+
+@pytest.mark.asyncio
+async def test_single_holding_full_data() -> None:
+    holdings = [_make_holding("AAPL", "Apple Inc.", "10")]
+    price_rows = [
+        ("AAPL", _MAR_1, Decimal("150.0000")),
+        ("AAPL", _MAR_31, Decimal("160.0000")),
+    ]
+    db = _make_db(holdings, price_rows)
+
+    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+
+    assert report is not None
+    assert report.month_label == "March 2026"
+    assert report.period_start == _MAR_1
+    assert report.period_end == _MAR_31
+
+    assert len(report.lines) == 1
+    line = report.lines[0]
+    assert line.ticker == "AAPL"
+    assert line.price_1st == Decimal("150.0000")
+    assert line.price_last == Decimal("160.0000")
+    assert line.value_1st == Decimal("1500.0000")
+    assert line.value_last == Decimal("1600.0000")
+    assert line.delta_eur == Decimal("100.0000")
+    assert line.delta_pct == Decimal("6.67")
+
+    assert report.total_value_1st == Decimal("1500.0000")
+    assert report.total_value_last == Decimal("1600.0000")
+    assert report.total_delta_eur == Decimal("100.0000")
+    assert report.total_delta_pct == Decimal("6.67")
+
+
+@pytest.mark.asyncio
+async def test_negative_delta() -> None:
+    holdings = [_make_holding("TSLA", "Tesla Inc.", "5")]
+    price_rows = [
+        ("TSLA", _MAR_1, Decimal("200.0000")),
+        ("TSLA", _MAR_31, Decimal("180.0000")),
+    ]
+    db = _make_db(holdings, price_rows)
+
+    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+
+    assert report is not None
+    line = report.lines[0]
+    assert line.delta_eur == Decimal("-100.0000")
+    assert line.delta_pct == Decimal("-10.00")
+    assert report.total_delta_eur == Decimal("-100.0000")
+
+
+@pytest.mark.asyncio
+async def test_holding_without_cached_prices() -> None:
+    holdings = [_make_holding("UNKN", "Unknown Corp.", "3")]
+    db = _make_db(holdings, [])  # no price rows
+
+    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+
+    assert report is not None
+    line = report.lines[0]
+    assert line.price_1st is None
+    assert line.price_last is None
+    assert line.value_1st is None
+    assert line.value_last is None
+    assert line.delta_eur is None
+    assert line.delta_pct is None
+    assert report.total_value_1st is None
+    assert report.total_value_last is None
+    assert report.total_delta_eur is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_holdings_mixed_prices() -> None:
+    """Holdings with and without cached prices; total excludes missing prices."""
+    holdings = [
+        _make_holding("AAPL", "Apple Inc.", "10"),
+        _make_holding("UNKN", "Unknown Corp.", "5"),
+    ]
+    price_rows = [
+        ("AAPL", _MAR_1, Decimal("100.0000")),
+        ("AAPL", _MAR_31, Decimal("110.0000")),
+    ]
+    db = _make_db(holdings, price_rows)
+
+    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+
+    assert report is not None
+    assert len(report.lines) == 2
+
+    aapl = next(line for line in report.lines if line.ticker == "AAPL")
+    unkn = next(line for line in report.lines if line.ticker == "UNKN")
+
+    assert aapl.delta_eur == Decimal("100.0000")
+    assert unkn.delta_eur is None
+
+    # Totals are based only on AAPL
+    assert report.total_value_1st == Decimal("1000.0000")
+    assert report.total_value_last == Decimal("1100.0000")
+    assert report.total_delta_eur == Decimal("100.0000")
+
+
+@pytest.mark.asyncio
+async def test_uses_first_and_last_available_trading_day() -> None:
+    """When prices don't start on the 1st, use the earliest/latest available."""
+    holdings = [_make_holding("MSFT", "Microsoft Corp.", "2")]
+    mar_3 = datetime.date(2026, 3, 3)
+    mar_28 = datetime.date(2026, 3, 28)
+    price_rows = [
+        ("MSFT", mar_3, Decimal("400.0000")),
+        ("MSFT", mar_28, Decimal("420.0000")),
+    ]
+    db = _make_db(holdings, price_rows)
+
+    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+
+    assert report is not None
+    line = report.lines[0]
+    assert line.price_1st == Decimal("400.0000")
+    assert line.price_last == Decimal("420.0000")
+
+
+# ---------------------------------------------------------------------------
+# Tests: render_html
+# ---------------------------------------------------------------------------
+
+def _make_report_data() -> MonthlyReportData:
+    lines = [
+        StockReportLine(
+            ticker="AAPL",
+            name="Apple Inc.",
+            quantity=Decimal("10"),
+            price_1st=Decimal("150.00"),
+            price_last=Decimal("160.00"),
+            value_1st=Decimal("1500.00"),
+            value_last=Decimal("1600.00"),
+            delta_eur=Decimal("100.00"),
+            delta_pct=Decimal("6.67"),
+        ),
+        StockReportLine(
+            ticker="TSLA",
+            name="Tesla Inc.",
+            quantity=Decimal("5"),
+            price_1st=None,
+            price_last=None,
+            value_1st=None,
+            value_last=None,
+            delta_eur=None,
+            delta_pct=None,
+        ),
+    ]
+    return MonthlyReportData(
+        month_label="March 2026",
+        period_start=datetime.date(2026, 3, 1),
+        period_end=datetime.date(2026, 3, 31),
+        lines=lines,
+        total_value_1st=Decimal("1500.00"),
+        total_value_last=Decimal("1600.00"),
+        total_delta_eur=Decimal("100.00"),
+        total_delta_pct=Decimal("6.67"),
+    )
+
+
+def test_render_html_contains_key_data() -> None:
+    data = _make_report_data()
+    html = ReportService().render_html(data)
+
+    assert "March 2026" in html
+    assert "AAPL" in html
+    assert "Apple Inc." in html
+    assert "1500.00" in html
+    assert "1600.00" in html
+    assert "+€100.00" in html
+    assert "+6.67%" in html
+    assert "TSLA" in html
+
+
+def test_render_html_shows_dash_for_missing_prices() -> None:
+    data = _make_report_data()
+    html = ReportService().render_html(data)
+
+    # TSLA has no prices — dashes should appear
+    assert "—" in html
+
+
+def test_render_html_negative_delta_no_plus_sign() -> None:
+    lines = [
+        StockReportLine(
+            ticker="TSLA",
+            name="Tesla Inc.",
+            quantity=Decimal("5"),
+            price_1st=Decimal("200.00"),
+            price_last=Decimal("180.00"),
+            value_1st=Decimal("1000.00"),
+            value_last=Decimal("900.00"),
+            delta_eur=Decimal("-100.00"),
+            delta_pct=Decimal("-10.00"),
+        )
+    ]
+    data = MonthlyReportData(
+        month_label="March 2026",
+        period_start=datetime.date(2026, 3, 1),
+        period_end=datetime.date(2026, 3, 31),
+        lines=lines,
+        total_value_1st=Decimal("1000.00"),
+        total_value_last=Decimal("900.00"),
+        total_delta_eur=Decimal("-100.00"),
+        total_delta_pct=Decimal("-10.00"),
+    )
+    html = ReportService().render_html(data)
+
+    assert "€-100.00" in html or "-€100.00" in html or "-100.00" in html
+    assert "+€-100.00" not in html


### PR DESCRIPTION
## Summary

- Adds `app/services/report_service.py` with `ReportService.generate_monthly_report()` that queries `PriceCache` for the first and last available trading-day prices of the previous month — no live API calls
- Calculates per-stock `value_1st`, `value_last`, `delta_eur`, `delta_pct` and aggregates totals across all holdings
- Renders the report into an HTML email using a new Jinja2 template at `app/templates/email/report.html`
- 9 unit tests with 100% coverage of the new service

## Test plan

- [x] `tests/test_report_service.py` — all 9 tests pass (`pytest tests/test_report_service.py -v`)
- [x] Full test suite: 35 passed, 8 skipped (DB-dependent skips)
- [x] Ruff linting: no issues

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)