### PR TITLE
feat: redesign HTMX partials with Terminal Ledger style (#60)

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -169,6 +169,19 @@
     .form-row { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem; }
     .form-row label { min-width: 70px; font-weight: 600; font-size: 0.9rem; color: var(--muted); }
     .form-row input { width: 160px; }
+    .form-or-divider {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.75rem;
+    }
+    .form-or-divider::before,
+    .form-or-divider::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: var(--border);
+    }
     .or-label { font-size: 0.8rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; }
     .input-group { display: flex; align-items: center; gap: 0.5rem; }
     .form-actions { margin-top: 0.75rem; display: flex; gap: 0.5rem; }
@@ -194,6 +207,25 @@
     }
 
     /* ── Ticker hints ────────────────────────────────────────── */
+    .ticker-hint {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+    .ticker-hint-dot {
+      display: inline-block;
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .ticker-hint.positive .ticker-hint-dot { background: var(--accent); }
+    .ticker-hint.negative .ticker-hint-dot { background: var(--danger); }
+    .ticker-hint.positive { color: var(--accent); }
+    .ticker-hint.negative { color: var(--danger); }
     .ticker-valid   { color: var(--accent); font-size: 0.85rem; }
     .ticker-invalid { color: var(--danger);  font-size: 0.85rem; }
 
@@ -204,8 +236,10 @@
 
     /* ── Inline edit (portfolio table) ───────────────────────── */
     .inline-form { display: flex; align-items: center; gap: 0.5rem; justify-content: flex-end; }
-    .qty-input { width: 100px; }
-    .editing td { background: rgba(34, 211, 160, 0.04); }
+    .qty-input { width: 100px; font-family: var(--font-mono); }
+    .editing td { background: #1c2128; }
+    .input-mono { font-family: var(--font-mono); }
+    .input-glow:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(34, 211, 160, 0.15); }
 
     /* ── Stock detail ────────────────────────────────────────── */
     .subtitle { color: var(--muted); margin-bottom: 2rem; font-family: var(--font-mono); font-size: 0.95rem; }

--- a/app/templates/partials/add_holding_form.html
+++ b/app/templates/partials/add_holding_form.html
@@ -18,6 +18,7 @@
           value="{{ ticker or '' }}"
           placeholder="e.g. AAPL"
           autocomplete="off"
+          class="input-mono input-glow"
           oninput="toggleWknTicker(this, 'wkn', 'ticker-hint', 'wkn-hint')"
           hx-get="/htmx/validate-ticker"
           hx-trigger="input changed delay:600ms"
@@ -27,7 +28,7 @@
         <span id="ticker-hint"></span>
       </div>
     </div>
-    <div class="form-row form-or-divider">
+    <div class="form-or-divider">
       <span class="or-label">OR</span>
     </div>
     <div class="form-row">
@@ -40,6 +41,7 @@
           value="{{ wkn or '' }}"
           placeholder="e.g. 840400"
           autocomplete="off"
+          class="input-mono input-glow"
           oninput="toggleWknTicker(this, 'ticker', 'wkn-hint', 'ticker-hint')"
           hx-get="/htmx/validate-wkn"
           hx-trigger="input changed delay:600ms"
@@ -59,14 +61,15 @@
         min="0.00000001"
         step="any"
         placeholder="e.g. 10"
-        required>
+        required
+        class="input-mono input-glow">
     </div>
     <div class="form-actions">
-      <button type="submit" class="btn-save">Add</button>
+      <button type="submit" class="btn-primary">Add</button>
       <button
         type="button"
         onclick="document.getElementById('add-holding-form').remove()"
-        class="btn-cancel">Cancel</button>
+        class="btn-ghost">Cancel</button>
     </div>
   </form>
 </div>

--- a/app/templates/partials/edit_holding_form.html
+++ b/app/templates/partials/edit_holding_form.html
@@ -1,5 +1,8 @@
 <tr id="holding-row-{{ holding.id }}" class="editing">
-  <td>{{ holding.name }} ({{ holding.ticker }})</td>
+  <td>
+    <span class="holding-ticker">{{ holding.ticker }}</span>
+    <span class="holding-name">{{ holding.name }}</span>
+  </td>
   <td class="number" colspan="2">
     <form
       hx-put="/htmx/holdings/{{ holding.id }}"
@@ -16,15 +19,15 @@
         min="0.00000001"
         step="any"
         required
-        class="qty-input"
+        class="qty-input input-mono input-glow"
         autofocus>
-      <button type="submit" class="btn-save">Save</button>
+      <button type="submit" class="btn-primary" style="padding: 0.3rem 0.7rem; font-size: 0.85rem;">Save</button>
       <button
         type="button"
         hx-get="/htmx/holdings/{{ holding.id }}/row"
         hx-target="#holding-row-{{ holding.id }}"
         hx-swap="outerHTML"
-        class="btn-cancel">Cancel</button>
+        class="btn-ghost" style="padding: 0.3rem 0.7rem; font-size: 0.85rem;">Cancel</button>
     </form>
   </td>
   <td class="actions"></td>

--- a/app/templates/partials/holding_row.html
+++ b/app/templates/partials/holding_row.html
@@ -1,5 +1,10 @@
 <tr id="holding-row-{{ holding.id }}">
-  <td><a href="/stocks/{{ holding.ticker }}">{{ holding.name }} ({{ holding.ticker }})</a></td>
+  <td>
+    <a href="/stocks/{{ holding.ticker }}" style="text-decoration: none;">
+      <span class="holding-ticker">{{ holding.ticker }}</span>
+      <span class="holding-name">{{ holding.name }}</span>
+    </a>
+  </td>
   <td class="number">{{ holding.quantity }}</td>
   <td class="number">
     {% if holding.current_value is not none %}

--- a/app/templates/partials/ticker_hint.html
+++ b/app/templates/partials/ticker_hint.html
@@ -1,5 +1,5 @@
 {% if valid %}
-<span class="ticker-valid">&#10003; {{ name }}</span>
+<span class="ticker-hint positive"><span class="ticker-hint-dot"></span> {{ name }}</span>
 {% else %}
-<span class="ticker-invalid">&#10007; Ticker not found</span>
+<span class="ticker-hint negative"><span class="ticker-hint-dot"></span> Ticker not found</span>
 {% endif %}


### PR DESCRIPTION
## Summary
- Restyle `holding_row.html` with ticker/name split layout (`.holding-ticker` / `.holding-name`), matching the portfolio table's hover accent bar
- Restyle `edit_holding_form.html` with `#1c2128` surface-2 background, mono input with accent glow, `.btn-primary` / `.btn-ghost` inline buttons
- Restyle `add_holding_form.html` with visual OR divider line (CSS `::before`/`::after`), mono input fields with accent-green glow on focus
- Restyle `ticker_hint.html` as compact inline badge with colored dot indicator (green = valid, red = invalid)
- Add shared CSS classes in `base.html`: `.ticker-hint`, `.form-or-divider`, `.input-mono`, `.input-glow`

Closes #60

## Test plan
- [ ] Add a holding via the form — verify ticker/WKN validation hints show with dot badges
- [ ] Toggle between ticker and WKN fields — verify OR divider renders as a line
- [ ] Edit a holding inline — verify surface-2 background and styled buttons
- [ ] Delete a holding — verify confirm dialog and row removal
- [ ] Check input focus states show accent-green glow

🤖 Generated with [Claude Code](https://claude.com/claude-code)