### PR TITLE
feat: add build script for Docker registry deployment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGISTRY="192.168.178.29:5000"
+IMAGE_NAME="stock-portfolio-tracker"
+TAG="${1:-latest}"
+
+FULL_TAG="${REGISTRY}/${IMAGE_NAME}:${TAG}"
+
+echo "Building ${FULL_TAG} ..."
+docker build -t "${FULL_TAG}" .
+
+echo "Pushing ${FULL_TAG} ..."
+docker push "${FULL_TAG}"
+
+echo "Done: ${FULL_TAG}"


### PR DESCRIPTION
## Summary
- Adds `build.sh` that builds and pushes the Docker image to the private registry at `192.168.178.29:5000`
- Supports an optional tag argument (defaults to `latest`)

## Test plan
- [ ] Run `./build.sh` and verify the image is pushed to the registry
- [ ] Run `./build.sh v1.0.0` and verify custom tag works

🤖 Generated with [Claude Code](https://claude.com/claude-code)