### PR TITLE
fix: handle NaN values in performance chart JSON response

### DIFF
--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import plotly.graph_objects as go
+import plotly.io as pio
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -57,7 +58,7 @@ async def get_performance_chart(
         plot_bgcolor="#fff",
         paper_bgcolor="#fff",
     )
-    return JSONResponse(content=fig.to_dict())
+    return Response(content=pio.to_json(fig), media_type="application/json")
 
 
 @router.get("/chart/allocation")


### PR DESCRIPTION
## Summary
- The `/api/v1/holdings/chart/performance` endpoint crashes with `ValueError: Out of range float values are not JSON compliant: nan` when performance data contains NaN values
- Replaced `JSONResponse(content=fig.to_dict())` with `Response(content=pio.to_json(fig))` to use Plotly's built-in JSON encoder, which converts NaN to `null`

## Test plan
- [ ] Verify the performance chart endpoint returns valid JSON when data contains NaN values
- [ ] Verify the performance chart still renders correctly with complete data

🤖 Generated with [Claude Code](https://claude.com/claude-code)