### PR TITLE
feat: WKN support via OpenFIGI integration

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -69,6 +69,11 @@ class Settings(BaseSettings):
     stock_api_base_url: str = "https://api.example-stock-provider.com/v1"
 
     # ------------------------------------------------------------------
+    # OpenFIGI  (issue #51 — WKN resolution)
+    # ------------------------------------------------------------------
+    openfigi_api_key: str = ""  # optional; unauthenticated: 25 req/min
+
+    # ------------------------------------------------------------------
     # PDF import  (issue #16, #17)
     # ------------------------------------------------------------------
     pdf_upload_dir: Path = Path("/tmp/portfolio_uploads")

--- a/app/routers/htmx.py
+++ b/app/routers/htmx.py
@@ -11,9 +11,11 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import get_settings
 from app.database import get_async_session
 from app.models.holding import Holding
 from app.models.stock import Stock
+from app.services.openfigi_lookup import resolve_wkn
 from app.services.stock_lookup import fetch_stock_info
 
 router = APIRouter(prefix="/htmx", tags=["htmx"])
@@ -60,6 +62,33 @@ async def validate_ticker(
 
 
 # ---------------------------------------------------------------------------
+# WKN validation (inline, triggered on input)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/validate-wkn", response_class=HTMLResponse)
+async def validate_wkn(
+    request: Request,
+    wkn: str = "",
+) -> HTMLResponse:
+    """Return an inline validation hint for the WKN field."""
+    wkn = wkn.strip().upper()
+    if not wkn:
+        return HTMLResponse("")
+
+    settings = get_settings()
+    ticker = await resolve_wkn(wkn, api_key=settings.openfigi_api_key)
+    if ticker is None:
+        return _render(request, "partials/ticker_hint.html", {"valid": False, "name": None})
+
+    info = await fetch_stock_info(ticker)
+    if info:
+        return _render(request, "partials/ticker_hint.html", {"valid": True, "name": info.name})
+
+    return _render(request, "partials/ticker_hint.html", {"valid": False, "name": None})
+
+
+# ---------------------------------------------------------------------------
 # Add holding form & submission
 # ---------------------------------------------------------------------------
 
@@ -72,11 +101,40 @@ async def add_holding_form(request: Request) -> HTMLResponse:
 @router.post("/holdings", response_class=HTMLResponse)
 async def htmx_create_holding(
     request: Request,
-    ticker: str = Form(...),
+    ticker: str = Form(""),
+    wkn: str = Form(""),
     quantity: str = Form(...),
     db: AsyncSession = _DB,
 ) -> HTMLResponse:
     ticker = ticker.strip().upper()
+    wkn = wkn.strip().upper()
+
+    # Validate mutual exclusion
+    if ticker and wkn:
+        return _render(
+            request,
+            "partials/add_holding_form.html",
+            {"error": "Please provide either a Ticker or a WKN, not both.", "quantity": quantity},
+        )
+    if not ticker and not wkn:
+        return _render(
+            request,
+            "partials/add_holding_form.html",
+            {"error": "Please provide a Ticker or a WKN.", "quantity": quantity},
+        )
+
+    # Resolve WKN → ticker when WKN is provided
+    if wkn:
+        settings = get_settings()
+        resolved = await resolve_wkn(wkn, api_key=settings.openfigi_api_key)
+        if resolved is None:
+            return _render(
+                request,
+                "partials/add_holding_form.html",
+                {"error": f"WKN '{wkn}' could not be resolved.", "wkn": wkn, "quantity": quantity},
+            )
+        ticker = resolved
+
     try:
         qty = Decimal(quantity)
         if qty <= 0:
@@ -87,7 +145,8 @@ async def htmx_create_holding(
             "partials/add_holding_form.html",
             {
                 "error": "Quantity must be a positive number.",
-                "ticker": ticker,
+                "ticker": ticker if not wkn else "",
+                "wkn": wkn,
                 "quantity": quantity,
             },
         )

--- a/app/services/openfigi_lookup.py
+++ b/app/services/openfigi_lookup.py
@@ -1,0 +1,52 @@
+"""WKN → ticker resolution via the OpenFIGI mapping API."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_OPENFIGI_URL = "https://api.openfigi.com/v3/mapping"
+
+
+async def resolve_wkn(wkn: str, api_key: str = "") -> str | None:
+    """Return the ticker symbol for a WKN, or None if it cannot be resolved.
+
+    Args:
+        wkn: The 6-character WKN (Wertpapierkennnummer) to resolve.
+        api_key: Optional OpenFIGI API key for higher rate limits.
+                 Unauthenticated requests are limited to 25 req/min.
+
+    Returns:
+        The resolved ticker symbol (upper-case), or None on failure.
+    """
+    wkn = wkn.strip().upper()
+    if not wkn:
+        return None
+
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-OPENFIGI-APIKEY"] = api_key
+
+    payload = [{"idType": "ID_WERTPAPIER", "idValue": wkn}]
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(_OPENFIGI_URL, json=payload, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+    except httpx.HTTPError as exc:
+        logger.warning("OpenFIGI request failed for WKN %s: %s", wkn, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Unexpected error during OpenFIGI lookup for WKN %s: %s", wkn, exc)
+        return None
+
+    # Response shape: [{"data": [{"ticker": "AAPL", ...}]}]
+    try:
+        ticker = data[0]["data"][0]["ticker"]
+        return str(ticker).upper() if ticker else None
+    except (KeyError, IndexError, TypeError):
+        return None

--- a/app/templates/partials/add_holding_form.html
+++ b/app/templates/partials/add_holding_form.html
@@ -17,14 +17,36 @@
           name="ticker"
           value="{{ ticker or '' }}"
           placeholder="e.g. AAPL"
-          required
           autocomplete="off"
+          oninput="toggleWknTicker(this, 'wkn', 'ticker-hint', 'wkn-hint')"
           hx-get="/htmx/validate-ticker"
           hx-trigger="blur, input changed delay:600ms"
           hx-include="[name='ticker']"
           hx-target="#ticker-hint"
           hx-swap="innerHTML">
         <span id="ticker-hint"></span>
+      </div>
+    </div>
+    <div class="form-row form-or-divider">
+      <span class="or-label">OR</span>
+    </div>
+    <div class="form-row">
+      <label for="wkn">WKN</label>
+      <div class="input-group">
+        <input
+          type="text"
+          id="wkn"
+          name="wkn"
+          value="{{ wkn or '' }}"
+          placeholder="e.g. 840400"
+          autocomplete="off"
+          oninput="toggleWknTicker(this, 'ticker', 'wkn-hint', 'ticker-hint')"
+          hx-get="/htmx/validate-wkn"
+          hx-trigger="blur, input changed delay:600ms"
+          hx-include="[name='wkn']"
+          hx-target="#wkn-hint"
+          hx-swap="innerHTML">
+        <span id="wkn-hint"></span>
       </div>
     </div>
     <div class="form-row">
@@ -48,3 +70,14 @@
     </div>
   </form>
 </div>
+<script>
+  function toggleWknTicker(activeInput, otherId, activeHintId, otherHintId) {
+    var other = document.getElementById(otherId);
+    if (activeInput.value) {
+      other.disabled = true;
+    } else {
+      other.disabled = false;
+      document.getElementById(otherHintId).innerHTML = '';
+    }
+  }
+</script>

--- a/app/templates/partials/add_holding_form.html
+++ b/app/templates/partials/add_holding_form.html
@@ -20,7 +20,7 @@
           autocomplete="off"
           oninput="toggleWknTicker(this, 'wkn', 'ticker-hint', 'wkn-hint')"
           hx-get="/htmx/validate-ticker"
-          hx-trigger="blur, input changed delay:600ms"
+          hx-trigger="input changed delay:600ms"
           hx-include="[name='ticker']"
           hx-target="#ticker-hint"
           hx-swap="innerHTML">
@@ -42,7 +42,7 @@
           autocomplete="off"
           oninput="toggleWknTicker(this, 'ticker', 'wkn-hint', 'ticker-hint')"
           hx-get="/htmx/validate-wkn"
-          hx-trigger="blur, input changed delay:600ms"
+          hx-trigger="input changed delay:600ms"
           hx-include="[name='wkn']"
           hx-target="#wkn-hint"
           hx-swap="innerHTML">

--- a/tests/test_openfigi_lookup.py
+++ b/tests/test_openfigi_lookup.py
@@ -1,0 +1,109 @@
+"""Unit tests for the OpenFIGI WKN → ticker resolution service."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.openfigi_lookup import resolve_wkn
+
+pytestmark = pytest.mark.asyncio
+
+
+def _mock_response(json_data: object, status_code: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = json_data
+    response.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import httpx
+
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=MagicMock()
+        )
+    return response
+
+
+@pytest.fixture
+def mock_post():
+    """Patch httpx.AsyncClient.post and yield the mock."""
+    with patch("app.services.openfigi_lookup.httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+        yield mock_client
+
+
+async def test_resolve_wkn_success(mock_post: AsyncMock) -> None:
+    """Valid WKN returns the ticker from OpenFIGI."""
+    mock_post.post = AsyncMock(
+        return_value=_mock_response([{"data": [{"ticker": "AAPL", "figi": "BBG000B9XRY4"}]}])
+    )
+    result = await resolve_wkn("840400")
+    assert result == "AAPL"
+
+
+async def test_resolve_wkn_uppercase(mock_post: AsyncMock) -> None:
+    """Ticker returned by OpenFIGI is normalised to upper-case."""
+    mock_post.post = AsyncMock(
+        return_value=_mock_response([{"data": [{"ticker": "msft"}]}])
+    )
+    result = await resolve_wkn("870747")
+    assert result == "MSFT"
+
+
+async def test_resolve_wkn_not_found(mock_post: AsyncMock) -> None:
+    """OpenFIGI returns no data → None."""
+    mock_post.post = AsyncMock(return_value=_mock_response([{}]))
+    result = await resolve_wkn("000000")
+    assert result is None
+
+
+async def test_resolve_wkn_empty_data_list(mock_post: AsyncMock) -> None:
+    """OpenFIGI returns empty data array → None."""
+    mock_post.post = AsyncMock(return_value=_mock_response([{"data": []}]))
+    result = await resolve_wkn("000000")
+    assert result is None
+
+
+async def test_resolve_wkn_http_error(mock_post: AsyncMock) -> None:
+    """HTTP error from OpenFIGI → None (no exception propagated)."""
+    import httpx
+
+    mock_post.post = AsyncMock(
+        side_effect=httpx.HTTPError("connection error")
+    )
+    result = await resolve_wkn("840400")
+    assert result is None
+
+
+async def test_resolve_wkn_empty_string() -> None:
+    """Empty WKN returns None without making any HTTP call."""
+    result = await resolve_wkn("")
+    assert result is None
+
+
+async def test_resolve_wkn_whitespace_only() -> None:
+    """Whitespace-only WKN returns None without making any HTTP call."""
+    result = await resolve_wkn("   ")
+    assert result is None
+
+
+async def test_resolve_wkn_sends_api_key(mock_post: AsyncMock) -> None:
+    """When an API key is provided it is sent as X-OPENFIGI-APIKEY header."""
+    mock_post.post = AsyncMock(
+        return_value=_mock_response([{"data": [{"ticker": "AAPL"}]}])
+    )
+    await resolve_wkn("840400", api_key="my-secret-key")
+    _, kwargs = mock_post.post.call_args
+    assert kwargs["headers"]["X-OPENFIGI-APIKEY"] == "my-secret-key"
+
+
+async def test_resolve_wkn_no_api_key_header_when_empty(mock_post: AsyncMock) -> None:
+    """When no API key is given the X-OPENFIGI-APIKEY header is absent."""
+    mock_post.post = AsyncMock(
+        return_value=_mock_response([{"data": [{"ticker": "AAPL"}]}])
+    )
+    await resolve_wkn("840400", api_key="")
+    _, kwargs = mock_post.post.call_args
+    assert "X-OPENFIGI-APIKEY" not in kwargs["headers"]


### PR DESCRIPTION
## Summary

Closes #51.

- **`app/services/openfigi_lookup.py`** — new `async def resolve_wkn(wkn, api_key="") -> str | None` that calls `POST https://api.openfigi.com/v3/mapping` with `idType: ID_WERTPAPIER` and extracts the ticker from the response
- **`GET /htmx/validate-wkn`** — mirrors `validate-ticker`; resolves WKN → ticker → `fetch_stock_info` → returns the `ticker_hint.html` fragment
- **`POST /htmx/holdings`** — now accepts optional `wkn` form field; validates mutual exclusion with `ticker`, resolves WKN if provided, then follows the unchanged ticker path
- **`add_holding_form.html`** — WKN input added below Ticker with an "OR" divider; `oninput` JS disables the other field while one has content and clears its hint when emptied
- **`app/config.py`** — `openfigi_api_key: str = ""` setting added; used for the `X-OPENFIGI-APIKEY` header when non-empty
- **`httpx`** was already in `pyproject.toml` — no new dependency required

## Test plan

- [x] 9 unit tests for `resolve_wkn` (mock HTTP): success, uppercase normalisation, not-found, empty data, HTTP error, empty/whitespace WKN, API-key header present/absent — all pass
- [ ] Manual: enter WKN `840400` → hint shows ✓ Apple Inc.
- [ ] Manual: enter invalid WKN → hint shows ✗
- [ ] Manual: submit form with valid WKN → holding added correctly
- [ ] Manual: typing in Ticker disables WKN field and vice versa; clearing re-enables
- [ ] Manual: existing ticker-based flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)