### PR TITLE
fix: find BUY/SELL transactions nested inside XStream crossEntry elements

### DIFF
--- a/app/services/portfolio_performance_importer.py
+++ b/app/services/portfolio_performance_importer.py
@@ -161,13 +161,7 @@ class PortfolioPerformanceImporter:
         securities = self._collect_securities(root)
         warnings: list[str] = []
 
-        transactions: list[ParsedTransaction] = []
-        transactions.extend(
-            self._extract_portfolio_transactions(root, securities, warnings)
-        )
-        transactions.extend(
-            self._extract_account_transactions(root, securities, warnings)
-        )
+        transactions = self._extract_all_transactions(root, securities, warnings)
         transactions.sort(key=lambda t: t.date)
 
         return ParseResult(
@@ -200,62 +194,65 @@ class PortfolioPerformanceImporter:
 
     # -- transaction extraction ----------------------------------------
 
-    def _extract_portfolio_transactions(
+    def _extract_all_transactions(
         self,
         root: ET.Element,
         securities: dict[str, SecurityInfo],
         warnings: list[str],
     ) -> list[ParsedTransaction]:
-        out: list[ParsedTransaction] = []
-        portfolios = root.find("portfolios")
-        if portfolios is None:
-            return out
+        """Recursively find every transaction element in the document.
 
-        for p_idx, portfolio in enumerate(portfolios.findall("portfolio"), start=1):
-            transactions_el = portfolio.find("transactions")
-            if transactions_el is None:
-                continue
-            for t_idx, tx_el in enumerate(
-                transactions_el.findall("portfolio-transaction"), start=1
-            ):
-                path = _build_path(
-                    ["portfolios", f"portfolio[{p_idx}]", "transactions",
-                     f"portfolio-transaction[{t_idx}]"]
+        Portfolio Performance serialises accounts before portfolios in the XML.
+        The first BUY/SELL account-transaction triggers inline serialisation of
+        the entire linked Portfolio (with all its portfolio-transactions) inside
+        the <crossEntry> element.  Subsequent references to those objects are
+        written as <... reference="..."/> stubs with no content.
+
+        Walking just `portfolios/portfolio/transactions` therefore misses every
+        BUY/SELL portfolio-transaction.  Instead we iterate the full element
+        tree and skip back-reference stubs (elements that carry a ``reference``
+        attribute but no UUID child).
+        """
+        # Build parent map once so we can reconstruct each element's XPath.
+        parent_map: dict[ET.Element, ET.Element] = {
+            child: parent for parent in root.iter() for child in parent
+        }
+
+        def compute_path(element: ET.Element) -> list[str]:
+            segments: list[str] = []
+            current = element
+            while current in parent_map:
+                p = parent_map[current]
+                same_tag = [c for c in p if c.tag == current.tag]
+                idx = same_tag.index(current) + 1
+                segments.append(
+                    f"{current.tag}[{idx}]" if len(same_tag) > 1 else current.tag
                 )
+                current = p
+            segments.append(root.tag)
+            return list(reversed(segments))
+
+        out: list[ParsedTransaction] = []
+        seen: set[str] = set()
+
+        for tag, kind in (
+            ("portfolio-transaction", "portfolio"),
+            ("account-transaction", "account"),
+        ):
+            for tx_el in root.iter(tag):
+                if tx_el.get("reference"):
+                    continue  # back-reference stub — actual data is elsewhere
+                uuid = _text(tx_el.find("uuid")) or ""
+                if uuid in seen:
+                    continue
+                seen.add(uuid)
+                path = compute_path(tx_el)
                 parsed = self._parse_transaction(
-                    tx_el, root, path, "portfolio", securities, warnings
+                    tx_el, root, path, kind, securities, warnings  # type: ignore[arg-type]
                 )
                 if parsed:
                     out.append(parsed)
-        return out
 
-    def _extract_account_transactions(
-        self,
-        root: ET.Element,
-        securities: dict[str, SecurityInfo],
-        warnings: list[str],
-    ) -> list[ParsedTransaction]:
-        out: list[ParsedTransaction] = []
-        accounts = root.find("accounts")
-        if accounts is None:
-            return out
-
-        for a_idx, account in enumerate(accounts.findall("account"), start=1):
-            transactions_el = account.find("transactions")
-            if transactions_el is None:
-                continue
-            for t_idx, tx_el in enumerate(
-                transactions_el.findall("account-transaction"), start=1
-            ):
-                path = _build_path(
-                    ["accounts", f"account[{a_idx}]", "transactions",
-                     f"account-transaction[{t_idx}]"]
-                )
-                parsed = self._parse_transaction(
-                    tx_el, root, path, "account", securities, warnings
-                )
-                if parsed:
-                    out.append(parsed)
         return out
 
     def _parse_transaction(
@@ -268,8 +265,17 @@ class PortfolioPerformanceImporter:
         warnings: list[str],
     ) -> ParsedTransaction | None:
         uuid = _text(tx_el.find("uuid")) or ""
-        date_str = _text(tx_el.find("date"))
         tx_type = _text(tx_el.find("type")) or "UNKNOWN"
+
+        date_el = tx_el.find("date")
+        date_ref = date_el.get("reference") if date_el is not None else None
+        if date_ref:
+            # XStream may serialise a shared LocalDateTime object by reference
+            # (e.g. portfolio-transaction sharing its paired account-transaction's date).
+            ref_target = _resolve_reference(root, [*tx_path, "date"], date_ref)
+            date_str = _text(ref_target) if ref_target is not None else None
+        else:
+            date_str = _text(date_el)
 
         if not date_str:
             warnings.append(f"Skipped transaction {uuid or '?'} — missing date.")
@@ -375,10 +381,6 @@ def _decode_millionths(raw: str | None) -> Decimal:
     except Exception:
         return Decimal("0")
 
-
-def _build_path(segments: list[str]) -> list[str]:
-    """Return the XPath-style segments that identify an element's location."""
-    return ["client", *segments]
 
 
 def _resolve_reference(

--- a/tests/test_portfolio_performance_importer.py
+++ b/tests/test_portfolio_performance_importer.py
@@ -204,6 +204,105 @@ async def test_import_xml_post_rejects_invalid_xml(client: AsyncClient) -> None:
     assert "Invalid XML" in response.text
 
 
+def test_parser_finds_transactions_nested_in_crossentry() -> None:
+    """BUY portfolio-transactions are serialised inside account crossEntry in real PP files."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<client>
+  <version>69</version>
+  <baseCurrency>EUR</baseCurrency>
+  <securities>
+    <security>
+      <uuid>sec-1</uuid>
+      <name>Commerzbank AG</name>
+      <currencyCode>EUR</currencyCode>
+      <tickerSymbol>CBK.DE</tickerSymbol>
+    </security>
+  </securities>
+  <accounts>
+    <account>
+      <uuid>acc-1</uuid>
+      <name>Cash</name>
+      <currencyCode>EUR</currencyCode>
+      <transactions>
+        <!-- First BUY account-transaction triggers inline portfolio serialisation -->
+        <account-transaction>
+          <uuid>acct-tx-1</uuid>
+          <date>2021-04-13T16:25</date>
+          <currencyCode>EUR</currencyCode>
+          <amount>244683</amount>
+          <security reference="../../../../../securities/security"/>
+          <shares>0</shares>
+          <crossEntry class="buysell">
+            <!-- Portfolio serialised INLINE here (first occurrence) -->
+            <portfolio>
+              <uuid>port-1</uuid>
+              <name>Comdirect</name>
+              <isRetired>false</isRetired>
+              <referenceAccount reference="../../../../.."/>
+              <transactions>
+                <!-- portfolio-transaction also serialised INLINE here -->
+                <portfolio-transaction>
+                  <uuid>port-tx-1</uuid>
+                  <date reference="../../../../../date"/>
+                  <currencyCode>EUR</currencyCode>
+                  <amount>244683</amount>
+                  <security reference="../../../../../../../../../securities/security"/>
+                  <shares>5000000</shares>
+                  <units>
+                    <unit type="FEE">
+                      <amount currency="EUR" amount="500"/>
+                    </unit>
+                  </units>
+                  <type>BUY</type>
+                </portfolio-transaction>
+              </transactions>
+            </portfolio>
+            <portfolioTransaction reference="../portfolio/transactions/portfolio-transaction"/>
+            <account reference="../../../../.."/>
+            <accountTransaction reference="../.."/>
+          </crossEntry>
+          <type>BUY</type>
+        </account-transaction>
+        <!-- DEPOSIT has no crossEntry — always at top level -->
+        <account-transaction>
+          <uuid>acct-tx-2</uuid>
+          <date>2021-01-01T00:00</date>
+          <currencyCode>EUR</currencyCode>
+          <amount>1000000000</amount>
+          <shares>0</shares>
+          <type>DEPOSIT</type>
+        </account-transaction>
+      </transactions>
+    </account>
+  </accounts>
+  <portfolios>
+    <!-- Portfolio already serialised above; only a back-reference here -->
+    <portfolio reference="../accounts/account/transactions/account-transaction/crossEntry/portfolio"/>
+  </portfolios>
+</client>"""
+
+    result = PortfolioPerformanceImporter().parse_bytes(xml.encode())
+
+    types = {t.type for t in result.transactions}
+    assert "BUY" in types, "BUY portfolio-transaction nested in crossEntry must be found"
+    assert "DEPOSIT" in types
+
+    buy_portfolio = next(t for t in result.transactions if t.type == "BUY" and t.kind == "portfolio")
+    assert buy_portfolio.shares == Decimal("5.000000")
+    assert buy_portfolio.fees == Decimal("0.000500")
+    assert buy_portfolio.security is not None
+    assert buy_portfolio.security.ticker == "CBK.DE"
+
+    # date was a reference — must be resolved to the account-transaction's date
+    from datetime import datetime
+    assert buy_portfolio.date == datetime(2021, 4, 13, 16, 25)
+
+    buy_account = next(t for t in result.transactions if t.type == "BUY" and t.kind == "account")
+    assert buy_account.uuid == "acct-tx-1"
+
+    assert result.total_count == 3  # port-tx-1 (BUY), acct-tx-1 (BUY), acct-tx-2 (DEPOSIT)
+
+
 @pytest.mark.asyncio
 async def test_import_xml_post_shows_preview(client: AsyncClient) -> None:
     response = await client.post(

--- a/tests/test_portfolio_performance_importer.py
+++ b/tests/test_portfolio_performance_importer.py
@@ -277,7 +277,8 @@ def test_parser_finds_transactions_nested_in_crossentry() -> None:
   </accounts>
   <portfolios>
     <!-- Portfolio already serialised above; only a back-reference here -->
-    <portfolio reference="../accounts/account/transactions/account-transaction/crossEntry/portfolio"/>
+    <portfolio
+      reference="../accounts/account/transactions/account-transaction/crossEntry/portfolio"/>
   </portfolios>
 </client>"""
 
@@ -287,7 +288,9 @@ def test_parser_finds_transactions_nested_in_crossentry() -> None:
     assert "BUY" in types, "BUY portfolio-transaction nested in crossEntry must be found"
     assert "DEPOSIT" in types
 
-    buy_portfolio = next(t for t in result.transactions if t.type == "BUY" and t.kind == "portfolio")
+    buy_portfolio = next(
+        t for t in result.transactions if t.type == "BUY" and t.kind == "portfolio"
+    )
     assert buy_portfolio.shares == Decimal("5.000000")
     assert buy_portfolio.fees == Decimal("0.000500")
     assert buy_portfolio.security is not None


### PR DESCRIPTION
## Summary

- **Root cause**: Portfolio Performance serialises `Client` fields in declaration order (`securities → accounts → portfolios`). The first BUY/SELL account-transaction triggers inline serialisation of the entire linked Portfolio (with all its portfolio-transactions) inside its `<crossEntry class="buysell">` element. The `<portfolios>` section ends up containing only `<portfolio reference="..."/>` stubs — so the old path-specific searches missed nearly all BUY/SELL portfolio-transactions and most cross-entry account-transactions.
- Replace `_extract_portfolio_transactions` + `_extract_account_transactions` with a single `_extract_all_transactions` that scans the full element tree via `root.iter()`, skips back-reference stubs (`reference` attribute present), and deduplicates by UUID. Each element's actual tree path is reconstructed via a parent map so relative security references resolve correctly regardless of nesting depth.
- Handle `<date reference="..."/>` elements: XStream emits these when a shared `LocalDateTime` instance is serialised by reference between a paired account- and portfolio-transaction. The reference is now resolved through the existing `_resolve_reference` helper instead of silently dropping the transaction.

## Test plan

- [x] All 12 existing tests continue to pass
- [x] New regression test `test_parser_finds_transactions_nested_in_crossentry` covers a realistic crossEntry XML structure with inline portfolio serialisation, back-reference stubs, and a date reference — confirming BUY portfolio-transactions, cross-entry account-transactions, and date resolution all work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)