### PR TITLE
Rename database schema from 'costs' to 'finance'

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -7,7 +7,7 @@ script_location = alembic
 prepend_sys_path = .
 version_path_separator = os
 file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
-search_path = costs
+search_path = finance
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -35,7 +35,7 @@ settings = get_settings()
 config.set_main_option("sqlalchemy.url", settings.database_url)
 
 # Read the search_path configured in alembic.ini.
-_search_path = config.get_main_option("search_path", "costs")
+_search_path = config.get_main_option("search_path", "finance")
 
 # Attach Python logging configuration from alembic.ini.
 if config.config_file_name is not None:

--- a/alembic/versions/20260406_0000_a3f7c9e1b2d4_create_stock_and_holding_tables.py
+++ b/alembic/versions/20260406_0000_a3f7c9e1b2d4_create_stock_and_holding_tables.py
@@ -22,7 +22,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute("CREATE SCHEMA IF NOT EXISTS costs")
+    op.execute("CREATE SCHEMA IF NOT EXISTS finance")
 
     op.create_table(
         "stock",
@@ -32,7 +32,7 @@ def upgrade() -> None:
         sa.Column("currency", sa.String(length=10), nullable=False),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("ticker", name="uq_stock_ticker"),
-        schema="costs",
+        schema="finance",
     )
 
     op.create_table(
@@ -42,15 +42,15 @@ def upgrade() -> None:
         sa.Column("quantity", sa.Numeric(precision=18, scale=8), nullable=False),
         sa.ForeignKeyConstraint(
             ["stock_id"],
-            ["costs.stock.id"],
+            ["finance.stock.id"],
             ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("id"),
-        schema="costs",
+        schema="finance",
     )
 
 
 def downgrade() -> None:
-    op.drop_table("holding", schema="costs")
-    op.drop_table("stock", schema="costs")
-    op.execute("DROP SCHEMA IF EXISTS costs")
+    op.drop_table("holding", schema="finance")
+    op.drop_table("stock", schema="finance")
+    op.execute("DROP SCHEMA IF EXISTS finance")

--- a/alembic/versions/20260406_0001_b5e8d2f3a1c6_add_current_price_to_stock.py
+++ b/alembic/versions/20260406_0001_b5e8d2f3a1c6_add_current_price_to_stock.py
@@ -24,9 +24,9 @@ def upgrade() -> None:
     op.add_column(
         "stock",
         sa.Column("current_price", sa.Numeric(precision=18, scale=4), nullable=True),
-        schema="costs",
+        schema="finance",
     )
 
 
 def downgrade() -> None:
-    op.drop_column("stock", "current_price", schema="costs")
+    op.drop_column("stock", "current_price", schema="finance")

--- a/alembic/versions/20260406_0002_c7a1e4f8b3d5_create_price_cache_table.py
+++ b/alembic/versions/20260406_0002_c7a1e4f8b3d5_create_price_cache_table.py
@@ -29,9 +29,9 @@ def upgrade() -> None:
         sa.Column("close_price", sa.Numeric(precision=18, scale=4), nullable=False),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("ticker", "date", name="uq_price_cache_ticker_date"),
-        schema="costs",
+        schema="finance",
     )
 
 
 def downgrade() -> None:
-    op.drop_table("price_cache", schema="costs")
+    op.drop_table("price_cache", schema="finance")

--- a/app/models/holding.py
+++ b/app/models/holding.py
@@ -18,11 +18,11 @@ class Holding(Base):
     """Represents the current holding of a stock in the portfolio."""
 
     __tablename__ = "holding"
-    __table_args__ = {"schema": "costs"}
+    __table_args__ = {"schema": "finance"}
 
     id: Mapped[int] = mapped_column(primary_key=True)
     stock_id: Mapped[int] = mapped_column(
-        ForeignKey("costs.stock.id", ondelete="CASCADE"), nullable=False
+        ForeignKey("finance.stock.id", ondelete="CASCADE"), nullable=False
     )
     quantity: Mapped[Decimal] = mapped_column(
         Numeric(precision=18, scale=8), nullable=False

--- a/app/models/price_cache.py
+++ b/app/models/price_cache.py
@@ -17,7 +17,7 @@ class PriceCache(Base):
     __tablename__ = "price_cache"
     __table_args__ = (
         UniqueConstraint("ticker", "date", name="uq_price_cache_ticker_date"),
-        {"schema": "costs"},
+        {"schema": "finance"},
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/app/models/stock.py
+++ b/app/models/stock.py
@@ -20,7 +20,7 @@ class Stock(Base):
     __tablename__ = "stock"
     __table_args__ = (
         UniqueConstraint("ticker", name="uq_stock_ticker"),
-        {"schema": "costs"},
+        {"schema": "finance"},
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,4 +1,4 @@
 -- Initialisation script run once when the postgres container is first created.
--- Creates the `costs` schema used for testing.
+-- Creates the `finance` schema used for testing.
 
-CREATE SCHEMA IF NOT EXISTS costs;
+CREATE SCHEMA IF NOT EXISTS finance;


### PR DESCRIPTION
## Summary
- Renames the PostgreSQL schema from `costs` to `finance` across all models, migrations, Alembic config, and the Docker init script

## Changed files
- `alembic.ini` — search_path
- `alembic/env.py` — default fallback
- `app/models/holding.py`, `stock.py`, `price_cache.py` — `__table_args__` schema + ForeignKey reference
- `alembic/versions/` — all three migration files
- `docker/postgres/init.sql` — `CREATE SCHEMA` statement

## Test plan
- [ ] Rebuild containers with `docker compose up -d --build app` (fresh volume to pick up new init.sql)
- [ ] Verify migrations run successfully against the `finance` schema
- [ ] Confirm CRUD operations work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)