### PR TITLE
feat: persist FX rates and add DB fallback for yfinance failures

### DIFF
--- a/alembic/versions/20260417_0000_d9b2f6a4e8c1_create_fx_rate_table.py
+++ b/alembic/versions/20260417_0000_d9b2f6a4e8c1_create_fx_rate_table.py
@@ -1,0 +1,40 @@
+"""create fx_rate table
+
+Revision ID: d9b2f6a4e8c1
+Revises: c7a1e4f8b3d5
+Create Date: 2026-04-17 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d9b2f6a4e8c1"
+down_revision: str | None = "c7a1e4f8b3d5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fx_rate",
+        sa.Column("currency", sa.String(length=10), nullable=False),
+        sa.Column("rate", sa.Numeric(precision=18, scale=8), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("currency"),
+        schema="finance",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("fx_rate", schema="finance")

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,12 @@ async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
     """
     import asyncio
 
-    from app.scheduler import create_scheduler, run_fx_rate_refresh, run_price_cache_refresh
+    from app.scheduler import (
+        create_scheduler,
+        run_fx_cache_warmup,
+        run_fx_rate_refresh,
+        run_price_cache_refresh,
+    )
 
     settings: Settings = application.state.settings
     logger.info("Starting up — env=%s", settings.app_env)
@@ -44,6 +49,13 @@ async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
     scheduler = create_scheduler(settings, _sched_factory)
     scheduler.start()
     logger.info("Scheduler started (price cache: daily 07:00, monthly report: 1st 08:00).")
+
+    # Warm the FX cache from the DB synchronously so conversions work
+    # immediately — the yfinance refresh then runs in the background.
+    try:
+        await run_fx_cache_warmup(_sched_factory)
+    except Exception:
+        logger.exception("FX cache warm-up from DB failed.")
 
     # Run an initial cache warm-up in the background so it doesn't block startup.
     asyncio.create_task(run_price_cache_refresh(_sched_factory))

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,8 +5,9 @@ via ``Base.metadata`` after importing this package.
 """
 
 from app.database import Base  # noqa: F401 — re-exported for Alembic
+from app.models.fx_rate import FxRate  # noqa: F401
 from app.models.holding import Holding  # noqa: F401
 from app.models.price_cache import PriceCache  # noqa: F401
 from app.models.stock import Stock  # noqa: F401
 
-__all__ = ["Base", "Stock", "Holding", "PriceCache"]
+__all__ = ["Base", "Stock", "Holding", "PriceCache", "FxRate"]

--- a/app/models/fx_rate.py
+++ b/app/models/fx_rate.py
@@ -1,0 +1,33 @@
+"""ORM model for the FxRate entity."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+from sqlalchemy import DateTime, Numeric, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class FxRate(Base):
+    """Stores the most recently fetched EUR/{CURRENCY} exchange rate.
+
+    ``rate`` is the value of ``EUR{CURRENCY}=X`` — i.e. units of
+    *currency* per 1 EUR (e.g. USD=1.10 means 1 EUR = 1.10 USD).
+    """
+
+    __tablename__ = "fx_rate"
+    __table_args__ = ({"schema": "finance"},)
+
+    currency: Mapped[str] = mapped_column(String(10), primary_key=True)
+    rate: Mapped[Decimal] = mapped_column(
+        Numeric(precision=18, scale=8), nullable=False
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -31,7 +31,7 @@ async def _get_or_404(holding_id: int, db: AsyncSession) -> Holding:
 @router.get("/chart/performance")
 async def get_performance_chart(
     db: AsyncSession = _DB,
-) -> JSONResponse:
+) -> Response:
     """Return a Plotly line chart of total portfolio value over the past year."""
     performance = await PortfolioService().get_performance_history(db)
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.config import Settings
 from app.models.stock import Stock
-from app.services.fx_service import refresh_fx_rates
+from app.services.fx_service import load_fx_cache_from_db, refresh_fx_rates
 from app.services.price_service import refresh_price_cache
 from app.services.report_service import ReportService
 
@@ -44,12 +44,18 @@ async def run_fx_rate_refresh(session_factory: async_sessionmaker[AsyncSession])
         currencies_result = await db.execute(select(Stock.currency).distinct())
         currencies = list(currencies_result.scalars().all())
 
-    if not currencies:
-        logger.info("FX rate refresh: no currencies to refresh.")
-        return
+        if not currencies:
+            logger.info("FX rate refresh: no currencies to refresh.")
+            return
 
-    await refresh_fx_rates(currencies)
+        await refresh_fx_rates(currencies, db)
     logger.info("FX rate refresh complete for %d currency/ies.", len(currencies))
+
+
+async def run_fx_cache_warmup(session_factory: async_sessionmaker[AsyncSession]) -> None:
+    """Warm the in-memory FX cache from the ``finance.fx_rate`` table."""
+    async with session_factory() as db:
+        await load_fx_cache_from_db(db)
 
 
 async def run_monthly_report(session_factory: async_sessionmaker[AsyncSession]) -> None:

--- a/app/services/fx_service.py
+++ b/app/services/fx_service.py
@@ -1,7 +1,9 @@
 """Foreign exchange rate service for EUR conversion.
 
 Fetches live exchange rates via yfinance and caches them in memory.
-Rates are refreshed once daily by the scheduler.
+Rates are refreshed once daily by the scheduler and persisted to the
+``finance.fx_rate`` table so the cache can be warmed on startup and
+used as a fallback when yfinance is unavailable.
 """
 
 from __future__ import annotations
@@ -10,6 +12,12 @@ import asyncio
 import logging
 from decimal import Decimal
 from functools import partial
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.fx_rate import FxRate
 
 logger = logging.getLogger(__name__)
 
@@ -34,11 +42,59 @@ def _fetch_rate_sync(currency: str) -> Decimal | None:
     return Decimal(str(round(close, 6)))
 
 
-async def refresh_fx_rates(currencies: list[str]) -> None:
-    """Refresh the in-memory FX cache for the given currency codes.
+async def load_fx_cache_from_db(db: AsyncSession) -> int:
+    """Populate the in-memory FX cache from the ``finance.fx_rate`` table.
+
+    Returns the number of rates loaded (EUR is always set to 1 and is
+    not counted).
+    """
+    _fx_cache["EUR"] = Decimal("1")
+    result = await db.execute(select(FxRate.currency, FxRate.rate))
+    loaded = 0
+    for currency, rate in result.all():
+        cu = currency.upper()
+        if cu == "EUR":
+            continue
+        _fx_cache[cu] = rate
+        loaded += 1
+    logger.info("FX cache warmed from DB with %d rate(s).", loaded)
+    return loaded
+
+
+async def _persist_rate(db: AsyncSession, currency: str, rate: Decimal) -> None:
+    """Upsert the latest rate for *currency* into ``finance.fx_rate``."""
+    stmt = (
+        insert(FxRate)
+        .values(currency=currency, rate=rate)
+        .on_conflict_do_update(
+            index_elements=[FxRate.currency],
+            set_={"rate": rate, "updated_at": func.now()},
+        )
+    )
+    await db.execute(stmt)
+
+
+async def _fallback_from_db(db: AsyncSession, currency: str) -> Decimal | None:
+    """Load the last persisted rate for *currency* from the DB and cache it."""
+    result = await db.execute(
+        select(FxRate.rate).where(FxRate.currency == currency)
+    )
+    rate = result.scalar_one_or_none()
+    if rate is not None:
+        _fx_cache[currency] = rate
+        logger.warning(
+            "FX fallback: using persisted rate for %s (rate=%s).", currency, rate
+        )
+    return rate
+
+
+async def refresh_fx_rates(currencies: list[str], db: AsyncSession) -> None:
+    """Refresh the in-memory FX cache and persist rates to the DB.
 
     EUR is always set to 1.0.  For all other currencies the rate is
-    fetched from yfinance and stored in *_fx_cache*.
+    fetched from yfinance and, on success, persisted to ``finance.fx_rate``.
+    When a fetch fails (empty result or exception), the last persisted
+    rate is loaded from the DB into the cache as a fallback.
     """
     loop = asyncio.get_running_loop()
     _fx_cache["EUR"] = Decimal("1")
@@ -47,15 +103,28 @@ async def refresh_fx_rates(currencies: list[str]) -> None:
         cu = currency.upper()
         if cu == "EUR":
             continue
+        rate: Decimal | None = None
         try:
             rate = await loop.run_in_executor(None, partial(_fetch_rate_sync, cu))
-            if rate is not None:
-                _fx_cache[cu] = rate
-                logger.debug("FX rate updated: EUR/%s = %s", cu, rate)
-            else:
-                logger.warning("No FX rate returned for %s", cu)
         except Exception:
             logger.exception("Failed to fetch FX rate for %s", cu)
+
+        if rate is not None:
+            _fx_cache[cu] = rate
+            logger.debug("FX rate updated: EUR/%s = %s", cu, rate)
+            try:
+                await _persist_rate(db, cu, rate)
+            except Exception:
+                logger.exception("Failed to persist FX rate for %s", cu)
+        else:
+            logger.warning("No FX rate returned for %s, attempting DB fallback.", cu)
+            await _fallback_from_db(db, cu)
+
+    try:
+        await db.commit()
+    except Exception:
+        logger.exception("Failed to commit FX rate updates.")
+        await db.rollback()
 
     logger.info("FX rates refreshed for %d currency/ies.", len(currencies))
 

--- a/tests/test_fx_service.py
+++ b/tests/test_fx_service.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import app.services.fx_service as fx_module
-from app.services.fx_service import refresh_fx_rates, to_eur
+from app.services.fx_service import (
+    load_fx_cache_from_db,
+    refresh_fx_rates,
+    to_eur,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -18,6 +22,24 @@ from app.services.fx_service import refresh_fx_rates, to_eur
 def _reset_cache() -> None:
     """Clear the in-memory FX cache between tests."""
     fx_module._fx_cache.clear()
+
+
+def _make_db(select_rows: list | None = None, scalar: Decimal | None = None) -> AsyncMock:
+    """Build a mock AsyncSession.
+
+    ``select_rows`` is used as the return value of ``result.all()`` (for
+    ``load_fx_cache_from_db``). ``scalar`` is returned by
+    ``scalar_one_or_none`` (for the DB fallback lookup).
+    """
+    result = MagicMock()
+    result.all = MagicMock(return_value=select_rows or [])
+    result.scalar_one_or_none = MagicMock(return_value=scalar)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
 
 
 # ---------------------------------------------------------------------------
@@ -76,56 +98,112 @@ def test_to_eur_eur_stock_conversion_factor_is_one() -> None:
 @pytest.mark.asyncio
 async def test_refresh_fx_rates_sets_eur_to_one() -> None:
     _reset_cache()
+    db = _make_db()
     with patch("app.services.fx_service._fetch_rate_sync", return_value=None):
-        await refresh_fx_rates(["EUR"])
+        await refresh_fx_rates(["EUR"], db)
     assert fx_module._fx_cache.get("EUR") == Decimal("1")
 
 
 @pytest.mark.asyncio
-async def test_refresh_fx_rates_stores_fetched_rate() -> None:
+async def test_refresh_fx_rates_stores_fetched_rate_and_persists() -> None:
     _reset_cache()
     mock_rate = Decimal("1.085432")
+    db = _make_db()
 
     def _fake_fetch(currency: str) -> Decimal | None:
         return mock_rate if currency == "USD" else None
 
     with patch("app.services.fx_service._fetch_rate_sync", side_effect=_fake_fetch):
-        await refresh_fx_rates(["USD"])
+        await refresh_fx_rates(["USD"], db)
 
     assert fx_module._fx_cache.get("USD") == mock_rate
+    # An upsert should have been executed, followed by a commit.
+    assert db.execute.await_count >= 1
+    db.commit.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_refresh_fx_rates_skips_on_none_result() -> None:
+async def test_refresh_fx_rates_falls_back_to_db_on_none_result() -> None:
     _reset_cache()
+    db_rate = Decimal("1.07")
+    db = _make_db(scalar=db_rate)
+
     with patch("app.services.fx_service._fetch_rate_sync", return_value=None):
-        await refresh_fx_rates(["USD"])
-    assert "USD" not in fx_module._fx_cache
+        await refresh_fx_rates(["USD"], db)
+
+    # Cache should contain the DB fallback rate.
+    assert fx_module._fx_cache.get("USD") == db_rate
 
 
 @pytest.mark.asyncio
-async def test_refresh_fx_rates_handles_exception_gracefully() -> None:
+async def test_refresh_fx_rates_falls_back_to_db_on_exception() -> None:
     _reset_cache()
+    db_rate = Decimal("0.86")
+    db = _make_db(scalar=db_rate)
+
     with patch(
         "app.services.fx_service._fetch_rate_sync",
         side_effect=RuntimeError("network error"),
     ):
         # Should not raise
-        await refresh_fx_rates(["USD"])
+        await refresh_fx_rates(["GBP"], db)
+
+    assert fx_module._fx_cache.get("GBP") == db_rate
+
+
+@pytest.mark.asyncio
+async def test_refresh_fx_rates_no_fallback_when_db_empty() -> None:
+    _reset_cache()
+    db = _make_db(scalar=None)
+
+    with patch("app.services.fx_service._fetch_rate_sync", return_value=None):
+        await refresh_fx_rates(["USD"], db)
+
     assert "USD" not in fx_module._fx_cache
 
 
 @pytest.mark.asyncio
 async def test_refresh_fx_rates_multiple_currencies() -> None:
     _reset_cache()
+    db = _make_db()
     rates = {"USD": Decimal("1.10"), "GBP": Decimal("0.85")}
 
     def _fake_fetch(currency: str) -> Decimal | None:
         return rates.get(currency)
 
     with patch("app.services.fx_service._fetch_rate_sync", side_effect=_fake_fetch):
-        await refresh_fx_rates(["EUR", "USD", "GBP"])
+        await refresh_fx_rates(["EUR", "USD", "GBP"], db)
 
     assert fx_module._fx_cache["EUR"] == Decimal("1")
     assert fx_module._fx_cache["USD"] == Decimal("1.10")
     assert fx_module._fx_cache["GBP"] == Decimal("0.85")
+
+
+# ---------------------------------------------------------------------------
+# load_fx_cache_from_db
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_fx_cache_from_db_populates_cache() -> None:
+    _reset_cache()
+    rows = [("USD", Decimal("1.10")), ("GBP", Decimal("0.85"))]
+    db = _make_db(select_rows=rows)
+
+    loaded = await load_fx_cache_from_db(db)
+
+    assert loaded == 2
+    assert fx_module._fx_cache["EUR"] == Decimal("1")
+    assert fx_module._fx_cache["USD"] == Decimal("1.10")
+    assert fx_module._fx_cache["GBP"] == Decimal("0.85")
+
+
+@pytest.mark.asyncio
+async def test_load_fx_cache_from_db_empty() -> None:
+    _reset_cache()
+    db = _make_db(select_rows=[])
+
+    loaded = await load_fx_cache_from_db(db)
+
+    assert loaded == 0
+    assert fx_module._fx_cache == {"EUR": Decimal("1")}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -11,6 +11,7 @@ import pytest
 from app.config import Settings
 from app.scheduler import (
     create_scheduler,
+    run_fx_cache_warmup,
     run_fx_rate_refresh,
     run_monthly_report,
     run_price_cache_refresh,
@@ -132,6 +133,17 @@ async def test_run_fx_rate_refresh_calls_service_with_currencies() -> None:
         called_currencies = mock_refresh.call_args[0][0]
         assert "USD" in called_currencies
         assert "EUR" in called_currencies
+
+
+@pytest.mark.asyncio
+async def test_run_fx_cache_warmup_delegates_to_loader() -> None:
+    factory = _make_session_factory([])
+
+    with patch(
+        "app.scheduler.load_fx_cache_from_db", new_callable=AsyncMock
+    ) as mock_load:
+        await run_fx_cache_warmup(factory)
+        mock_load.assert_called_once()
 
 
 def test_fx_rate_job_scheduled_at_07_05() -> None:


### PR DESCRIPTION
## Summary
- Add `finance.fx_rate` table + Alembic migration to persist the latest EUR/{CURRENCY} rate per currency.
- On app startup, synchronously warm the in-memory FX cache from the DB so conversions work immediately — even while the background yfinance refresh is still running.
- When a yfinance fetch returns no data or raises, fall back to the last persisted rate loaded from the DB instead of silently leaving the cache empty (which previously made `to_eur` return the unconverted amount and distorted EUR totals).

## Test plan
- [x] `pytest tests/test_fx_service.py tests/test_scheduler.py` — new coverage for persistence + fallback + DB warm-up
- [x] Full `pytest` suite — 88 passed, 8 skipped
- [ ] Manual: rebuild app via `docker compose up -d --build app`, run the migration, and verify logs show `FX cache warmed from DB` on startup and `FX fallback: using persisted rate` when yfinance is stubbed/down

🤖 Generated with [Claude Code](https://claude.com/claude-code)