### PR TITLE
fix: source portfolio total value from PriceCache

### DIFF
--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -31,7 +31,7 @@ async def _get_or_404(holding_id: int, db: AsyncSession) -> Holding:
 @router.get("/chart/performance")
 async def get_performance_chart(
     db: AsyncSession = _DB,
-) -> JSONResponse:
+) -> Response:
     """Return a Plotly line chart of total portfolio value over the past year."""
     performance = await PortfolioService().get_performance_history(db)
 

--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import datetime
-from dataclasses import dataclass
-from decimal import Decimal
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, Request
@@ -12,12 +10,10 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.database import get_async_session
-from app.models.holding import Holding
 from app.models.price_cache import PriceCache
-from app.services.fx_service import to_eur
+from app.services.portfolio_service import PortfolioService
 
 router = APIRouter(tags=["portfolio-ui"])
 
@@ -27,57 +23,24 @@ templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 _DB = Depends(get_async_session)
 
 
-@dataclass
-class HoldingRow:
-    id: int
-    ticker: str
-    name: str
-    quantity: Decimal
-    current_value: Decimal | None
-
-
 @router.get("/", response_class=HTMLResponse)
 async def portfolio_overview(
     request: Request,
     db: AsyncSession = _DB,
 ) -> HTMLResponse:
     """Render the portfolio overview page."""
-    rows_result = await db.execute(select(Holding).options(selectinload(Holding.stock)))
-    holdings = rows_result.scalars().all()
+    summary = await PortfolioService().get_summary(db)
 
-    holding_rows: list[HoldingRow] = []
-    total_value: Decimal | None = None
-
-    for h in holdings:
-        stock = h.stock
-        current_value: Decimal | None = None
-        if stock.current_price is not None:
-            eur_price = to_eur(stock.current_price, stock.currency)
-            current_value = h.quantity * eur_price
-            total_value = (total_value or Decimal("0")) + current_value
-
-        holding_rows.append(
-            HoldingRow(
-                id=h.id,
-                ticker=stock.ticker,
-                name=stock.name,
-                quantity=h.quantity,
-                current_value=current_value,
-            )
-        )
-
-    last_refresh_result = await db.execute(
-        select(func.max(PriceCache.date))
-    )
+    last_refresh_result = await db.execute(select(func.max(PriceCache.date)))
     last_refresh: datetime.date | None = last_refresh_result.scalar()
 
     return templates.TemplateResponse(
         request=request,
         name="portfolio.html",
         context={
-            "holdings": holding_rows,
-            "total_value": total_value,
-            "holdings_count": len(holding_rows),
+            "holdings": summary.holdings,
+            "total_value": summary.total_value,
+            "holdings_count": len(summary.holdings),
             "last_refresh": last_refresh,
         },
     )

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -18,14 +18,34 @@ from app.services.fx_service import to_eur
 class PortfolioService:
     """Calculates current market values for portfolio holdings."""
 
+    async def _latest_close_prices(
+        self, db: AsyncSession, tickers: list[str]
+    ) -> dict[str, Decimal]:
+        """Return ``{ticker: latest close_price}`` from PriceCache."""
+        if not tickers:
+            return {}
+        stmt = (
+            select(PriceCache.ticker, PriceCache.close_price)
+            .distinct(PriceCache.ticker)
+            .where(PriceCache.ticker.in_(tickers))
+            .order_by(PriceCache.ticker, PriceCache.date.desc())
+        )
+        result = await db.execute(stmt)
+        return {ticker: price for ticker, price in result.all()}
+
     async def get_summary(self, db: AsyncSession) -> PortfolioSummary:
         """Return per-holding market values and total portfolio value.
 
-        Holdings without a ``current_price`` contribute ``None`` for their
-        value and are excluded from the ``total_value`` sum.
+        Uses the latest close price from ``PriceCache`` so the total stays
+        consistent with the performance chart.  Holdings without a cached
+        price contribute ``None`` for their value and are excluded from
+        the ``total_value`` sum.
         """
         rows = await db.execute(select(Holding).options(selectinload(Holding.stock)))
         holdings = rows.scalars().all()
+
+        tickers = [h.stock.ticker.upper() for h in holdings]
+        latest_prices = await self._latest_close_prices(db, tickers)
 
         items: list[HoldingSummaryItem] = []
         total_value: Decimal | None = None
@@ -33,8 +53,9 @@ class PortfolioService:
         for h in holdings:
             current_value: Decimal | None = None
             eur_price: Decimal | None = None
-            if h.stock.current_price is not None:
-                eur_price = to_eur(h.stock.current_price, h.stock.currency)
+            close_price = latest_prices.get(h.stock.ticker.upper())
+            if close_price is not None:
+                eur_price = to_eur(close_price, h.stock.currency)
                 current_value = h.quantity * eur_price
                 total_value = (total_value or Decimal("0")) + current_value
 

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -16,14 +16,12 @@ def _make_holding(
     ticker: str,
     name: str,
     quantity: str,
-    current_price: str | None,
     currency: str = "EUR",
 ) -> MagicMock:
     stock = MagicMock()
     stock.ticker = ticker
     stock.name = name
     stock.currency = currency
-    stock.current_price = Decimal(current_price) if current_price else None
 
     holding = MagicMock()
     holding.id = id
@@ -32,12 +30,28 @@ def _make_holding(
     return holding
 
 
+def _make_db(holdings: list, prices: dict[str, str | None]) -> AsyncMock:
+    """Build a mock AsyncSession that returns holdings + latest prices.
+
+    ``prices`` maps ticker -> latest close price string (or None to omit).
+    ``get_summary`` calls ``db.execute`` twice: first for holdings, then
+    for the latest-close lookup.
+    """
+    holdings_result = MagicMock()
+    holdings_result.scalars.return_value.all.return_value = holdings
+
+    price_rows = [(t, Decimal(p)) for t, p in prices.items() if p is not None]
+    prices_result = MagicMock()
+    prices_result.all.return_value = price_rows
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[holdings_result, prices_result])
+    return db
+
+
 @pytest.mark.asyncio
 async def test_summary_no_holdings() -> None:
-    db = AsyncMock()
-    result = MagicMock()
-    result.scalars.return_value.all.return_value = []
-    db.execute = AsyncMock(return_value=result)
+    db = _make_db([], {})
 
     summary = await PortfolioService().get_summary(db)
 
@@ -47,12 +61,10 @@ async def test_summary_no_holdings() -> None:
 
 @pytest.mark.asyncio
 async def test_summary_single_holding_with_price() -> None:
-    db = AsyncMock()
-    result = MagicMock()
-    result.scalars.return_value.all.return_value = [
-        _make_holding(1, "AAPL", "Apple Inc.", "10", "150.00")
-    ]
-    db.execute = AsyncMock(return_value=result)
+    db = _make_db(
+        [_make_holding(1, "AAPL", "Apple Inc.", "10")],
+        {"AAPL": "150.00"},
+    )
 
     summary = await PortfolioService().get_summary(db)
 
@@ -66,12 +78,10 @@ async def test_summary_single_holding_with_price() -> None:
 
 @pytest.mark.asyncio
 async def test_summary_holding_without_price() -> None:
-    db = AsyncMock()
-    result = MagicMock()
-    result.scalars.return_value.all.return_value = [
-        _make_holding(1, "AAPL", "Apple Inc.", "10", None)
-    ]
-    db.execute = AsyncMock(return_value=result)
+    db = _make_db(
+        [_make_holding(1, "AAPL", "Apple Inc.", "10")],
+        {"AAPL": None},
+    )
 
     summary = await PortfolioService().get_summary(db)
 
@@ -81,20 +91,20 @@ async def test_summary_holding_without_price() -> None:
 
 @pytest.mark.asyncio
 async def test_summary_mixed_holdings() -> None:
-    """Total value counts only holdings that have a price."""
-    db = AsyncMock()
-    result = MagicMock()
-    result.scalars.return_value.all.return_value = [
-        _make_holding(1, "AAPL", "Apple Inc.", "10", "150.00"),
-        _make_holding(2, "TSLA", "Tesla Inc.", "5", None),
-        _make_holding(3, "MSFT", "Microsoft Corp.", "2", "300.00"),
-    ]
-    db.execute = AsyncMock(return_value=result)
+    """Total value counts only holdings that have a cached price."""
+    db = _make_db(
+        [
+            _make_holding(1, "AAPL", "Apple Inc.", "10"),
+            _make_holding(2, "TSLA", "Tesla Inc.", "5"),
+            _make_holding(3, "MSFT", "Microsoft Corp.", "2"),
+        ],
+        {"AAPL": "150.00", "TSLA": None, "MSFT": "300.00"},
+    )
 
     summary = await PortfolioService().get_summary(db)
 
     assert len(summary.holdings) == 3
-    assert summary.total_value == Decimal("2100.00")  # 10*150 + 2*300 (all EUR, no conversion)
+    assert summary.total_value == Decimal("2100.00")  # 10*150 + 2*300
     assert summary.holdings[1].current_value is None
 
 
@@ -104,12 +114,10 @@ async def test_summary_usd_holding_converted_to_eur() -> None:
     fx_module._fx_cache.clear()
     fx_module._fx_cache["USD"] = Decimal("1.10")  # 1 EUR = 1.10 USD
 
-    db = AsyncMock()
-    result = MagicMock()
-    result.scalars.return_value.all.return_value = [
-        _make_holding(1, "AAPL", "Apple Inc.", "10", "110.00", currency="USD"),
-    ]
-    db.execute = AsyncMock(return_value=result)
+    db = _make_db(
+        [_make_holding(1, "AAPL", "Apple Inc.", "10", currency="USD")],
+        {"AAPL": "110.00"},
+    )
 
     summary = await PortfolioService().get_summary(db)
 


### PR DESCRIPTION
## Summary
- Total Portfolio Value now uses the latest `PriceCache.close_price` per ticker — the same source the performance chart reads from — so the hero total and the chart's latest point stay consistent.
- Previously the total read `Stock.current_price`, which is only written when a stock is created or edited and has no scheduled refresh, leaving it arbitrarily stale relative to the daily-refreshed chart.
- Delegates `portfolio_overview` to `PortfolioService.get_summary` to keep a single code path.

## Test plan
- [x] `pytest tests/test_portfolio_service.py tests/test_portfolio_summary.py tests/test_portfolio_page.py`
- [x] Full `pytest` suite — 84 passed, 8 skipped
- [ ] Manual: rebuild with `docker compose up -d --build app`, load `/`, and verify the hero Total matches the rightmost point of the performance chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)