### PR TITLE
feat: Convert all stock prices to EUR for unified portfolio display (#53)

### DIFF
--- a/app/routers/htmx.py
+++ b/app/routers/htmx.py
@@ -15,6 +15,7 @@ from app.config import get_settings
 from app.database import get_async_session
 from app.models.holding import Holding
 from app.models.stock import Stock
+from app.services.fx_service import to_eur
 from app.services.openfigi_lookup import resolve_wkn
 from app.services.stock_lookup import fetch_stock_info
 
@@ -177,7 +178,11 @@ async def htmx_create_holding(
     await db.flush()
     await db.refresh(holding)
 
-    current_value = qty * stock.current_price if stock.current_price is not None else None
+    current_value = (
+        qty * to_eur(stock.current_price, stock.currency)
+        if stock.current_price is not None
+        else None
+    )
     return _render(
         request,
         "partials/holding_row.html",
@@ -186,7 +191,6 @@ async def htmx_create_holding(
                 "id": holding.id,
                 "ticker": stock.ticker,
                 "name": stock.name,
-                "currency": stock.currency,
                 "quantity": qty,
                 "current_value": current_value,
             }
@@ -210,7 +214,9 @@ async def holding_row(
         return HTMLResponse("", status_code=404)
     stock = holding.stock
     current_value = (
-        holding.quantity * stock.current_price if stock.current_price is not None else None
+        holding.quantity * to_eur(stock.current_price, stock.currency)
+        if stock.current_price is not None
+        else None
     )
     return _render(
         request,
@@ -220,7 +226,6 @@ async def holding_row(
                 "id": holding.id,
                 "ticker": stock.ticker,
                 "name": stock.name,
-                "currency": stock.currency,
                 "quantity": holding.quantity,
                 "current_value": current_value,
             }
@@ -251,7 +256,6 @@ async def edit_holding_form(
                 "id": holding.id,
                 "ticker": stock.ticker,
                 "name": stock.name,
-                "currency": stock.currency,
                 "quantity": holding.quantity,
             }
         },
@@ -284,7 +288,6 @@ async def htmx_update_holding(
                     "id": holding.id,
                     "ticker": stock.ticker,
                     "name": stock.name,
-                    "currency": stock.currency,
                     "quantity": holding.quantity,
                 },
             },
@@ -294,7 +297,11 @@ async def htmx_update_holding(
     await db.flush()
     await db.refresh(holding)
     stock = holding.stock
-    current_value = qty * stock.current_price if stock.current_price is not None else None
+    current_value = (
+        qty * to_eur(stock.current_price, stock.currency)
+        if stock.current_price is not None
+        else None
+    )
 
     return _render(
         request,
@@ -304,7 +311,6 @@ async def htmx_update_holding(
                 "id": holding.id,
                 "ticker": stock.ticker,
                 "name": stock.name,
-                "currency": stock.currency,
                 "quantity": qty,
                 "current_value": current_value,
             }

--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import selectinload
 
 from app.database import get_async_session
 from app.models.holding import Holding
+from app.services.fx_service import to_eur
 
 router = APIRouter(tags=["portfolio-ui"])
 
@@ -29,7 +30,6 @@ class HoldingRow:
     id: int
     ticker: str
     name: str
-    currency: str
     quantity: Decimal
     current_value: Decimal | None
 
@@ -50,7 +50,8 @@ async def portfolio_overview(
         stock = h.stock
         current_value: Decimal | None = None
         if stock.current_price is not None:
-            current_value = h.quantity * stock.current_price
+            eur_price = to_eur(stock.current_price, stock.currency)
+            current_value = h.quantity * eur_price
             total_value = (total_value or Decimal("0")) + current_value
 
         holding_rows.append(
@@ -58,7 +59,6 @@ async def portfolio_overview(
                 id=h.id,
                 ticker=stock.ticker,
                 name=stock.name,
-                currency=stock.currency,
                 quantity=h.quantity,
                 current_value=current_value,
             )

--- a/app/routers/stocks.py
+++ b/app/routers/stocks.py
@@ -19,6 +19,7 @@ from app.database import get_async_session
 from app.models.holding import Holding
 from app.models.price_cache import PriceCache
 from app.models.stock import Stock
+from app.services.fx_service import to_eur
 
 router = APIRouter(tags=["stocks"])
 
@@ -32,7 +33,6 @@ _DB = Depends(get_async_session)
 class StockDetail:
     ticker: str
     name: str
-    currency: str
     current_price: Decimal | None
     quantity: Decimal | None
     current_value: Decimal | None
@@ -63,16 +63,18 @@ async def stock_detail(
 
     quantity: Decimal | None = None
     current_value: Decimal | None = None
+    eur_price: Decimal | None = None
+    if stock.current_price is not None:
+        eur_price = to_eur(stock.current_price, stock.currency)
     if holding is not None:
         quantity = holding.quantity
-        if stock.current_price is not None:
-            current_value = quantity * stock.current_price
+        if eur_price is not None:
+            current_value = quantity * eur_price
 
     detail = StockDetail(
         ticker=stock.ticker,
         name=stock.name,
-        currency=stock.currency,
-        current_price=stock.current_price,
+        current_price=eur_price,
         quantity=quantity,
         current_value=current_value,
     )

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.config import Settings
 from app.models.stock import Stock
+from app.services.fx_service import refresh_fx_rates
 from app.services.price_service import refresh_price_cache
 from app.services.report_service import ReportService
 
@@ -35,6 +36,20 @@ async def run_price_cache_refresh(session_factory: async_sessionmaker[AsyncSessi
         await refresh_price_cache(tickers, db)
 
     logger.info("Price cache refresh complete for %d ticker(s).", len(tickers))
+
+
+async def run_fx_rate_refresh(session_factory: async_sessionmaker[AsyncSession]) -> None:
+    """Fetch all distinct currencies from tracked stocks and refresh FX cache."""
+    async with session_factory() as db:
+        currencies_result = await db.execute(select(Stock.currency).distinct())
+        currencies = list(currencies_result.scalars().all())
+
+    if not currencies:
+        logger.info("FX rate refresh: no currencies to refresh.")
+        return
+
+    await refresh_fx_rates(currencies)
+    logger.info("FX rate refresh complete for %d currency/ies.", len(currencies))
 
 
 async def run_monthly_report(session_factory: async_sessionmaker[AsyncSession]) -> None:
@@ -64,7 +79,8 @@ def create_scheduler(
     """Build and return a configured AsyncIOScheduler (not yet started).
 
     Schedule 1 — daily price cache refresh at 07:00.
-    Schedule 2 — monthly report generation on the 1st of each month at 08:00.
+    Schedule 2 — daily FX rate refresh at 07:05.
+    Schedule 3 — monthly report generation on the 1st of each month at 08:00.
 
     Args:
         settings: Application settings used for timezone configuration.
@@ -82,6 +98,16 @@ def create_scheduler(
         minute=0,
         args=[session_factory],
         id="refresh_price_cache",
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        run_fx_rate_refresh,
+        trigger="cron",
+        hour=7,
+        minute=5,
+        args=[session_factory],
+        id="refresh_fx_rates",
         replace_existing=True,
     )
 

--- a/app/services/fx_service.py
+++ b/app/services/fx_service.py
@@ -1,0 +1,78 @@
+"""Foreign exchange rate service for EUR conversion.
+
+Fetches live exchange rates via yfinance and caches them in memory.
+Rates are refreshed once daily by the scheduler.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from decimal import Decimal
+from functools import partial
+
+logger = logging.getLogger(__name__)
+
+# In-memory cache: currency code -> EUR/{CURRENCY}=X rate
+# e.g. "USD" -> Decimal("1.10") means 1 EUR = 1.10 USD
+_fx_cache: dict[str, Decimal] = {}
+
+
+def _fetch_rate_sync(currency: str) -> Decimal | None:
+    """Fetch the EUR/{CURRENCY} rate from yfinance (blocking).
+
+    Uses the ticker ``EUR{CURRENCY}=X`` (e.g. ``EURUSD=X``).
+    Returns the latest close price, or None if unavailable.
+    """
+    import yfinance as yf  # type: ignore[import-untyped]
+
+    ticker = f"EUR{currency.upper()}=X"
+    hist = yf.Ticker(ticker).history(period="1d")
+    if hist.empty:
+        return None
+    close = float(hist["Close"].iloc[-1])
+    return Decimal(str(round(close, 6)))
+
+
+async def refresh_fx_rates(currencies: list[str]) -> None:
+    """Refresh the in-memory FX cache for the given currency codes.
+
+    EUR is always set to 1.0.  For all other currencies the rate is
+    fetched from yfinance and stored in *_fx_cache*.
+    """
+    loop = asyncio.get_running_loop()
+    _fx_cache["EUR"] = Decimal("1")
+
+    for currency in currencies:
+        cu = currency.upper()
+        if cu == "EUR":
+            continue
+        try:
+            rate = await loop.run_in_executor(None, partial(_fetch_rate_sync, cu))
+            if rate is not None:
+                _fx_cache[cu] = rate
+                logger.debug("FX rate updated: EUR/%s = %s", cu, rate)
+            else:
+                logger.warning("No FX rate returned for %s", cu)
+        except Exception:
+            logger.exception("Failed to fetch FX rate for %s", cu)
+
+    logger.info("FX rates refreshed for %d currency/ies.", len(currencies))
+
+
+def to_eur(amount: Decimal, currency: str) -> Decimal:
+    """Convert *amount* from *currency* to EUR using the cached rate.
+
+    If *currency* is already EUR the amount is returned unchanged.
+    If no cached rate is available the amount is returned unchanged
+    (graceful fallback).
+    """
+    currency = currency.upper()
+    if currency == "EUR":
+        return amount
+    rate = _fx_cache.get(currency)
+    if rate is None:
+        logger.warning("No cached FX rate for %s, returning amount unchanged.", currency)
+        return amount
+    # EURUSD=X gives USD per 1 EUR, so: amount_eur = amount_usd / rate
+    return amount / rate

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import selectinload
 from app.models.holding import Holding
 from app.models.price_cache import PriceCache
 from app.schemas.holdings import HoldingSummaryItem, PortfolioSummary
+from app.services.fx_service import to_eur
 
 
 class PortfolioService:
@@ -31,8 +32,10 @@ class PortfolioService:
 
         for h in holdings:
             current_value: Decimal | None = None
+            eur_price: Decimal | None = None
             if h.stock.current_price is not None:
-                current_value = h.quantity * h.stock.current_price
+                eur_price = to_eur(h.stock.current_price, h.stock.currency)
+                current_value = h.quantity * eur_price
                 total_value = (total_value or Decimal("0")) + current_value
 
             items.append(
@@ -41,7 +44,7 @@ class PortfolioService:
                     ticker=h.stock.ticker,
                     name=h.stock.name,
                     quantity=h.quantity,
-                    current_price=h.stock.current_price,
+                    current_price=eur_price,
                     current_value=current_value,
                 )
             )

--- a/app/templates/partials/holding_row.html
+++ b/app/templates/partials/holding_row.html
@@ -3,7 +3,7 @@
   <td class="number">{{ holding.quantity }}</td>
   <td class="number">
     {% if holding.current_value is not none %}
-      {{ "%.2f"|format(holding.current_value) }} {{ holding.currency }}
+      {{ "%.2f"|format(holding.current_value) }} &euro;
     {% else %}
       <span class="na">N/A</span>
     {% endif %}

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -122,7 +122,7 @@
         <td class="number">{{ row.quantity }}</td>
         <td class="number">
           {% if row.current_value is not none %}
-            {{ "%.2f"|format(row.current_value) }} {{ row.currency }}
+            {{ "%.2f"|format(row.current_value) }} &euro;
           {% else %}
             <span class="na">N/A</span>
           {% endif %}
@@ -148,7 +148,7 @@
         <td colspan="3">Total Portfolio Value</td>
         <td class="number">
           {% if total_value is not none %}
-            {{ "%.2f"|format(total_value) }}
+            {{ "%.2f"|format(total_value) }} &euro;
           {% else %}
             <span class="na">N/A</span>
           {% endif %}

--- a/app/templates/stock_detail.html
+++ b/app/templates/stock_detail.html
@@ -31,7 +31,7 @@
   <p><a href="/">&larr; Back to Portfolio</a></p>
 
   <h1>{{ stock.name }}</h1>
-  <p class="subtitle">{{ stock.ticker }} &middot; {{ stock.currency }}</p>
+  <p class="subtitle">{{ stock.ticker }}</p>
 
   <div class="summary-card">
     <h2>Current Holding</h2>
@@ -50,7 +50,7 @@
         <span class="summary-label">Current Price</span>
         <span class="summary-value">
           {% if stock.current_price is not none %}
-            {{ "%.2f"|format(stock.current_price) }} {{ stock.currency }}
+            {{ "%.2f"|format(stock.current_price) }} &euro;
           {% else %}
             <span class="na">N/A</span>
           {% endif %}
@@ -60,7 +60,7 @@
         <span class="summary-label">Current Value</span>
         <span class="summary-value">
           {% if stock.current_value is not none %}
-            {{ "%.2f"|format(stock.current_value) }} {{ stock.currency }}
+            {{ "%.2f"|format(stock.current_value) }} &euro;
           {% else %}
             <span class="na">N/A</span>
           {% endif %}

--- a/tests/test_fx_service.py
+++ b/tests/test_fx_service.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 import app.services.fx_service as fx_module
 from app.services.fx_service import refresh_fx_rates, to_eur
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_fx_service.py
+++ b/tests/test_fx_service.py
@@ -1,0 +1,132 @@
+"""Unit tests for the FX rate service (app/services/fx_service.py)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.services.fx_service as fx_module
+from app.services.fx_service import refresh_fx_rates, to_eur
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_cache() -> None:
+    """Clear the in-memory FX cache between tests."""
+    fx_module._fx_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# to_eur
+# ---------------------------------------------------------------------------
+
+
+def test_to_eur_already_eur() -> None:
+    _reset_cache()
+    result = to_eur(Decimal("100"), "EUR")
+    assert result == Decimal("100")
+
+
+def test_to_eur_usd_with_cached_rate() -> None:
+    _reset_cache()
+    # EURUSD=X = 1.10 means 1 EUR = 1.10 USD
+    fx_module._fx_cache["USD"] = Decimal("1.10")
+    result = to_eur(Decimal("110"), "USD")
+    assert result == Decimal("110") / Decimal("1.10")
+
+
+def test_to_eur_gbp_with_cached_rate() -> None:
+    _reset_cache()
+    # EURGBP=X = 0.85 means 1 EUR = 0.85 GBP
+    fx_module._fx_cache["GBP"] = Decimal("0.85")
+    result = to_eur(Decimal("85"), "GBP")
+    assert result == Decimal("85") / Decimal("0.85")
+
+
+def test_to_eur_no_cached_rate_returns_unchanged() -> None:
+    _reset_cache()
+    result = to_eur(Decimal("200"), "USD")
+    assert result == Decimal("200")
+
+
+def test_to_eur_currency_case_insensitive() -> None:
+    _reset_cache()
+    fx_module._fx_cache["USD"] = Decimal("1.10")
+    result_upper = to_eur(Decimal("110"), "USD")
+    result_lower = to_eur(Decimal("110"), "usd")
+    assert result_upper == result_lower
+
+
+def test_to_eur_eur_stock_conversion_factor_is_one() -> None:
+    _reset_cache()
+    fx_module._fx_cache["EUR"] = Decimal("1")
+    result = to_eur(Decimal("50"), "EUR")
+    assert result == Decimal("50")
+
+
+# ---------------------------------------------------------------------------
+# refresh_fx_rates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_fx_rates_sets_eur_to_one() -> None:
+    _reset_cache()
+    with patch("app.services.fx_service._fetch_rate_sync", return_value=None):
+        await refresh_fx_rates(["EUR"])
+    assert fx_module._fx_cache.get("EUR") == Decimal("1")
+
+
+@pytest.mark.asyncio
+async def test_refresh_fx_rates_stores_fetched_rate() -> None:
+    _reset_cache()
+    mock_rate = Decimal("1.085432")
+
+    def _fake_fetch(currency: str) -> Decimal | None:
+        return mock_rate if currency == "USD" else None
+
+    with patch("app.services.fx_service._fetch_rate_sync", side_effect=_fake_fetch):
+        await refresh_fx_rates(["USD"])
+
+    assert fx_module._fx_cache.get("USD") == mock_rate
+
+
+@pytest.mark.asyncio
+async def test_refresh_fx_rates_skips_on_none_result() -> None:
+    _reset_cache()
+    with patch("app.services.fx_service._fetch_rate_sync", return_value=None):
+        await refresh_fx_rates(["USD"])
+    assert "USD" not in fx_module._fx_cache
+
+
+@pytest.mark.asyncio
+async def test_refresh_fx_rates_handles_exception_gracefully() -> None:
+    _reset_cache()
+    with patch(
+        "app.services.fx_service._fetch_rate_sync",
+        side_effect=RuntimeError("network error"),
+    ):
+        # Should not raise
+        await refresh_fx_rates(["USD"])
+    assert "USD" not in fx_module._fx_cache
+
+
+@pytest.mark.asyncio
+async def test_refresh_fx_rates_multiple_currencies() -> None:
+    _reset_cache()
+    rates = {"USD": Decimal("1.10"), "GBP": Decimal("0.85")}
+
+    def _fake_fetch(currency: str) -> Decimal | None:
+        return rates.get(currency)
+
+    with patch("app.services.fx_service._fetch_rate_sync", side_effect=_fake_fetch):
+        await refresh_fx_rates(["EUR", "USD", "GBP"])
+
+    assert fx_module._fx_cache["EUR"] == Decimal("1")
+    assert fx_module._fx_cache["USD"] == Decimal("1.10")
+    assert fx_module._fx_cache["GBP"] == Decimal("0.85")

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import app.services.fx_service as fx_module
 from app.services.portfolio_service import PortfolioService
 
 
@@ -16,10 +17,12 @@ def _make_holding(
     name: str,
     quantity: str,
     current_price: str | None,
+    currency: str = "EUR",
 ) -> MagicMock:
     stock = MagicMock()
     stock.ticker = ticker
     stock.name = name
+    stock.currency = currency
     stock.current_price = Decimal(current_price) if current_price else None
 
     holding = MagicMock()
@@ -91,5 +94,28 @@ async def test_summary_mixed_holdings() -> None:
     summary = await PortfolioService().get_summary(db)
 
     assert len(summary.holdings) == 3
-    assert summary.total_value == Decimal("2100.00")  # 10*150 + 2*300
+    assert summary.total_value == Decimal("2100.00")  # 10*150 + 2*300 (all EUR, no conversion)
     assert summary.holdings[1].current_value is None
+
+
+@pytest.mark.asyncio
+async def test_summary_usd_holding_converted_to_eur() -> None:
+    """Holdings in USD are converted to EUR via the FX cache."""
+    fx_module._fx_cache.clear()
+    fx_module._fx_cache["USD"] = Decimal("1.10")  # 1 EUR = 1.10 USD
+
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = [
+        _make_holding(1, "AAPL", "Apple Inc.", "10", "110.00", currency="USD"),
+    ]
+    db.execute = AsyncMock(return_value=result)
+
+    summary = await PortfolioService().get_summary(db)
+
+    expected_eur_price = Decimal("110.00") / Decimal("1.10")
+    assert summary.holdings[0].current_price == expected_eur_price
+    assert summary.holdings[0].current_value == Decimal("10") * expected_eur_price
+    assert summary.total_value == Decimal("10") * expected_eur_price
+
+    fx_module._fx_cache.clear()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -11,6 +11,7 @@ import pytest
 from app.config import Settings
 from app.scheduler import (
     create_scheduler,
+    run_fx_rate_refresh,
     run_monthly_report,
     run_price_cache_refresh,
 )
@@ -48,7 +49,7 @@ def _make_session_factory(tickers: list[str]) -> AsyncMock:
 # create_scheduler
 # ---------------------------------------------------------------------------
 
-def test_create_scheduler_registers_two_jobs() -> None:
+def test_create_scheduler_registers_three_jobs() -> None:
     settings = _make_settings()
     factory = MagicMock()
 
@@ -57,6 +58,7 @@ def test_create_scheduler_registers_two_jobs() -> None:
     jobs = scheduler.get_jobs()
     job_ids = {j.id for j in jobs}
     assert "refresh_price_cache" in job_ids
+    assert "refresh_fx_rates" in job_ids
     assert "send_monthly_report" in job_ids
 
 
@@ -105,6 +107,42 @@ async def test_run_price_cache_refresh_calls_service() -> None:
         called_tickers = mock_refresh.call_args[0][0]
         assert "AAPL" in called_tickers
         assert "TSLA" in called_tickers
+
+
+# ---------------------------------------------------------------------------
+# run_fx_rate_refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_fx_rate_refresh_no_currencies_logs_and_returns() -> None:
+    factory = _make_session_factory([])
+
+    with patch("app.scheduler.refresh_fx_rates", new_callable=AsyncMock) as mock_refresh:
+        await run_fx_rate_refresh(factory)
+        mock_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_fx_rate_refresh_calls_service_with_currencies() -> None:
+    factory = _make_session_factory(["USD", "EUR"])
+
+    with patch("app.scheduler.refresh_fx_rates", new_callable=AsyncMock) as mock_refresh:
+        await run_fx_rate_refresh(factory)
+        mock_refresh.assert_called_once()
+        called_currencies = mock_refresh.call_args[0][0]
+        assert "USD" in called_currencies
+        assert "EUR" in called_currencies
+
+
+def test_fx_rate_job_scheduled_at_07_05() -> None:
+    settings = _make_settings()
+    scheduler = create_scheduler(settings, MagicMock())
+
+    job = next(j for j in scheduler.get_jobs() if j.id == "refresh_fx_rates")
+    trigger_repr = str(job.trigger)
+    assert "hour='7'" in trigger_repr
+    assert "minute='5'" in trigger_repr
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #53

- **New `app/services/fx_service.py`**: fetches EUR/{CURRENCY} rates via yfinance (`EURUSD=X`, `EURGBP=X`, etc.), caches them in memory, and exposes `to_eur(amount, currency) -> Decimal`
- **Scheduler**: new `run_fx_rate_refresh` job runs daily at 07:05 UTC, querying all distinct currencies from tracked stocks and refreshing the FX cache
- **Portfolio service & routers**: `to_eur()` applied when computing `current_value` per holding in `portfolio_service.py`, `portfolio.py` router, `htmx.py` router, and `stocks.py` router
- **Templates**: replaced mixed `{{ currency }}` with a fixed `€` symbol in `portfolio.html`, `stock_detail.html`, and `partials/holding_row.html`

## Test plan

- [x] `test_fx_service.py` — 11 tests covering `to_eur()` (EUR passthrough, USD/GBP conversion, no-cache fallback, case insensitivity) and `refresh_fx_rates()` (stores rate, skips None, handles exceptions)
- [x] `test_portfolio_service.py` — added `test_summary_usd_holding_converted_to_eur` verifying USD→EUR conversion; updated helper to include `currency` field
- [x] `test_scheduler.py` — updated to assert three jobs registered; added tests for `run_fx_rate_refresh` and the 07:05 schedule
- [x] Full suite: 80 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)