### PR TITLE
feat: widen XML import preview and add type/search filters

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -96,6 +96,9 @@
       margin: 0 auto;
       padding: 2rem 1.5rem;
     }
+    .page--wide {
+      max-width: min(1400px, calc(100vw - 3rem));
+    }
 
     /* ── Tables ──────────────────────────────────────────────── */
     table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }
@@ -255,6 +258,24 @@
     /* ── Import page ─────────────────────────────────────────── */
     div.actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
     .note { color: var(--muted); font-size: 0.85rem; margin-bottom: 1rem; }
+
+    /* ── Filter bar (preview/list tables) ────────────────────── */
+    .filter-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+      margin-bottom: 1rem;
+    }
+    .filter-bar .filter-search { flex: 1 1 260px; min-width: 220px; }
+    .filter-bar .filter-type   { min-width: 180px; }
+    .filter-bar .filter-count  {
+      color: var(--muted);
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      margin-left: auto;
+    }
+    tr.is-hidden { display: none; }
 
     /* ── Step indicator ──────────────────────────────────────── */
     .step-indicator {
@@ -448,7 +469,7 @@
     <span class="nav-sep">/</span>
     <a href="/import/xml" class="nav-link">Import XML</a>
   </nav>
-  <main class="page">
+  <main class="{% block page_class %}page{% endblock %}">
     {% block content %}{% endblock %}
   </main>
   {% block extra_scripts %}{% endblock %}

--- a/app/templates/import_xml.html
+++ b/app/templates/import_xml.html
@@ -2,6 +2,8 @@
 
 {% block title %}Import Portfolio Performance XML{% endblock %}
 
+{% block page_class %}page{% if step == "preview" %} page--wide{% endif %}{% endblock %}
+
 {% block content %}
   <p style="margin-bottom: 0.75rem;"><a href="/">&larr; Back to portfolio</a></p>
   <h1>Import Portfolio Performance XML</h1>
@@ -101,8 +103,24 @@
   <div class="card anim-fade-slide-up">
     <h2>Transactions ({{ result.total_count }})</h2>
     {% if result.transactions %}
+    <div class="filter-bar">
+      <input
+        type="search"
+        class="filter-search"
+        id="tx-search"
+        placeholder="Search date, security, currency, note…"
+        autocomplete="off">
+      <select class="filter-type" id="tx-type-filter">
+        <option value="">All types</option>
+        {% for bucket in result.type_breakdown %}
+        <option value="{{ bucket.type }}">{{ bucket.type }} ({{ bucket.count }})</option>
+        {% endfor %}
+      </select>
+      <button type="button" class="btn-ghost" id="tx-filter-reset">Reset</button>
+      <span class="filter-count" id="tx-filter-count">{{ result.transactions | length }} of {{ result.transactions | length }}</span>
+    </div>
     <div style="overflow-x: auto;">
-      <table class="table-striped">
+      <table class="table-striped" id="tx-table">
         <thead>
           <tr>
             <th>Date</th>
@@ -118,7 +136,8 @@
         </thead>
         <tbody>
           {% for tx in result.transactions %}
-          <tr>
+          {% set search_blob %}{{ tx.date.strftime("%Y-%m-%d") }} {{ tx.type }} {{ tx.security.display if tx.security else "" }} {{ tx.currency }} {{ tx.note or "" }}{% endset %}
+          <tr data-type="{{ tx.type }}" data-search="{{ search_blob | lower }}">
             <td class="text-mono">{{ tx.date.strftime("%Y-%m-%d") }}</td>
             <td class="text-mono">{{ tx.type }}</td>
             <td>{{ tx.security.display if tx.security else "—" }}</td>
@@ -165,6 +184,40 @@
     });
     input.addEventListener("change", function () {
       label.textContent = input.files.length ? input.files[0].name : "";
+    });
+  })();
+
+  (function () {
+    var search = document.getElementById("tx-search");
+    if (!search) return;
+    var typeSel = document.getElementById("tx-type-filter");
+    var resetBtn = document.getElementById("tx-filter-reset");
+    var countEl = document.getElementById("tx-filter-count");
+    var rows = Array.prototype.slice.call(
+      document.querySelectorAll("#tx-table tbody tr")
+    );
+    var total = rows.length;
+
+    function apply() {
+      var q = search.value.trim().toLowerCase();
+      var t = typeSel.value;
+      var shown = 0;
+      rows.forEach(function (row) {
+        var matchType = !t || row.getAttribute("data-type") === t;
+        var matchText = !q || row.getAttribute("data-search").indexOf(q) !== -1;
+        var visible = matchType && matchText;
+        row.classList.toggle("is-hidden", !visible);
+        if (visible) shown++;
+      });
+      countEl.textContent = shown + " of " + total;
+    }
+
+    search.addEventListener("input", apply);
+    typeSel.addEventListener("change", apply);
+    resetBtn.addEventListener("click", function () {
+      search.value = "";
+      typeSel.value = "";
+      apply();
     });
   })();
 </script>


### PR DESCRIPTION
## Summary
- `/import/xml` preview opts into a new `.page--wide` container (1400px, `min(1400px, calc(100vw - 3rem))`) so all 9 transaction columns fit without horizontal scroll on a 27" screen. Upload step and all other pages keep the existing 960px width.
- New filter bar above the transactions table: type dropdown sourced from `result.type_breakdown`, full-text search over date / type / security / currency / note (pre-built lowercase `data-search` blob per row), reset button, and a live "X of Y" count.
- Filtering runs client-side — preview data is already in the DOM, so no HTMX round-trip / re-parse is needed. Filters combine as AND.

## Changes
- `app/templates/base.html`: add `{% block page_class %}` on `<main>`, `.page--wide` modifier, and `.filter-bar` styles.
- `app/templates/import_xml.html`: override `page_class` only for the preview step, insert filter bar, add `data-type` + `data-search` on each `<tr>`, and add a second IIFE that wires up input/change/reset handlers.

## Test plan
- [x] Existing importer tests pass (`13 passed`, including `test_import_xml_post_shows_preview`)
- [x] Docker build + smoke test: upload step renders at 960px, preview step renders at `page page--wide` with filter bar and per-row `data-type` / `data-search`
- [ ] Manual check on a 27" monitor: all 9 columns visible end-to-end, no horizontal scroll
- [ ] Manual filter/search interaction check in the browser (type select, search input, combined, reset)
- [ ] Regression check: Portfolio, Import PDF, and Stock detail pages still render at 960px

🤖 Generated with [Claude Code](https://claude.com/claude-code)