### PR TITLE
feat: add manual price/FX refresh button to portfolio

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -21,3 +21,24 @@ async def trigger_report() -> dict[str, str]:
 
     await run_monthly_report(_session_factory)
     return {"status": "ok", "message": "Monthly report job triggered."}
+
+
+@router.post("/refresh-prices", status_code=200)
+async def refresh_prices(response: Response) -> dict[str, str]:
+    """Manually trigger price cache and FX rate refresh.
+
+    Runs the same jobs that execute daily at 07:00 / 07:05. When called via
+    HTMX, responds with ``HX-Refresh: true`` so the client reloads the page
+    to show the updated values.
+    """
+    from app.database import _session_factory
+    from app.scheduler import run_fx_rate_refresh, run_price_cache_refresh
+
+    if _session_factory is None:
+        raise HTTPException(status_code=503, detail="Database not initialised.")
+
+    await run_price_cache_refresh(_session_factory)
+    await run_fx_rate_refresh(_session_factory)
+
+    response.headers["HX-Refresh"] = "true"
+    return {"status": "ok", "message": "Price cache and FX rates refreshed."}

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -69,6 +69,11 @@
     margin-bottom: 1.25rem;
   }
 
+  /* Refresh button loading state swap */
+  .htmx-indicator-show { display: none; }
+  .htmx-request .htmx-indicator-hide { display: none; }
+  .htmx-request .htmx-indicator-show { display: inline; }
+
   /* ── Form slot slide-down ────────────────────────────────────── */
   #add-form-slot {
     overflow: hidden;
@@ -232,6 +237,15 @@
 
   <!-- Action bar -->
   <div class="action-bar">
+    <button
+      class="btn-ghost"
+      hx-post="/admin/refresh-prices"
+      hx-swap="none"
+      hx-disabled-elt="this"
+      title="Fetch latest prices and FX rates now">
+      <span class="htmx-indicator-hide">&#x21bb; Refresh Prices</span>
+      <span class="htmx-indicator-show">Refreshing…</span>
+    </button>
     <button
       class="btn-primary"
       hx-get="/htmx/holdings/add-form"


### PR DESCRIPTION
## Summary
- Adds a **Refresh Prices** button to the portfolio action bar that fetches latest prices and FX rates on demand, instead of waiting for the daily 07:00 scheduler run.
- New `POST /admin/refresh-prices` endpoint runs the existing `run_price_cache_refresh` + `run_fx_rate_refresh` jobs against the module-level session factory, mirroring how `/admin/trigger-report` is wired.
- Response sets `HX-Refresh: true` so the portfolio page reloads automatically once yfinance finishes; while in flight the button disables itself and shows a "Refreshing…" label via a tiny HTMX indicator CSS swap.

## Test plan
- [x] Rebuild container via `docker compose up -d --build app`, app starts cleanly
- [x] `curl -X POST /admin/refresh-prices` returns `200` with `HX-Refresh: true` header
- [x] Portfolio page renders the new button
- [ ] Add a fresh holding in the UI, click **Refresh Prices**, confirm N/A value becomes populated after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)