### PR TITLE
chore(deps): remove psycopg2-binary and migrate Alembic to asyncpg

### DIFF
--- a/.claude/agent-memory/python-fullstack-architect/project_overview.md
+++ b/.claude/agent-memory/python-fullstack-architect/project_overview.md
@@ -29,9 +29,9 @@ Greenfield FastAPI + PostgreSQL stock portfolio tracker scaffolded 2026-04-06.
 **Key architectural decisions:**
 - App factory pattern: `create_app(settings)` in `app/main.py` so tests inject custom Settings
 - Database init/teardown in FastAPI lifespan (not at module import time)
-- Alembic reads `DATABASE_SYNC_URL` (psycopg2) from environment — never from alembic.ini
+- Alembic reads `DATABASE_URL` (asyncpg) from environment — never from alembic.ini; uses async engine via `asyncio.run`
 - `app/models/__init__.py` must import every model module so `Base.metadata` is complete for Alembic
 - `/health` is a liveness probe — no DB I/O, always returns `{"status": "ok"}`
-- Two DB URL env vars: `DATABASE_URL` (asyncpg, app) and `DATABASE_SYNC_URL` (psycopg2, alembic)
+- Single DB URL env var: `DATABASE_URL` (asyncpg) — used by both the app and Alembic migrations
 
 **How to apply:** When adding new models, import them in `app/models/__init__.py`. When adding new routes, register them in `app/main.py` under `/api/v1/`. Follow the service → repository → router layering already established.

--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,6 @@ ALLOWED_HOSTS=["http://localhost:8000"]
 # Database (PostgreSQL)
 # -----------------------------------------------------------------------
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/portfolio
-# Used by Alembic (sync driver) for migrations
-DATABASE_SYNC_URL=postgresql+psycopg2://postgres:postgres@localhost:5432/portfolio
 
 # -----------------------------------------------------------------------
 # Email / SMTP  (issue #20)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,7 @@ FROM python:3.12-slim AS builder
 
 WORKDIR /build
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc \
-    libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
+# No system build dependencies needed — asyncpg ships pre-compiled wheels
 
 # Copy dependency manifest and install into an isolated prefix
 COPY pyproject.toml README.md ./
@@ -18,11 +14,6 @@ RUN pip install --upgrade pip && \
 FROM python:3.12-slim AS runtime
 
 WORKDIR /app
-
-# Runtime system dependency for asyncpg / psycopg2
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libpq5 \
-    && rm -rf /var/lib/apt/lists/*
 
 # Copy installed packages from builder
 COPY --from=builder /install /usr/local

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,6 +1,6 @@
 # Alembic configuration file.
 # The `sqlalchemy.url` value is intentionally left as a placeholder —
-# env.py reads DATABASE_SYNC_URL from the environment at runtime.
+# env.py reads DATABASE_URL from the environment at runtime.
 
 [alembic]
 script_location = alembic

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,17 +1,21 @@
 """Alembic migration environment.
 
-Reads DATABASE_SYNC_URL from the environment (via pydantic-settings) so
+Reads DATABASE_URL from the environment (via pydantic-settings) so
 that credentials are never stored in alembic.ini.  All application
 models must be imported (directly or transitively) through
 ``app.models`` so that ``Base.metadata`` is fully populated before
 Alembic inspects it.
+
+Uses the asyncpg driver exclusively — no psycopg2 dependency required.
 """
 
 from __future__ import annotations
 
+import asyncio
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.pool import NullPool
 
 from alembic import context
 
@@ -26,9 +30,9 @@ from app.models import Base  # noqa: F401 — populates Base.metadata
 # ---------------------------------------------------------------------------
 config = context.config
 
-# Inject the sync database URL from pydantic-settings at runtime.
+# Inject the async database URL from pydantic-settings at runtime.
 settings = get_settings()
-config.set_main_option("sqlalchemy.url", settings.database_sync_url)
+config.set_main_option("sqlalchemy.url", settings.database_url)
 
 # Read the search_path configured in alembic.ini.
 _search_path = config.get_main_option("search_path", "costs")
@@ -62,27 +66,38 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
-def run_migrations_online() -> None:
-    """Run migrations in 'online' mode (against a live database connection)."""
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-        connect_args={"options": f"-csearch_path={_search_path}"},
+def do_run_migrations(connection: object) -> None:
+    """Run migrations against a live connection (called inside async context)."""
+    context.configure(
+        connection=connection,  # type: ignore[arg-type]
+        target_metadata=target_metadata,
+        compare_type=True,
+        compare_server_default=True,
+        include_schemas=True,
+        version_table_schema=_search_path,
     )
 
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-            compare_type=True,
-            compare_server_default=True,
-            include_schemas=True,
-            version_table_schema=_search_path,
-        )
+    with context.begin_transaction():
+        context.run_migrations()
 
-        with context.begin_transaction():
-            context.run_migrations()
+
+async def run_async_migrations() -> None:
+    """Create an async engine and run migrations inside a sync callback."""
+    connectable: AsyncEngine = create_async_engine(
+        settings.database_url,
+        poolclass=NullPool,
+        connect_args={"server_settings": {"search_path": _search_path}},
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode (against a live database connection)."""
+    asyncio.run(run_async_migrations())
 
 
 if context.is_offline_mode():

--- a/app/config.py
+++ b/app/config.py
@@ -40,10 +40,6 @@ class Settings(BaseSettings):
         ...,
         description="Async SQLAlchemy URL — must use asyncpg driver.",
     )
-    database_sync_url: str = Field(
-        ...,
-        description="Sync SQLAlchemy URL for Alembic migrations (psycopg2).",
-    )
 
     # ------------------------------------------------------------------
     # Email / SMTP  (issue #20)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
     environment:
       # Override DATABASE_URL to use the postgres container when running via docker compose
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/portfolio
-      DATABASE_SYNC_URL: postgresql+psycopg2://postgres:postgres@postgres:5432/portfolio
     ports:
       - "8000:8000"
     depends_on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.0",
     "alembic>=1.13.0",
     "asyncpg>=0.29.0",
-    "psycopg2-binary>=2.9.0",
 
     # Validation & settings
     "pydantic>=2.7.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,22 +20,20 @@ from app.config import Settings
 from app.main import create_app
 
 _DB_URL = os.environ.get("TEST_DATABASE_URL")
-_DB_SYNC_URL = os.environ.get("TEST_DATABASE_SYNC_URL")
 
 
 @pytest.fixture(scope="session")
 def test_settings() -> Settings:
     """Return a Settings instance suitable for testing.
 
-    Override TEST_DATABASE_URL / TEST_DATABASE_SYNC_URL via environment
-    variables in CI to point at a real test database.
+    Override TEST_DATABASE_URL via environment variable in CI to point
+    at a real test database.
     """
     return Settings(
         app_env="development",
         app_debug=True,
         secret_key="test-secret-key-that-is-long-enough-32chars",
         database_url=_DB_URL or "postgresql+asyncpg://postgres:postgres@localhost:5432/portfolio_test",
-        database_sync_url=_DB_SYNC_URL or "postgresql+psycopg2://postgres:postgres@localhost:5432/portfolio_test",
     )
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -17,7 +17,6 @@ def _make_settings() -> Settings:
         app_debug=False,
         secret_key="test-secret-key-that-is-long-enough-32chars",
         database_url="postgresql+asyncpg://postgres:postgres@localhost/test",
-        database_sync_url="postgresql+psycopg2://postgres:postgres@localhost/test",
     )
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -26,7 +26,6 @@ def _make_settings() -> Settings:
         app_debug=False,
         secret_key="test-secret-key-that-is-long-enough-32chars",
         database_url="postgresql+asyncpg://postgres:postgres@localhost/test",
-        database_sync_url="postgresql+psycopg2://postgres:postgres@localhost/test",
         scheduler_timezone="UTC",
     )
 


### PR DESCRIPTION
## Summary

Resolves #71.

- **Remove `psycopg2-binary`** from `pyproject.toml` — it was only needed by Alembic's sync engine; asyncpg is the sole PostgreSQL driver now
- **Migrate `alembic/env.py`** to use an async SQLAlchemy engine (`create_async_engine` + `asyncio.run`) with asyncpg, replacing `engine_from_config` + psycopg2
- **Remove `DATABASE_SYNC_URL`** env var from `app/config.py`, `.env`, `.env.example`, and `docker-compose.yml` — Alembic now reads `DATABASE_URL` directly
- **Slim the Docker image**: remove `libpq5` apt layer from the runtime stage and `gcc`/`libpq-dev` from the builder stage (~8 MB saved)
- **Update tests** (`conftest.py`, `test_admin.py`, `test_scheduler.py`) to drop the now-removed `database_sync_url` parameter

## How it works

`alembic/env.py` now creates an `AsyncEngine` and calls `connection.run_sync(do_run_migrations)` inside an `async with` block, which is the standard Alembic async pattern. `asyncio.run()` drives the event loop from the synchronous `run_migrations_online` entry point.

## Expected savings

| Component | Size |
|---|---|
| `psycopg2-binary` wheel | ~4–5 MB |
| `libpq5` + Kerberos/LDAP chain | ~4 MB |
| **Total** | **~8 MB** |