### PR TITLE
feat: redesign PDF import flow with Terminal Ledger style (issue #59)

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -220,6 +220,122 @@
     .actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
     .note { color: var(--muted); font-size: 0.85rem; margin-bottom: 1rem; }
 
+    /* ── Step indicator ──────────────────────────────────────── */
+    .step-indicator {
+      display: flex;
+      align-items: center;
+      gap: 0;
+      margin-bottom: 2rem;
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      letter-spacing: 0.03em;
+    }
+    .step-item {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+      color: var(--muted);
+      opacity: 0.5;
+    }
+    .step-item.active {
+      color: var(--accent);
+      opacity: 1;
+    }
+    .step-item.completed {
+      color: var(--accent);
+      opacity: 0.7;
+    }
+    .step-num {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      border: 1.5px solid currentColor;
+      font-size: 0.72rem;
+      font-weight: 600;
+    }
+    .step-item.active .step-num {
+      background: var(--accent);
+      color: var(--bg);
+      border-color: var(--accent);
+    }
+    .step-arrow {
+      color: var(--border);
+      margin: 0 0.7rem;
+      font-size: 0.75rem;
+      user-select: none;
+    }
+
+    /* ── Drop zone ───────────────────────────────────────────── */
+    .drop-zone {
+      border: 2px dashed var(--accent);
+      border-radius: var(--radius);
+      padding: 2.5rem 1.5rem;
+      text-align: center;
+      margin-bottom: 1.25rem;
+      transition: background 0.15s;
+      cursor: pointer;
+      position: relative;
+    }
+    .drop-zone:hover,
+    .drop-zone.dragover {
+      background: rgba(34, 211, 160, 0.06);
+    }
+    .drop-zone-icon {
+      display: block;
+      margin: 0 auto 0.75rem;
+      color: var(--accent);
+    }
+    .drop-zone-text {
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin-bottom: 0.5rem;
+    }
+    .drop-zone-text strong {
+      color: var(--accent);
+    }
+    .file-badge {
+      display: inline-block;
+      background: rgba(34, 211, 160, 0.1);
+      color: var(--accent);
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 0.2rem 0.6rem;
+      border-radius: var(--radius-sm);
+      letter-spacing: 0.04em;
+    }
+    .drop-zone input[type="file"] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+    }
+    .selected-file {
+      color: var(--accent);
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      margin-top: 0.75rem;
+    }
+
+    /* ── Striped table rows (preview/done) ───────────────────── */
+    .table-striped tbody tr:nth-child(even) {
+      background: rgba(255, 255, 255, 0.015);
+    }
+    .table-striped tbody tr:nth-child(odd) {
+      background: transparent;
+    }
+
+    /* ── Done state ──────────────────────────────────────────── */
+    .done-icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 1.25rem;
+    }
+
     /* ── Utility classes ─────────────────────────────────────── */
     .text-mono { font-family: var(--font-mono); }
     .positive  { color: var(--accent); }

--- a/app/templates/import_pdf.html
+++ b/app/templates/import_pdf.html
@@ -91,6 +91,7 @@
   <!-- Success / error summary                                              -->
   <!-- ------------------------------------------------------------------ -->
   <div class="card" style="text-align: center;">
+    <h2>Import complete</h2>
     {% if processed %}
     <div class="done-icon">
       <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">

--- a/app/templates/import_pdf.html
+++ b/app/templates/import_pdf.html
@@ -3,8 +3,23 @@
 {% block title %}Import Broker PDF{% endblock %}
 
 {% block content %}
+  <p style="margin-bottom: 0.75rem;"><a href="/">&larr; Back to portfolio</a></p>
   <h1>Import Broker PDF</h1>
-  <p><a href="/">&larr; Back to portfolio</a></p>
+
+  <!-- Step indicator -->
+  <div class="step-indicator">
+    <span class="step-item {{ 'active' if step == 'upload' else 'completed' }}">
+      <span class="step-num">1</span> Upload
+    </span>
+    <span class="step-arrow">&rarr;</span>
+    <span class="step-item {{ 'active' if step == 'preview' else ('completed' if step == 'done' else '') }}">
+      <span class="step-num">2</span> Preview
+    </span>
+    <span class="step-arrow">&rarr;</span>
+    <span class="step-item {{ 'active' if step == 'done' else '' }}">
+      <span class="step-num">3</span> Done
+    </span>
+  </div>
 
   {% if step == "upload" %}
   <!-- ------------------------------------------------------------------ -->
@@ -16,9 +31,17 @@
     <div class="error">{{ error }}</div>
     {% endif %}
     <form method="post" action="/import/pdf" enctype="multipart/form-data">
-      <div class="form-row">
-        <label for="file">PDF file</label>
+      <div class="drop-zone" id="drop-zone">
+        <svg class="drop-zone-icon" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+          <polyline points="14 2 14 8 20 8"/>
+          <line x1="12" y1="18" x2="12" y2="12"/>
+          <polyline points="9 15 12 12 15 15"/>
+        </svg>
+        <p class="drop-zone-text">Drag &amp; drop your PDF here or <strong>click to browse</strong></p>
+        <span class="file-badge">.PDF</span>
         <input type="file" id="file" name="file" accept=".pdf" required>
+        <p class="selected-file" id="selected-file"></p>
       </div>
       <button type="submit" class="btn-primary">Upload &amp; Preview</button>
     </form>
@@ -35,7 +58,7 @@
       these quantities to your existing holdings (or create new ones).
       Tickers not yet tracked in the portfolio will be skipped.
     </p>
-    <table>
+    <table class="table-striped">
       <thead>
         <tr>
           <th>Ticker</th>
@@ -57,21 +80,26 @@
       <input type="hidden" name="quantities" value="{{ qty }}">
       {% endfor %}
       <div class="actions">
-        <button type="submit" class="btn-confirm">Confirm Import</button>
-        <a href="/import/pdf"><button type="button" class="btn-secondary">Cancel</button></a>
+        <button type="submit" class="btn-primary">Confirm Import</button>
+        <a href="/import/pdf"><button type="button" class="btn-ghost">Cancel</button></a>
       </div>
     </form>
   </div>
 
   {% elif step == "done" %}
   <!-- ------------------------------------------------------------------ -->
-  <!-- Success summary                                                      -->
+  <!-- Success / error summary                                              -->
   <!-- ------------------------------------------------------------------ -->
-  <div class="card">
-    <h2>Import complete</h2>
+  <div class="card" style="text-align: center;">
     {% if processed %}
+    <div class="done-icon">
+      <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/>
+        <polyline points="9 12 11.5 14.5 16 10"/>
+      </svg>
+    </div>
     <div class="success">Successfully imported {{ processed | length }} holding(s).</div>
-    <table>
+    <table class="table-striped" style="text-align: left;">
       <thead>
         <tr>
           <th>Ticker</th>
@@ -88,12 +116,44 @@
       </tbody>
     </table>
     {% else %}
+    <div class="done-icon">
+      <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/>
+        <line x1="15" y1="9" x2="9" y2="15"/>
+        <line x1="9" y1="9" x2="15" y2="15"/>
+      </svg>
+    </div>
     <div class="error">No holdings were imported. Make sure the tickers exist in your portfolio.</div>
     {% endif %}
-    <div class="actions">
+    <div class="actions" style="justify-content: center; margin-top: 1rem;">
       <a href="/"><button type="button" class="btn-primary">Back to portfolio</button></a>
-      <a href="/import/pdf"><button type="button" class="btn-secondary">Import another PDF</button></a>
+      <a href="/import/pdf"><button type="button" class="btn-ghost">Import another PDF</button></a>
     </div>
   </div>
   {% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+  (function () {
+    var zone = document.getElementById("drop-zone");
+    if (!zone) return;
+    var input = zone.querySelector('input[type="file"]');
+    var label = document.getElementById("selected-file");
+
+    zone.addEventListener("dragover", function (e) { e.preventDefault(); zone.classList.add("dragover"); });
+    zone.addEventListener("dragleave", function () { zone.classList.remove("dragover"); });
+    zone.addEventListener("drop", function (e) {
+      e.preventDefault();
+      zone.classList.remove("dragover");
+      if (e.dataTransfer.files.length) {
+        input.files = e.dataTransfer.files;
+        label.textContent = e.dataTransfer.files[0].name;
+      }
+    });
+    input.addEventListener("change", function () {
+      label.textContent = input.files.length ? input.files[0].name : "";
+    });
+  })();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add horizontal step indicator (`1 Upload → 2 Preview → 3 Done`) with active step highlighted in accent green
- Replace plain file input with drag-and-drop zone (dashed accent border, file icon SVG, `.PDF` badge, filename feedback)
- Add striped table rows for preview and done steps
- Add large checkmark/X SVG icons for done/error states
- Use `btn-ghost` for cancel/secondary actions, consistent back link at top
- All new CSS added to `base.html` design system

Closes #59

## Test plan
- [ ] Visit `/import/pdf` — verify step indicator shows step 1 active, drop zone renders with dashed border
- [ ] Drag a file onto the zone — verify highlight effect and filename appears
- [ ] Click browse — verify file picker works and filename displays
- [ ] Upload a valid PDF — verify step 2 shows with striped preview table and Confirm/Cancel buttons
- [ ] Confirm import — verify step 3 shows checkmark icon and success banner (or X icon and error banner if no tickers match)
- [ ] Verify back link and action buttons navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)