### PR TITLE
feat: add XML preview for Portfolio Performance imports

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,16 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import Settings, get_settings
 from app.database import build_engine, build_session_factory, close_db, init_db
-from app.routers import admin, health, holdings, htmx, import_pdf, portfolio, stocks
+from app.routers import (
+    admin,
+    health,
+    holdings,
+    htmx,
+    import_pdf,
+    import_xml,
+    portfolio,
+    stocks,
+)
 
 __all__ = ["app", "create_app"]
 
@@ -117,6 +126,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(holdings.router, prefix="/api/v1")
     app.include_router(htmx.router)
     app.include_router(import_pdf.router)
+    app.include_router(import_xml.router)
     app.include_router(admin.router)
     # Future routers (uncomment as implemented):
     # app.include_router(auth.router,       prefix="/api/v1/auth",       tags=["auth"])

--- a/app/routers/import_xml.py
+++ b/app/routers/import_xml.py
@@ -1,0 +1,78 @@
+"""Portfolio Performance XML import UI — upload and preview."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree.ElementTree import ParseError
+
+from fastapi import APIRouter, Request, UploadFile
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from app.services.portfolio_performance_importer import PortfolioPerformanceImporter
+
+router = APIRouter(prefix="/import", tags=["import"])
+
+_TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+
+_importer = PortfolioPerformanceImporter()
+
+
+def _render(request: Request, name: str, context: dict) -> HTMLResponse:  # type: ignore[type-arg]
+    context["request"] = request
+    return templates.TemplateResponse(request=request, name=name, context=context)
+
+
+@router.get("/xml", response_class=HTMLResponse)
+async def import_xml_page(request: Request) -> HTMLResponse:
+    """Render the XML upload form."""
+    return _render(request, "import_xml.html", {"step": "upload"})
+
+
+@router.post("/xml", response_class=HTMLResponse)
+async def import_xml_preview(
+    request: Request,
+    file: UploadFile,
+) -> HTMLResponse:
+    """Accept a Portfolio Performance XML (or zip) and show a preview."""
+    filename = (file.filename or "").lower()
+    if not (filename.endswith(".xml") or filename.endswith(".zip")):
+        return _render(
+            request,
+            "import_xml.html",
+            {"step": "upload", "error": "Please upload a .xml or .zip file."},
+        )
+
+    contents = await file.read()
+    if not contents:
+        return _render(
+            request,
+            "import_xml.html",
+            {"step": "upload", "error": "The uploaded file is empty."},
+        )
+
+    try:
+        result = _importer.parse_bytes(contents)
+    except ParseError as exc:
+        return _render(
+            request,
+            "import_xml.html",
+            {"step": "upload", "error": f"Invalid XML: {exc}"},
+        )
+    except ValueError as exc:
+        return _render(
+            request,
+            "import_xml.html",
+            {"step": "upload", "error": str(exc)},
+        )
+
+    return _render(
+        request,
+        "import_xml.html",
+        {
+            "step": "preview",
+            "result": result,
+            "filename": file.filename,
+        },
+    )

--- a/app/services/portfolio_performance_importer.py
+++ b/app/services/portfolio_performance_importer.py
@@ -1,0 +1,430 @@
+"""Portfolio Performance XML file parser.
+
+Parses the XStream-serialised XML produced by Portfolio Performance and
+returns a structured preview of the contained transactions.  The parser
+does not touch the database — it is a pure extraction layer that the
+import router uses to drive the preview UI.
+
+XML structure is documented in issue #82.
+"""
+
+from __future__ import annotations
+
+import io
+import xml.etree.ElementTree as ET
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Data classes used by the preview layer
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class SecurityInfo:
+    uuid: str
+    name: str | None = None
+    isin: str | None = None
+    ticker: str | None = None
+    currency: str | None = None
+
+    @property
+    def display(self) -> str:
+        parts = [p for p in (self.name, self.ticker, self.isin) if p]
+        return " · ".join(parts) if parts else self.uuid
+
+
+@dataclass(slots=True)
+class Unit:
+    type: str  # FEE | TAX | GROSS_VALUE
+    amount: Decimal
+    currency: str
+
+
+@dataclass(slots=True)
+class ParsedTransaction:
+    kind: Literal["portfolio", "account"]
+    uuid: str
+    date: datetime
+    type: str
+    amount: Decimal
+    currency: str
+    shares: Decimal
+    note: str | None
+    security: SecurityInfo | None
+    units: list[Unit] = field(default_factory=list)
+
+    @property
+    def fees(self) -> Decimal:
+        return sum((u.amount for u in self.units if u.type == "FEE"), Decimal("0"))
+
+    @property
+    def taxes(self) -> Decimal:
+        return sum((u.amount for u in self.units if u.type == "TAX"), Decimal("0"))
+
+
+@dataclass(slots=True)
+class TypeBreakdown:
+    type: str
+    count: int
+
+
+@dataclass(slots=True)
+class ParseResult:
+    version: str | None
+    base_currency: str | None
+    transactions: list[ParsedTransaction]
+    securities: dict[str, SecurityInfo]
+    warnings: list[str] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Convenience summaries used by the preview template
+    # ------------------------------------------------------------------
+    @property
+    def total_count(self) -> int:
+        return len(self.transactions)
+
+    @property
+    def type_breakdown(self) -> list[TypeBreakdown]:
+        counts: dict[str, int] = {}
+        for t in self.transactions:
+            counts[t.type] = counts.get(t.type, 0) + 1
+        return [
+            TypeBreakdown(type=k, count=v)
+            for k, v in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+        ]
+
+    @property
+    def date_range(self) -> tuple[datetime, datetime] | None:
+        if not self.transactions:
+            return None
+        dates = [t.date for t in self.transactions]
+        return min(dates), max(dates)
+
+    @property
+    def unique_securities(self) -> list[SecurityInfo]:
+        seen: dict[str, SecurityInfo] = {}
+        for t in self.transactions:
+            if t.security and t.security.uuid not in seen:
+                seen[t.security.uuid] = t.security
+        return list(seen.values())
+
+
+# ---------------------------------------------------------------------------
+# Parser implementation
+# ---------------------------------------------------------------------------
+
+_MILLIONTHS = Decimal(1_000_000)
+
+
+class PortfolioPerformanceImporter:
+    """Parses Portfolio Performance XML (optionally inside a zip).
+
+    The importer follows the ``XPATH_RELATIVE_REFERENCES`` convention used
+    by Portfolio Performance.  ``<security reference="../../../securities/security"/>``
+    means: walk up the given number of path segments from the current
+    element, then descend into the remaining segments.  We also honour
+    positional indices such as ``security[2]`` (1-based).
+    """
+
+    def parse_bytes(self, data: bytes) -> ParseResult:
+        xml_bytes = self._maybe_unzip(data)
+        root = ET.fromstring(xml_bytes)
+        return self._parse_root(root)
+
+    def parse_file(self, path: Path) -> ParseResult:
+        return self.parse_bytes(path.read_bytes())
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _maybe_unzip(data: bytes) -> bytes:
+        if data[:2] == b"PK":
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                xml_names = [n for n in zf.namelist() if n.lower().endswith(".xml")]
+                if not xml_names:
+                    raise ValueError("Zip archive does not contain an XML file.")
+                with zf.open(xml_names[0]) as fh:
+                    return fh.read()
+        return data
+
+    def _parse_root(self, root: ET.Element) -> ParseResult:
+        version = _text(root.find("version"))
+        base_currency = _text(root.find("baseCurrency"))
+
+        securities = self._collect_securities(root)
+        warnings: list[str] = []
+
+        transactions: list[ParsedTransaction] = []
+        transactions.extend(
+            self._extract_portfolio_transactions(root, securities, warnings)
+        )
+        transactions.extend(
+            self._extract_account_transactions(root, securities, warnings)
+        )
+        transactions.sort(key=lambda t: t.date)
+
+        return ParseResult(
+            version=version,
+            base_currency=base_currency,
+            transactions=transactions,
+            securities=securities,
+            warnings=warnings,
+        )
+
+    # -- securities -----------------------------------------------------
+
+    def _collect_securities(self, root: ET.Element) -> dict[str, SecurityInfo]:
+        securities: dict[str, SecurityInfo] = {}
+        sec_container = root.find("securities")
+        if sec_container is None:
+            return securities
+        for sec in sec_container.findall("security"):
+            uuid = _text(sec.find("uuid"))
+            if not uuid:
+                continue
+            securities[uuid] = SecurityInfo(
+                uuid=uuid,
+                name=_text(sec.find("name")),
+                isin=_text(sec.find("isin")),
+                ticker=_text(sec.find("tickerSymbol")),
+                currency=_text(sec.find("currencyCode")),
+            )
+        return securities
+
+    # -- transaction extraction ----------------------------------------
+
+    def _extract_portfolio_transactions(
+        self,
+        root: ET.Element,
+        securities: dict[str, SecurityInfo],
+        warnings: list[str],
+    ) -> list[ParsedTransaction]:
+        out: list[ParsedTransaction] = []
+        portfolios = root.find("portfolios")
+        if portfolios is None:
+            return out
+
+        for p_idx, portfolio in enumerate(portfolios.findall("portfolio"), start=1):
+            transactions_el = portfolio.find("transactions")
+            if transactions_el is None:
+                continue
+            for t_idx, tx_el in enumerate(
+                transactions_el.findall("portfolio-transaction"), start=1
+            ):
+                path = _build_path(
+                    ["portfolios", f"portfolio[{p_idx}]", "transactions",
+                     f"portfolio-transaction[{t_idx}]"]
+                )
+                parsed = self._parse_transaction(
+                    tx_el, root, path, "portfolio", securities, warnings
+                )
+                if parsed:
+                    out.append(parsed)
+        return out
+
+    def _extract_account_transactions(
+        self,
+        root: ET.Element,
+        securities: dict[str, SecurityInfo],
+        warnings: list[str],
+    ) -> list[ParsedTransaction]:
+        out: list[ParsedTransaction] = []
+        accounts = root.find("accounts")
+        if accounts is None:
+            return out
+
+        for a_idx, account in enumerate(accounts.findall("account"), start=1):
+            transactions_el = account.find("transactions")
+            if transactions_el is None:
+                continue
+            for t_idx, tx_el in enumerate(
+                transactions_el.findall("account-transaction"), start=1
+            ):
+                path = _build_path(
+                    ["accounts", f"account[{a_idx}]", "transactions",
+                     f"account-transaction[{t_idx}]"]
+                )
+                parsed = self._parse_transaction(
+                    tx_el, root, path, "account", securities, warnings
+                )
+                if parsed:
+                    out.append(parsed)
+        return out
+
+    def _parse_transaction(
+        self,
+        tx_el: ET.Element,
+        root: ET.Element,
+        tx_path: list[str],
+        kind: Literal["portfolio", "account"],
+        securities: dict[str, SecurityInfo],
+        warnings: list[str],
+    ) -> ParsedTransaction | None:
+        uuid = _text(tx_el.find("uuid")) or ""
+        date_str = _text(tx_el.find("date"))
+        tx_type = _text(tx_el.find("type")) or "UNKNOWN"
+
+        if not date_str:
+            warnings.append(f"Skipped transaction {uuid or '?'} — missing date.")
+            return None
+
+        try:
+            date = datetime.fromisoformat(date_str)
+        except ValueError:
+            warnings.append(
+                f"Skipped transaction {uuid or '?'} — invalid date {date_str!r}."
+            )
+            return None
+
+        amount = _decode_millionths(_text(tx_el.find("amount")))
+        shares = _decode_millionths(_text(tx_el.find("shares")))
+        currency = _text(tx_el.find("currencyCode")) or ""
+        note = _text(tx_el.find("note"))
+
+        security = self._resolve_security(
+            tx_el.find("security"), root, tx_path, securities, warnings
+        )
+
+        units = self._parse_units(tx_el.find("units"))
+
+        return ParsedTransaction(
+            kind=kind,
+            uuid=uuid,
+            date=date,
+            type=tx_type,
+            amount=amount,
+            currency=currency,
+            shares=shares,
+            note=note,
+            security=security,
+            units=units,
+        )
+
+    def _parse_units(self, units_el: ET.Element | None) -> list[Unit]:
+        if units_el is None:
+            return []
+        out: list[Unit] = []
+        for unit in units_el.findall("unit"):
+            utype = unit.get("type") or ""
+            amount_el = unit.find("amount")
+            if amount_el is None:
+                continue
+            raw = amount_el.get("amount") or _text(amount_el) or "0"
+            currency = amount_el.get("currency") or ""
+            out.append(
+                Unit(type=utype, amount=_decode_millionths(raw), currency=currency)
+            )
+        return out
+
+    def _resolve_security(
+        self,
+        sec_el: ET.Element | None,
+        root: ET.Element,
+        tx_path: list[str],
+        securities: dict[str, SecurityInfo],
+        warnings: list[str],
+    ) -> SecurityInfo | None:
+        if sec_el is None:
+            return None
+
+        # Direct UUID child — rare, but supported.
+        direct_uuid = _text(sec_el.find("uuid"))
+        if direct_uuid:
+            return securities.get(direct_uuid) or SecurityInfo(uuid=direct_uuid)
+
+        reference = sec_el.get("reference")
+        if not reference:
+            return None
+
+        # The reference is relative to the <security> element, which is a
+        # direct child of the transaction element.
+        target = _resolve_reference(root, [*tx_path, "security"], reference)
+        if target is None:
+            warnings.append(f"Could not resolve security reference {reference!r}.")
+            return None
+        uuid = _text(target.find("uuid"))
+        if not uuid:
+            return None
+        return securities.get(uuid) or SecurityInfo(uuid=uuid)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _text(element: ET.Element | None) -> str | None:
+    if element is None:
+        return None
+    return (element.text or "").strip() or None
+
+
+def _decode_millionths(raw: str | None) -> Decimal:
+    """Portfolio Performance stores numeric values as integers in millionths."""
+    if not raw:
+        return Decimal("0")
+    try:
+        return (Decimal(raw) / _MILLIONTHS).quantize(Decimal("0.000001"))
+    except Exception:
+        return Decimal("0")
+
+
+def _build_path(segments: list[str]) -> list[str]:
+    """Return the XPath-style segments that identify an element's location."""
+    return ["client", *segments]
+
+
+def _resolve_reference(
+    root: ET.Element, tx_path: list[str], reference: str
+) -> ET.Element | None:
+    """Resolve an XStream ``XPATH_RELATIVE_REFERENCES`` string.
+
+    ``reference`` is of the form ``../../../securities/security`` or
+    ``../../../securities/security[2]``.  We walk ``tx_path`` backwards for
+    every ``..`` segment, then descend into the remaining segments from the
+    resulting element.
+    """
+    parts = [p for p in reference.split("/") if p]
+    up = 0
+    while up < len(parts) and parts[up] == "..":
+        up += 1
+
+    remaining_path = tx_path[: len(tx_path) - up] if up else list(tx_path)
+    remaining_path.extend(parts[up:])
+
+    # The first segment is always "client" which is the root element itself.
+    if not remaining_path or remaining_path[0] != root.tag:
+        return None
+
+    current: ET.Element | None = root
+    for segment in remaining_path[1:]:
+        if current is None:
+            return None
+        name, index = _split_index(segment)
+        matches = current.findall(name)
+        if not matches:
+            return None
+        if index is None:
+            current = matches[0]
+        else:
+            if index < 1 or index > len(matches):
+                return None
+            current = matches[index - 1]
+    return current
+
+
+def _split_index(segment: str) -> tuple[str, int | None]:
+    if "[" in segment and segment.endswith("]"):
+        name, rest = segment.split("[", 1)
+        try:
+            return name, int(rest[:-1])
+        except ValueError:
+            return segment, None
+    return segment, None

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -443,6 +443,10 @@
     <a href="/" class="nav-logo">Terminal Ledger</a>
     <span class="nav-sep">/</span>
     <a href="/" class="nav-link">Portfolio</a>
+    <span class="nav-sep">/</span>
+    <a href="/import/pdf" class="nav-link">Import PDF</a>
+    <span class="nav-sep">/</span>
+    <a href="/import/xml" class="nav-link">Import XML</a>
   </nav>
   <main class="page">
     {% block content %}{% endblock %}

--- a/app/templates/import_xml.html
+++ b/app/templates/import_xml.html
@@ -1,0 +1,171 @@
+{% extends "base.html" %}
+
+{% block title %}Import Portfolio Performance XML{% endblock %}
+
+{% block content %}
+  <p style="margin-bottom: 0.75rem;"><a href="/">&larr; Back to portfolio</a></p>
+  <h1>Import Portfolio Performance XML</h1>
+
+  <div class="step-indicator">
+    <span class="step-item {{ 'active' if step == 'upload' else 'completed' }}">
+      <span class="step-num">1</span> Upload
+    </span>
+    <span class="step-arrow">&rarr;</span>
+    <span class="step-item {{ 'active' if step == 'preview' else '' }}">
+      <span class="step-num">2</span> Preview
+    </span>
+  </div>
+
+  {% if step == "upload" %}
+  <div class="card">
+    <h2>Upload Portfolio Performance file</h2>
+    {% if error %}
+    <div class="error">{{ error }}</div>
+    {% endif %}
+    <p class="note">
+      Upload a Portfolio Performance XML export (<code>.xml</code>) or a zip
+      archive containing one. The preview will show all detected transactions
+      without modifying your portfolio.
+    </p>
+    <form method="post" action="/import/xml" enctype="multipart/form-data">
+      <div class="drop-zone" id="drop-zone">
+        <svg class="drop-zone-icon" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+          <polyline points="14 2 14 8 20 8"/>
+          <line x1="12" y1="18" x2="12" y2="12"/>
+          <polyline points="9 15 12 12 15 15"/>
+        </svg>
+        <p class="drop-zone-text">Drag &amp; drop your XML or zip here or <strong>click to browse</strong></p>
+        <span class="file-badge">.XML / .ZIP</span>
+        <input type="file" id="file" name="file" accept=".xml,.zip" required>
+        <p class="selected-file" id="selected-file"></p>
+      </div>
+      <button type="submit" class="btn-primary">Upload &amp; Preview</button>
+    </form>
+  </div>
+
+  {% elif step == "preview" %}
+  <div class="summary-card anim-fade-slide-down">
+    <h2>File summary</h2>
+    <div class="summary-grid">
+      <div class="summary-item">
+        <span class="summary-label">File</span>
+        <span class="summary-value" style="font-size: 0.9rem; word-break: break-all;">{{ filename or "—" }}</span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Version</span>
+        <span class="summary-value">{{ result.version or "—" }}</span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Base currency</span>
+        <span class="summary-value">{{ result.base_currency or "—" }}</span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Securities</span>
+        <span class="summary-value">{{ result.unique_securities | length }}</span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Transactions</span>
+        <span class="summary-value">{{ result.total_count }}</span>
+      </div>
+      {% if result.date_range %}
+      <div class="summary-item">
+        <span class="summary-label">Date range</span>
+        <span class="summary-value" style="font-size: 0.9rem;">
+          {{ result.date_range[0].strftime("%Y-%m-%d") }} &rarr; {{ result.date_range[1].strftime("%Y-%m-%d") }}
+        </span>
+      </div>
+      {% endif %}
+    </div>
+
+    {% if result.type_breakdown %}
+    <div style="margin-top: 1.25rem; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+      {% for bucket in result.type_breakdown %}
+      <span class="file-badge">{{ bucket.type }} &middot; {{ bucket.count }}</span>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+
+  {% if result.warnings %}
+  <div class="card anim-fade-slide-down" style="border-color: var(--danger);">
+    <h2 style="color: var(--danger);">Warnings</h2>
+    <ul style="margin-left: 1.2rem; color: var(--muted); font-size: 0.85rem;">
+      {% for w in result.warnings %}
+      <li>{{ w }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+
+  <div class="card anim-fade-slide-up">
+    <h2>Transactions ({{ result.total_count }})</h2>
+    {% if result.transactions %}
+    <div style="overflow-x: auto;">
+      <table class="table-striped">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Type</th>
+            <th>Security</th>
+            <th class="number">Shares</th>
+            <th class="number">Amount</th>
+            <th>Currency</th>
+            <th class="number">Fees</th>
+            <th class="number">Taxes</th>
+            <th>Note</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for tx in result.transactions %}
+          <tr>
+            <td class="text-mono">{{ tx.date.strftime("%Y-%m-%d") }}</td>
+            <td class="text-mono">{{ tx.type }}</td>
+            <td>{{ tx.security.display if tx.security else "—" }}</td>
+            <td class="number">{{ "%.4f"|format(tx.shares) if tx.shares else "—" }}</td>
+            <td class="number">{{ "%.2f"|format(tx.amount) }}</td>
+            <td class="text-mono">{{ tx.currency }}</td>
+            <td class="number">{% if tx.fees %}{{ "%.2f"|format(tx.fees) }}{% else %}<span class="na">—</span>{% endif %}</td>
+            <td class="number">{% if tx.taxes %}{{ "%.2f"|format(tx.taxes) }}{% else %}<span class="na">—</span>{% endif %}</td>
+            <td style="color: var(--muted); font-size: 0.85rem;">{{ tx.note or "" }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <p class="note">No transactions were found in the uploaded file.</p>
+    {% endif %}
+
+    <div class="actions" style="margin-top: 1.25rem;">
+      <a href="/import/xml"><button type="button" class="btn-ghost">Upload another file</button></a>
+      <a href="/"><button type="button" class="btn-primary">Back to portfolio</button></a>
+    </div>
+  </div>
+  {% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+  (function () {
+    var zone = document.getElementById("drop-zone");
+    if (!zone) return;
+    var input = zone.querySelector('input[type="file"]');
+    var label = document.getElementById("selected-file");
+
+    zone.addEventListener("dragover", function (e) { e.preventDefault(); zone.classList.add("dragover"); });
+    zone.addEventListener("dragleave", function () { zone.classList.remove("dragover"); });
+    zone.addEventListener("drop", function (e) {
+      e.preventDefault();
+      zone.classList.remove("dragover");
+      if (e.dataTransfer.files.length) {
+        input.files = e.dataTransfer.files;
+        label.textContent = e.dataTransfer.files[0].name;
+      }
+    });
+    input.addEventListener("change", function () {
+      label.textContent = input.files.length ? input.files[0].name : "";
+    });
+  })();
+</script>
+{% endblock %}

--- a/tests/test_portfolio_performance_importer.py
+++ b/tests/test_portfolio_performance_importer.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import io
 import zipfile
 from decimal import Decimal
-from pathlib import Path
 
 import pytest
 from httpx import AsyncClient

--- a/tests/test_portfolio_performance_importer.py
+++ b/tests/test_portfolio_performance_importer.py
@@ -1,0 +1,219 @@
+"""Tests for the Portfolio Performance XML importer/parser."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+
+from app.services.portfolio_performance_importer import PortfolioPerformanceImporter
+
+SAMPLE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<client>
+  <version>69</version>
+  <baseCurrency>EUR</baseCurrency>
+  <securities>
+    <security>
+      <uuid>2bab2728-f3b2-4ca0-8330-825446831ade</uuid>
+      <name>Commerzbank AG</name>
+      <currencyCode>EUR</currencyCode>
+      <isin>DE000CBK1001</isin>
+      <tickerSymbol>CBK.DE</tickerSymbol>
+    </security>
+    <security>
+      <uuid>11111111-2222-3333-4444-555555555555</uuid>
+      <name>SAP SE</name>
+      <currencyCode>EUR</currencyCode>
+      <isin>DE0007164600</isin>
+      <tickerSymbol>SAP.DE</tickerSymbol>
+    </security>
+  </securities>
+  <accounts>
+    <account>
+      <uuid>6908edd0-1bb5-411e-bb4d-678a858eff66</uuid>
+      <name>Cash Account</name>
+      <currencyCode>EUR</currencyCode>
+      <transactions>
+        <account-transaction>
+          <uuid>11d2ebf5-a0c5-4de1-b2f6-19a0a701e1f6</uuid>
+          <date>2019-05-27T00:00</date>
+          <currencyCode>EUR</currencyCode>
+          <amount>1007</amount>
+          <security reference="../../../../../securities/security"/>
+          <shares>7000000000</shares>
+          <note>Dividend Payment</note>
+          <units>
+            <unit type="TAX">
+              <amount currency="EUR" amount="393"/>
+            </unit>
+          </units>
+          <type>DIVIDENDS</type>
+        </account-transaction>
+      </transactions>
+    </account>
+  </accounts>
+  <portfolios>
+    <portfolio>
+      <uuid>404c0fbf-68ab-4925-bdcb-9838e2380317</uuid>
+      <name>My Portfolio</name>
+      <transactions>
+        <portfolio-transaction>
+          <uuid>f73225c5-c9ee-4f3a-8b83-c1e883f2b437</uuid>
+          <date>2021-08-02T00:00</date>
+          <currencyCode>EUR</currencyCode>
+          <amount>10000</amount>
+          <security reference="../../../../../securities/security"/>
+          <shares>9000000</shares>
+          <note>Purchase via Sparplan</note>
+          <units>
+            <unit type="FEE">
+              <amount currency="EUR" amount="1000"/>
+            </unit>
+            <unit type="TAX">
+              <amount currency="EUR" amount="100"/>
+            </unit>
+          </units>
+          <type>BUY</type>
+        </portfolio-transaction>
+        <portfolio-transaction>
+          <uuid>abcdef01-0000-0000-0000-000000000001</uuid>
+          <date>2022-03-10T00:00</date>
+          <currencyCode>EUR</currencyCode>
+          <amount>5000000</amount>
+          <security reference="../../../../../securities/security[2]"/>
+          <shares>3000000</shares>
+          <type>SELL</type>
+        </portfolio-transaction>
+      </transactions>
+    </portfolio>
+  </portfolios>
+</client>
+"""
+
+
+def _parse(xml: str = SAMPLE_XML):
+    return PortfolioPerformanceImporter().parse_bytes(xml.encode("utf-8"))
+
+
+def test_parser_extracts_basic_metadata() -> None:
+    result = _parse()
+
+    assert result.version == "69"
+    assert result.base_currency == "EUR"
+    assert len(result.securities) == 2
+
+
+def test_parser_decodes_millionth_values() -> None:
+    result = _parse()
+
+    portfolio_tx = next(t for t in result.transactions if t.type == "BUY")
+    # shares: 9_000_000 / 1_000_000 = 9
+    assert portfolio_tx.shares == Decimal("9.000000")
+    # amount: 10_000 / 1_000_000 = 0.01
+    assert portfolio_tx.amount == Decimal("0.010000")
+
+
+def test_parser_resolves_security_references() -> None:
+    result = _parse()
+
+    buy = next(t for t in result.transactions if t.type == "BUY")
+    sell = next(t for t in result.transactions if t.type == "SELL")
+
+    assert buy.security is not None
+    assert buy.security.ticker == "CBK.DE"
+    assert sell.security is not None
+    assert sell.security.ticker == "SAP.DE"
+
+
+def test_parser_extracts_units_fees_and_taxes() -> None:
+    result = _parse()
+
+    buy = next(t for t in result.transactions if t.type == "BUY")
+    assert buy.fees == Decimal("0.001000")
+    assert buy.taxes == Decimal("0.000100")
+
+
+def test_parser_includes_portfolio_and_account_transactions() -> None:
+    result = _parse()
+
+    kinds = {t.kind for t in result.transactions}
+    assert kinds == {"portfolio", "account"}
+
+    div = next(t for t in result.transactions if t.type == "DIVIDENDS")
+    assert div.kind == "account"
+    assert div.security is not None
+    assert div.security.ticker == "CBK.DE"
+
+
+def test_parser_sorts_transactions_by_date() -> None:
+    result = _parse()
+    dates = [t.date for t in result.transactions]
+    assert dates == sorted(dates)
+
+
+def test_parser_handles_zip_archive() -> None:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("client.xml", SAMPLE_XML)
+
+    result = PortfolioPerformanceImporter().parse_bytes(buf.getvalue())
+    assert result.total_count == 3
+
+
+def test_parser_summary_helpers() -> None:
+    result = _parse()
+
+    breakdown = {b.type: b.count for b in result.type_breakdown}
+    assert breakdown == {"BUY": 1, "SELL": 1, "DIVIDENDS": 1}
+    assert result.total_count == 3
+    assert len(result.unique_securities) == 2
+
+
+# ---------------------------------------------------------------------------
+# Router integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_xml_get_renders_upload_form(client: AsyncClient) -> None:
+    response = await client.get("/import/xml")
+    assert response.status_code == 200
+    assert "Upload Portfolio Performance file" in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_xml_post_rejects_non_xml(client: AsyncClient) -> None:
+    response = await client.post(
+        "/import/xml",
+        files={"file": ("report.txt", b"hello", "text/plain")},
+    )
+    assert response.status_code == 200
+    assert ".xml or .zip" in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_xml_post_rejects_invalid_xml(client: AsyncClient) -> None:
+    response = await client.post(
+        "/import/xml",
+        files={"file": ("bad.xml", b"<not-xml", "application/xml")},
+    )
+    assert response.status_code == 200
+    assert "Invalid XML" in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_xml_post_shows_preview(client: AsyncClient) -> None:
+    response = await client.post(
+        "/import/xml",
+        files={"file": ("portfolio.xml", SAMPLE_XML.encode("utf-8"), "application/xml")},
+    )
+    assert response.status_code == 200
+    assert "File summary" in response.text
+    assert "CBK.DE" in response.text
+    assert "SAP.DE" in response.text
+    assert "DIVIDENDS" in response.text
+    assert "BUY" in response.text


### PR DESCRIPTION
## Summary
- New `/import/xml` page: upload a Portfolio Performance `.xml` (or `.zip` containing one) and see a read-only preview — no database writes yet.
- `PortfolioPerformanceImporter` service parses the XStream XML, resolves relative `<security reference="…"/>` paths (including positional `[n]` indices), decodes millionth-encoded `amount`/`shares`/unit values, and aggregates `FEE` / `TAX` units.
- Preview template shows a summary card (version, base currency, securities count, transaction count, date range, per-type breakdown) plus a full transaction table (date, type, security, shares, amount, currency, fees, taxes, note).
- Nav in `base.html` now links both import flows (`Import PDF`, `Import XML`).

## Addresses
- #82 — XML format documentation used as spec
- #83 — XML import parser logic
- #84 — Preview UI before import

## Test plan
- [x] `GET /import/xml` renders upload form
- [x] Unsupported file extension → error message
- [x] Malformed XML → error message
- [x] Sample XML upload → preview renders with BUY / SELL / DIVIDENDS, both securities (`CBK.DE` via `security`, `SAP.DE` via `security[2]`), fees/taxes
- [x] Zip archive containing XML → preview renders
- [x] Added unit + router tests in `tests/test_portfolio_performance_importer.py`

Follow-up (out of scope for this PR): wiring the preview into an actual import (select/filter + DB write), per issue #84's confirmation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)