### PR TITLE
test: update test suite after ticker → WKN migration (#47)

### DIFF
--- a/tests/test_import_pdf.py
+++ b/tests/test_import_pdf.py
@@ -82,7 +82,7 @@ async def test_import_pdf_post_valid_pdf_shows_all_wkns(client: AsyncClient) -> 
 
 @pytest.mark.asyncio
 async def test_import_pdf_confirm_calls_import_service(client: AsyncClient) -> None:
-    processed = [("AAPL", Decimal("10")), ("MSFT", Decimal("5.5"))]
+    processed = [("865985", Decimal("10")), ("870747", Decimal("5.5"))]
 
     with patch(
         "app.routers.import_pdf._service.import_from_holdings",
@@ -91,15 +91,15 @@ async def test_import_pdf_confirm_calls_import_service(client: AsyncClient) -> N
         response = await client.post(
             "/import/pdf/confirm",
             data={
-                "wkns": ["AAPL", "MSFT"],
+                "wkns": ["865985", "870747"],
                 "quantities": ["10", "5.5"],
             },
         )
 
     assert response.status_code == 200
     assert "Import complete" in response.text
-    assert "AAPL" in response.text
-    assert "MSFT" in response.text
+    assert "865985" in response.text
+    assert "870747" in response.text
     assert "2 holding" in response.text
 
 
@@ -124,7 +124,7 @@ async def test_import_pdf_confirm_no_processed_shows_warning(client: AsyncClient
 @pytest.mark.asyncio
 async def test_import_pdf_confirm_invalid_quantity_skipped(client: AsyncClient) -> None:
     """Invalid quantity entries are skipped; valid ones are passed through."""
-    processed = [("AAPL", Decimal("5"))]
+    processed = [("865985", Decimal("5"))]
 
     with patch(
         "app.routers.import_pdf._service.import_from_holdings",
@@ -133,16 +133,16 @@ async def test_import_pdf_confirm_invalid_quantity_skipped(client: AsyncClient) 
         response = await client.post(
             "/import/pdf/confirm",
             data={
-                "wkns": ["AAPL", "MSFT"],
+                "wkns": ["865985", "870747"],
                 "quantities": ["5", "not-a-number"],
             },
         )
 
     assert response.status_code == 200
-    # Only AAPL with valid quantity should have been passed
+    # Only 865985 with valid quantity should have been passed
     call_pairs = mock_import.call_args[0][0]
     assert len(call_pairs) == 1
-    assert call_pairs[0] == ("AAPL", Decimal("5"))
+    assert call_pairs[0] == ("865985", Decimal("5"))
 
 
 @pytest.mark.asyncio
@@ -150,7 +150,7 @@ async def test_import_pdf_confirm_all_invalid_returns_error(client: AsyncClient)
     response = await client.post(
         "/import/pdf/confirm",
         data={
-            "wkns": ["AAPL"],
+            "wkns": ["865985"],
             "quantities": ["bad"],
         },
     )
@@ -181,9 +181,9 @@ async def test_import_from_holdings_creates_new_holding() -> None:
     db.execute = AsyncMock(side_effect=[stock_result, holding_result])
 
     service = ImportService()
-    result = await service.import_from_holdings([("AAPL", Decimal("5"))], db)
+    result = await service.import_from_holdings([("865985", Decimal("5"))], db)
 
-    assert result == [("AAPL", Decimal("5"))]
+    assert result == [("865985", Decimal("5"))]
     db.add.assert_called_once()
 
 
@@ -208,9 +208,9 @@ async def test_import_from_holdings_increases_existing_holding() -> None:
     db.execute = AsyncMock(side_effect=[stock_result, holding_result])
 
     service = ImportService()
-    result = await service.import_from_holdings([("MSFT", Decimal("3"))], db)
+    result = await service.import_from_holdings([("870747", Decimal("3"))], db)
 
-    assert result == [("MSFT", Decimal("3"))]
+    assert result == [("870747", Decimal("3"))]
     assert holding.quantity == Decimal("13")
     db.add.assert_not_called()
 
@@ -221,7 +221,7 @@ async def test_import_from_pdf_delegates_to_import_from_holdings() -> None:
     from app.services.import_service import ImportService
 
     service = ImportService()
-    pairs = [("AAPL", Decimal("10"))]
+    pairs = [("865985", Decimal("10"))]
 
     parser = MagicMock()
     parser.extract.return_value = pairs

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -83,16 +83,16 @@ def _db_with(stock: MagicMock | None, holding: MagicMock | None) -> AsyncMock:
 
 @pytest.mark.asyncio
 async def test_import_creates_new_holding_when_none_exists() -> None:
-    stock = _make_stock("AAPL", stock_id=42)
+    stock = _make_stock("865985", stock_id=42)
     db = _db_with(stock=stock, holding=None)
 
     parser = MagicMock()
-    parser.extract.return_value = [("AAPL", Decimal("5"))]
+    parser.extract.return_value = [("865985", Decimal("5"))]
 
     service = ImportService()
     result = await service.import_from_pdf(FIXTURE_PDF, parser, db)
 
-    assert result == [("AAPL", Decimal("5"))]
+    assert result == [("865985", Decimal("5"))]
     db.add.assert_called_once()
     added: MagicMock = db.add.call_args[0][0]
     assert added.stock_id == 42
@@ -101,23 +101,23 @@ async def test_import_creates_new_holding_when_none_exists() -> None:
 
 @pytest.mark.asyncio
 async def test_import_increases_existing_holding() -> None:
-    stock = _make_stock("MSFT", stock_id=7)
+    stock = _make_stock("870747", stock_id=7)
     holding = _make_holding(stock_id=7, quantity=Decimal("10"))
     db = _db_with(stock=stock, holding=holding)
 
     parser = MagicMock()
-    parser.extract.return_value = [("MSFT", Decimal("2.5"))]
+    parser.extract.return_value = [("870747", Decimal("2.5"))]
 
     service = ImportService()
     result = await service.import_from_pdf(FIXTURE_PDF, parser, db)
 
-    assert result == [("MSFT", Decimal("2.5"))]
+    assert result == [("870747", Decimal("2.5"))]
     assert holding.quantity == Decimal("12.5")
     db.add.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_import_skips_unknown_ticker() -> None:
+async def test_import_skips_unknown_wkn() -> None:
     db = AsyncMock()
     no_stock = MagicMock()
     no_stock.scalar_one_or_none.return_value = None

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -35,7 +35,7 @@ async def test_get_price_found() -> None:
     expected = Decimal("150.1234")
     db = _make_db_mock(scalar_value=expected)
 
-    result = await get_price("AAPL", datetime.date(2025, 1, 10), db)
+    result = await get_price("865985", datetime.date(2025, 1, 10), db)
 
     assert result == expected
     db.execute.assert_awaited_once()
@@ -45,17 +45,17 @@ async def test_get_price_found() -> None:
 async def test_get_price_not_found() -> None:
     db = _make_db_mock(scalar_value=None)
 
-    result = await get_price("AAPL", datetime.date(2025, 1, 10), db)
+    result = await get_price("865985", datetime.date(2025, 1, 10), db)
 
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_get_price_uppercase_ticker() -> None:
-    """Ticker should be normalised to uppercase before querying."""
+async def test_get_price_uppercase_wkn() -> None:
+    """WKN should be normalised to uppercase before querying."""
     db = _make_db_mock(scalar_value=Decimal("50.00"))
 
-    await get_price("aapl", datetime.date(2025, 1, 10), db)
+    await get_price("a14y6f", datetime.date(2025, 1, 10), db)
 
     # Inspect the WHERE clause argument passed to execute — the compiled SQL
     # isn't easily introspectable, but we can verify execute was called at all.
@@ -82,7 +82,7 @@ async def test_refresh_price_cache_upserts_rows() -> None:
         "app.services.price_service._fetch_history",
         AsyncMock(return_value=_HISTORY),
     ):
-        await refresh_price_cache(["AAPL"], db)
+        await refresh_price_cache(["865985"], db)
 
     db.execute.assert_awaited_once()
     db.commit.assert_awaited_once()
@@ -98,7 +98,7 @@ async def test_refresh_price_cache_skips_empty_history() -> None:
         "app.services.price_service._fetch_history",
         AsyncMock(return_value={}),
     ):
-        await refresh_price_cache(["AAPL"], db)
+        await refresh_price_cache(["865985"], db)
 
     db.execute.assert_not_awaited()
     db.commit.assert_awaited_once()
@@ -115,14 +115,14 @@ async def test_refresh_price_cache_handles_fetch_error() -> None:
         AsyncMock(side_effect=RuntimeError("network error")),
     ):
         # Should not raise — errors are logged and skipped.
-        await refresh_price_cache(["AAPL"], db)
+        await refresh_price_cache(["865985"], db)
 
     db.execute.assert_not_awaited()
     db.commit.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_refresh_price_cache_multiple_tickers() -> None:
+async def test_refresh_price_cache_multiple_wkns() -> None:
     db = AsyncMock(spec=AsyncSession)
     db.execute = AsyncMock()
     db.commit = AsyncMock()
@@ -131,7 +131,7 @@ async def test_refresh_price_cache_multiple_tickers() -> None:
         "app.services.price_service._fetch_history",
         AsyncMock(return_value=_HISTORY),
     ):
-        await refresh_price_cache(["AAPL", "MSFT"], db)
+        await refresh_price_cache(["865985", "870747"], db)
 
     assert db.execute.await_count == 2
     db.commit.assert_awaited_once()

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -11,7 +11,7 @@ from app.services.price_service import StockPriceService
 from app.services.stock_lookup import StockInfo
 
 _APPLE = StockInfo(
-    wkn="AAPL",
+    wkn="865985",
     name="Apple Inc.",
     currency="USD",
     current_price=Decimal("175.00"),
@@ -24,28 +24,28 @@ def service() -> StockPriceService:
 
 
 @pytest.mark.asyncio
-async def test_get_current_price_known_ticker(service: StockPriceService) -> None:
+async def test_get_current_price_known_wkn(service: StockPriceService) -> None:
     with patch("app.services.price_service.fetch_stock_info", AsyncMock(return_value=_APPLE)):
-        price = await service.get_current_price("AAPL")
+        price = await service.get_current_price("865985")
     assert price == Decimal("175.00")
 
 
 @pytest.mark.asyncio
-async def test_get_current_price_unknown_ticker(service: StockPriceService) -> None:
+async def test_get_current_price_unknown_wkn(service: StockPriceService) -> None:
     with patch("app.services.price_service.fetch_stock_info", AsyncMock(return_value=None)):
         price = await service.get_current_price("INVALID")
     assert price is None
 
 
 @pytest.mark.asyncio
-async def test_get_company_name_known_ticker(service: StockPriceService) -> None:
+async def test_get_company_name_known_wkn(service: StockPriceService) -> None:
     with patch("app.services.price_service.fetch_stock_info", AsyncMock(return_value=_APPLE)):
-        name = await service.get_company_name("AAPL")
+        name = await service.get_company_name("865985")
     assert name == "Apple Inc."
 
 
 @pytest.mark.asyncio
-async def test_get_company_name_unknown_ticker(service: StockPriceService) -> None:
+async def test_get_company_name_unknown_wkn(service: StockPriceService) -> None:
     with patch("app.services.price_service.fetch_stock_info", AsyncMock(return_value=None)):
         name = await service.get_company_name("INVALID")
     assert name is None
@@ -54,7 +54,7 @@ async def test_get_company_name_unknown_ticker(service: StockPriceService) -> No
 @pytest.mark.asyncio
 async def test_validate_wkn_valid(service: StockPriceService) -> None:
     with patch("app.services.price_service.fetch_stock_info", AsyncMock(return_value=_APPLE)):
-        assert await service.validate_wkn("AAPL") is True
+        assert await service.validate_wkn("865985") is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -30,12 +30,12 @@ def _make_settings() -> Settings:
     )
 
 
-def _make_session_factory(tickers: list[str]) -> AsyncMock:
-    """Return a mock async_sessionmaker that yields a session with the given tickers."""
+def _make_session_factory(wkns: list[str]) -> AsyncMock:
+    """Return a mock async_sessionmaker that yields a session with the given wkns."""
     session = AsyncMock()
-    tickers_result = MagicMock()
-    tickers_result.scalars.return_value.all.return_value = tickers
-    session.execute = AsyncMock(return_value=tickers_result)
+    wkns_result = MagicMock()
+    wkns_result.scalars.return_value.all.return_value = wkns
+    session.execute = AsyncMock(return_value=wkns_result)
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=False)
 
@@ -87,7 +87,7 @@ def test_monthly_report_job_scheduled_on_1st_at_08_00() -> None:
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_run_price_cache_refresh_no_tickers_logs_and_returns() -> None:
+async def test_run_price_cache_refresh_no_wkns_logs_and_returns() -> None:
     factory = _make_session_factory([])
 
     with patch("app.scheduler.refresh_price_cache") as mock_refresh:
@@ -97,14 +97,14 @@ async def test_run_price_cache_refresh_no_tickers_logs_and_returns() -> None:
 
 @pytest.mark.asyncio
 async def test_run_price_cache_refresh_calls_service() -> None:
-    factory = _make_session_factory(["AAPL", "TSLA"])
+    factory = _make_session_factory(["865985", "716461"])
 
     with patch("app.scheduler.refresh_price_cache", new_callable=AsyncMock) as mock_refresh:
         await run_price_cache_refresh(factory)
         mock_refresh.assert_called_once()
-        called_tickers = mock_refresh.call_args[0][0]
-        assert "AAPL" in called_tickers
-        assert "TSLA" in called_tickers
+        called_wkns = mock_refresh.call_args[0][0]
+        assert "865985" in called_wkns
+        assert "716461" in called_wkns
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace all ticker symbols (`AAPL`, `MSFT`, `TSLA`) with realistic WKN values (`865985`, `870747`, `716461`, `A14Y6F`) across all test files
- Rename test functions containing `_ticker_` to `_wkn_` (`test_get_current_price_known_ticker` → `test_get_current_price_known_wkn`, etc.)
- Rename `_make_session_factory(tickers)` → `_make_session_factory(wkns)` and internal variables in `test_scheduler.py`
- Update docstrings: "Ticker should be normalised" → "WKN should be normalised"
- Use lowercase WKN `"a14y6f"` in the uppercase-normalisation test (replacing `"aapl"`)

Closes #47

## Test plan

- [x] All 52 tests pass (`pytest` green, no `ticker` references remaining in test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)