### PR TITLE
chore(docker): install only production dependencies in builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy dependency manifest and install into an isolated prefix
 COPY pyproject.toml README.md ./
 RUN pip install --upgrade pip && \
-    pip install --prefix=/install ".[dev]" --no-cache-dir
+    pip install --prefix=/install "." --no-cache-dir
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 FROM python:3.12-slim AS runtime


### PR DESCRIPTION
## Summary

- Removes `[dev]` extras from the builder stage `pip install`, so dev-only packages (`mypy`, `ruff`, `pytest`, `pytest-asyncio`, `pytest-cov`, `coverage`, `asgi-lifespan`, `types-passlib`) are no longer copied into the runtime image.
- Estimated reduction of **100–200 MB** in the `/install` layer (~559 MB → ~350–460 MB).
- Zero runtime risk: none of these packages are required by the `uvicorn app.main:app` entrypoint.

Closes #70