### PR TITLE
fix: resolve negative spikes in Portfolio Performance chart

### DIFF
--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -68,6 +68,7 @@ class PortfolioService:
 
         tickers = [h.stock.ticker for h in holdings]
         qty_by_ticker = {h.stock.ticker: h.quantity for h in holdings}
+        currency_by_ticker = {h.stock.ticker: h.stock.currency for h in holdings}
 
         one_year_ago = datetime.date.today() - datetime.timedelta(days=365)
         price_rows = await db.execute(
@@ -83,10 +84,18 @@ class PortfolioService:
         for ticker, date, close_price in price_rows:
             prices_by_date.setdefault(date, {})[ticker] = close_price
 
+        all_tickers = set(tickers)
         performance: list[tuple[datetime.date, Decimal]] = []
         for date in sorted(prices_by_date):
             day_prices = prices_by_date[date]
-            total = sum((qty_by_ticker[t] * p for t, p in day_prices.items()), Decimal("0"))
+            # Skip dates where not all holdings have price data to avoid
+            # artificially low totals from partial coverage.
+            if day_prices.keys() < all_tickers:
+                continue
+            total = sum(
+                (qty_by_ticker[t] * to_eur(p, currency_by_ticker[t]) for t, p in day_prices.items()),
+                Decimal("0"),
+            )
             performance.append((date, total))
 
         return performance

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -93,7 +93,8 @@ class PortfolioService:
             if day_prices.keys() < all_tickers:
                 continue
             total = sum(
-                (qty_by_ticker[t] * to_eur(p, currency_by_ticker[t]) for t, p in day_prices.items()),
+                (qty_by_ticker[t] * to_eur(p, currency_by_ticker[t])
+                 for t, p in day_prices.items()),
                 Decimal("0"),
             )
             performance.append((date, total))


### PR DESCRIPTION
## Summary

- Apply `to_eur()` conversion to historical prices in `get_performance_history()` — raw USD/foreign prices were being summed directly with EUR prices, producing incorrect totals
- Skip dates where not all holdings have a cached price, preventing artificially low values from partial coverage (the main cause of the sharp spikes)

## Root cause

`get_summary()` (the current portfolio view) correctly calls `to_eur()`, but `get_performance_history()` was never updated when EUR conversion was added in #53. Additionally, dates with incomplete price data (e.g. a stock added mid-year with shorter history) contributed only the subset of holdings that had prices, causing sudden drops in the chart.

## Test plan

- [ ] Open the Portfolio Performance (1Y) chart and verify the spikes are gone
- [ ] Confirm the overall value range is consistent with the current portfolio summary value
- [ ] Check that dates with missing price data are simply omitted rather than shown as drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)