### PR TITLE
feat: add animations and micro-interactions (issue #61)

### DIFF
--- a/app/routers/htmx.py
+++ b/app/routers/htmx.py
@@ -198,10 +198,11 @@ async def htmx_create_holding(
     )
     row_html = row_resp.body.decode()
     # OOB swap: append row to tbody with flash animation, clear form slot
+    oob_attr = 'class="anim-flash" hx-swap-oob="beforeend:#holdings-tbody"'
     oob_html = (
         row_html.replace(
             f'<tr id="holding-row-{holding.id}">',
-            f'<tr id="holding-row-{holding.id}" class="anim-flash" hx-swap-oob="beforeend:#holdings-tbody">',
+            f'<tr id="holding-row-{holding.id}" {oob_attr}>',
         )
         + "\n<script>"
         "var s=document.getElementById('add-form-slot');"

--- a/app/routers/htmx.py
+++ b/app/routers/htmx.py
@@ -196,7 +196,7 @@ async def htmx_create_holding(
             }
         },
     )
-    row_html = row_resp.body.decode()
+    row_html = bytes(row_resp.body).decode()
     # OOB swap: append row to tbody with flash animation, clear form slot
     oob_attr = 'class="anim-flash" hx-swap-oob="beforeend:#holdings-tbody"'
     oob_html = (

--- a/app/routers/htmx.py
+++ b/app/routers/htmx.py
@@ -183,7 +183,7 @@ async def htmx_create_holding(
         if stock.current_price is not None
         else None
     )
-    return _render(
+    row_resp = _render(
         request,
         "partials/holding_row.html",
         {
@@ -196,6 +196,20 @@ async def htmx_create_holding(
             }
         },
     )
+    row_html = row_resp.body.decode()
+    # OOB swap: append row to tbody with flash animation, clear form slot
+    oob_html = (
+        row_html.replace(
+            f'<tr id="holding-row-{holding.id}">',
+            f'<tr id="holding-row-{holding.id}" class="anim-flash" hx-swap-oob="beforeend:#holdings-tbody">',
+        )
+        + "\n<script>"
+        "var s=document.getElementById('add-form-slot');"
+        "s.classList.remove('open');"
+        "setTimeout(function(){s.innerHTML='';},300);"
+        "</script>"
+    )
+    return HTMLResponse(oob_html)
 
 
 # ---------------------------------------------------------------------------

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,10 +56,12 @@
       font-family: var(--font-ui);
       font-size: 0.9rem;
       padding: 0.35rem 0.6rem;
+      transition: border-color 150ms ease, box-shadow 150ms ease;
     }
     input:focus, select:focus, textarea:focus {
       outline: none;
       border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(34, 211, 160, 0.15);
     }
 
     /* ── Navigation ─────────────────────────────────────────── */
@@ -375,6 +377,64 @@
     .positive  { color: var(--accent); }
     .negative  { color: var(--danger); }
     .na        { color: var(--muted); font-weight: normal; }
+
+    /* ── Keyframes ───────────────────────────────────────────── */
+    @keyframes fade-slide-down {
+      from { opacity: 0; transform: translateY(-12px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fade-slide-up {
+      from { opacity: 0; transform: translateY(16px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fade-in {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+    @keyframes flash-highlight {
+      0%   { background: rgba(34, 211, 160, 0.18); }
+      100% { background: transparent; }
+    }
+    @keyframes row-collapse {
+      to { opacity: 0; max-height: 0; padding-top: 0; padding-bottom: 0; overflow: hidden; }
+    }
+    @keyframes scale-pulse {
+      0%   { transform: scale(1); }
+      50%  { transform: scale(0.97); }
+      100% { transform: scale(1); }
+    }
+
+    /* ── Shared animation classes ────────────────────────────── */
+    .anim-fade-slide-down {
+      animation: fade-slide-down 350ms ease-out both;
+    }
+    .anim-fade-slide-up {
+      animation: fade-slide-up 400ms ease-out both;
+    }
+    .anim-fade-in {
+      animation: fade-in 500ms ease both;
+    }
+    .anim-stagger {
+      animation: fade-in 350ms ease both;
+      animation-delay: calc(var(--row-index, 0) * 40ms);
+    }
+    .anim-flash {
+      animation: flash-highlight 800ms ease-out;
+    }
+
+    /* ── Button interactions ─────────────────────────────────── */
+    .btn-primary:active, .btn-save:active, .btn-confirm:active, .btn-add:active {
+      animation: scale-pulse 100ms ease;
+    }
+
+    /* ── Reduced motion ─────────────────────────────────────── */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
   </style>
   {% block extra_head %}{% endblock %}
 </head>

--- a/app/templates/partials/add_holding_form.html
+++ b/app/templates/partials/add_holding_form.html
@@ -2,9 +2,8 @@
   <h2>Add Holding</h2>
   <form
     hx-post="/htmx/holdings"
-    hx-target="#holdings-tbody"
-    hx-swap="beforeend"
-    hx-on::after-request="if(event.detail.successful && event.detail.elt === this) this.closest('#add-holding-form').remove()">
+    hx-target="#add-form-slot"
+    hx-swap="innerHTML">
     {% if error %}
     <div class="form-error">{{ error }}</div>
     {% endif %}
@@ -68,7 +67,7 @@
       <button type="submit" class="btn-primary">Add</button>
       <button
         type="button"
-        onclick="document.getElementById('add-holding-form').remove()"
+        onclick="var s=document.getElementById('add-form-slot'); s.classList.remove('open'); setTimeout(function(){s.innerHTML='';},300)"
         class="btn-ghost">Cancel</button>
     </div>
   </form>

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -199,7 +199,7 @@
 {% block content %}
 
   <!-- Hero stats bar -->
-  <div class="hero-bar">
+  <div class="hero-bar anim-fade-slide-down">
     <div class="hero-primary">
       <span class="hero-label">Total Portfolio Value</span>
       <span class="hero-value">
@@ -240,12 +240,12 @@
 
   <!-- Charts (only when there is data) -->
   {% if total_value is not none %}
-  <div class="chart-card">
+  <div class="chart-card anim-fade-in" style="animation-delay: 350ms">
     <h2>Performance</h2>
     <div id="performance-chart" style="height: 300px;"></div>
   </div>
 
-  <div class="chart-card">
+  <div class="chart-card anim-fade-in" style="animation-delay: 500ms">
     <h2>Allocation</h2>
     <div id="allocation-chart" style="height: 350px;"></div>
   </div>
@@ -264,7 +264,7 @@
     </thead>
     <tbody id="holdings-tbody">
       {% for row in holdings %}
-      <tr id="holding-row-{{ row.id }}">
+      <tr id="holding-row-{{ row.id }}" class="anim-stagger" style="--row-index: {{ loop.index0 }}">
         <td>
           <a href="/stocks/{{ row.ticker }}" style="text-decoration: none;">
             <span class="holding-ticker">{{ row.ticker }}</span>
@@ -386,4 +386,15 @@
   })();
 </script>
 {% endif %}
+<script>
+  // Delete row collapse animation
+  document.body.addEventListener('htmx:beforeSwap', function(evt) {
+    var target = evt.detail.target;
+    if (target && target.id && target.id.startsWith('holding-row-') && evt.detail.serverResponse === '') {
+      evt.detail.shouldSwap = false;
+      target.style.animation = 'row-collapse 250ms ease forwards';
+      target.addEventListener('animationend', function() { target.remove(); }, { once: true });
+    }
+  });
+</script>
 {% endblock %}

--- a/app/templates/stock_detail.html
+++ b/app/templates/stock_detail.html
@@ -149,7 +149,7 @@
 
   <!-- Stats strip -->
   <div class="stats-strip">
-    <div class="stat-card">
+    <div class="stat-card anim-fade-slide-up" style="animation-delay: 0ms">
       <span class="stat-label">Quantity</span>
       <span class="stat-value{% if stock.quantity is none %} na{% endif %}">
         {% if stock.quantity is not none %}
@@ -159,7 +159,7 @@
         {% endif %}
       </span>
     </div>
-    <div class="stat-card">
+    <div class="stat-card anim-fade-slide-up" style="animation-delay: 80ms">
       <span class="stat-label">Current Price</span>
       <span class="stat-value{% if stock.current_price is none %} na{% endif %}">
         {% if stock.current_price is not none %}
@@ -169,7 +169,7 @@
         {% endif %}
       </span>
     </div>
-    <div class="stat-card">
+    <div class="stat-card anim-fade-slide-up" style="animation-delay: 160ms">
       <span class="stat-label">Current Value</span>
       <span class="stat-value{% if stock.current_value is none %} na{% endif %}">
         {% if stock.current_value is not none %}
@@ -182,7 +182,7 @@
   </div>
 
   <!-- Price history chart -->
-  <div class="chart-card">
+  <div class="chart-card anim-fade-in" style="animation-delay: 200ms">
     <div class="chart-card-title">Price History &middot; 1Y</div>
     <div id="price-history-chart" style="height: 300px;"></div>
   </div>


### PR DESCRIPTION
## Summary
- Add page-load animations: hero bar slide-down, staggered table row fade-in (40ms per row), chart containers fade-in with delay
- Add stock detail animations: stats strip staggered slide-up, chart fade-in
- Add micro-interactions: input focus glow with box-shadow transition, button scale-pulse on click, new row flash-highlight on insert, delete row collapse animation before HTMX swap
- Add `prefers-reduced-motion` media query to disable all non-essential animations
- **Fix add-holding form bug**: form was targeting `#holdings-tbody` so validation errors injected form HTML into the table body; now targets `#add-form-slot` with OOB swap for success

Closes #61

## Test plan
- [ ] Verify hero bar slides down on portfolio page load
- [ ] Verify table rows fade in with stagger delay
- [ ] Verify chart cards fade in after hero completes
- [ ] Verify stat cards slide up on stock detail page
- [ ] Verify input focus shows green glow
- [ ] Verify delete row collapses before removal
- [ ] Verify add holding form opens, submits (new row flashes), and closes properly
- [ ] Verify add holding form shows validation errors correctly (not in table)
- [ ] Verify cancel button collapses the form slot
- [ ] Verify animations are disabled with `prefers-reduced-motion: reduce`
- [ ] All 80 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)