### PR TITLE
feat: add cryptocurrency support to portfolio

### DIFF
--- a/alembic/versions/20260418_0000_e1c3a5b9f7d2_add_asset_type_to_stock.py
+++ b/alembic/versions/20260418_0000_e1c3a5b9f7d2_add_asset_type_to_stock.py
@@ -1,0 +1,38 @@
+"""add asset_type to stock
+
+Revision ID: e1c3a5b9f7d2
+Revises: d9b2f6a4e8c1
+Create Date: 2026-04-18 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e1c3a5b9f7d2"
+down_revision: str | None = "d9b2f6a4e8c1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "stock",
+        sa.Column(
+            "asset_type",
+            sa.String(length=16),
+            nullable=False,
+            server_default="STOCK",
+        ),
+        schema="finance",
+    )
+    op.alter_column("stock", "asset_type", server_default=None, schema="finance")
+
+
+def downgrade() -> None:
+    op.drop_column("stock", "asset_type", schema="finance")

--- a/app/models/stock.py
+++ b/app/models/stock.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
     from app.models.holding import Holding
 
 
+ASSET_TYPE_STOCK = "STOCK"
+ASSET_TYPE_CRYPTO = "CRYPTO"
+
+
 class Stock(Base):
     """Represents a tradeable stock/security."""
 
@@ -27,6 +31,9 @@ class Stock(Base):
     ticker: Mapped[str] = mapped_column(String(20), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     currency: Mapped[str] = mapped_column(String(10), nullable=False)
+    asset_type: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=ASSET_TYPE_STOCK
+    )
     current_price: Mapped[Decimal | None] = mapped_column(
         Numeric(precision=18, scale=4), nullable=True
     )

--- a/app/routers/htmx.py
+++ b/app/routers/htmx.py
@@ -15,10 +15,16 @@ from sqlalchemy.orm import selectinload
 from app.config import get_settings
 from app.database import get_async_session
 from app.models.holding import Holding
-from app.models.stock import Stock
+from app.models.stock import ASSET_TYPE_CRYPTO, ASSET_TYPE_STOCK, Stock
 from app.services.fx_service import to_eur
 from app.services.openfigi_lookup import resolve_wkn
 from app.services.stock_lookup import fetch_stock_info
+
+_SUPPORTED_QUOTES = ("EUR", "USD")
+
+
+def _build_crypto_ticker(symbol: str, quote: str) -> str:
+    return f"{symbol.strip().upper()}-{quote.strip().upper()}"
 
 router = APIRouter(prefix="/htmx", tags=["htmx"])
 
@@ -153,7 +159,28 @@ async def htmx_create_holding(
             },
         )
 
-    # Resolve or create the stock
+    return await _create_or_attach_holding(
+        request=request,
+        db=db,
+        ticker=ticker,
+        qty=qty,
+        asset_type=ASSET_TYPE_STOCK,
+        not_found_form="partials/add_holding_form.html",
+        not_found_context={"ticker": ticker, "quantity": quantity},
+    )
+
+
+async def _create_or_attach_holding(
+    *,
+    request: Request,
+    db: AsyncSession,
+    ticker: str,
+    qty: Decimal,
+    asset_type: str,
+    not_found_form: str,
+    not_found_context: dict[str, object],
+) -> HTMLResponse:
+    """Find or create a Stock, attach a Holding, and return the OOB row HTML."""
     result = await db.execute(select(Stock).where(Stock.ticker == ticker))
     stock = result.scalar_one_or_none()
 
@@ -162,13 +189,14 @@ async def htmx_create_holding(
         if info is None:
             return _render(
                 request,
-                "partials/add_holding_form.html",
-                {"error": f"Ticker '{ticker}' not found.", "ticker": ticker, "quantity": quantity},
+                not_found_form,
+                {"error": f"Ticker '{ticker}' not found.", **not_found_context},
             )
         stock = Stock(
             ticker=info.ticker,
             name=info.name,
             currency=info.currency,
+            asset_type=asset_type,
             current_price=info.current_price,
         )
         db.add(stock)
@@ -192,13 +220,13 @@ async def htmx_create_holding(
                 "id": holding.id,
                 "ticker": stock.ticker,
                 "name": stock.name,
+                "asset_type": stock.asset_type,
                 "quantity": qty,
                 "current_value": current_value,
             }
         },
     )
     row_html = bytes(row_resp.body).decode()
-    # OOB swap: append row to tbody with flash animation, clear form slot
     oob_attr = 'class="anim-flash" hx-swap-oob="beforeend:#holdings-tbody"'
     oob_html = (
         row_html.replace(
@@ -242,6 +270,7 @@ async def holding_row(
                 "id": holding.id,
                 "ticker": stock.ticker,
                 "name": stock.name,
+                "asset_type": stock.asset_type,
                 "quantity": holding.quantity,
                 "current_value": current_value,
             }
@@ -332,9 +361,121 @@ async def htmx_update_holding(
                 "id": holding.id,
                 "ticker": stock.ticker,
                 "name": stock.name,
+                "asset_type": stock.asset_type,
                 "quantity": qty,
                 "current_value": current_value,
             }
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Add crypto holding
+# ---------------------------------------------------------------------------
+
+
+@router.get("/validate-crypto", response_class=HTMLResponse)
+async def validate_crypto(
+    request: Request,
+    symbol: str = "",
+    quote: str = "EUR",
+    db: AsyncSession = _DB,
+) -> HTMLResponse:
+    """Return an inline validation hint for the crypto symbol field."""
+    symbol = symbol.strip().upper()
+    quote = quote.strip().upper() or "EUR"
+    if not symbol:
+        return HTMLResponse("")
+    if quote not in _SUPPORTED_QUOTES:
+        return _render(request, "partials/ticker_hint.html", {"valid": False, "name": None})
+
+    ticker = _build_crypto_ticker(symbol, quote)
+
+    result = await db.execute(select(Stock).where(Stock.ticker == ticker))
+    stock = result.scalar_one_or_none()
+    if stock:
+        return _render(request, "partials/ticker_hint.html", {"valid": True, "name": stock.name})
+
+    info = await fetch_stock_info(ticker)
+    if info:
+        return _render(request, "partials/ticker_hint.html", {"valid": True, "name": info.name})
+
+    return _render(request, "partials/ticker_hint.html", {"valid": False, "name": None})
+
+
+@router.get("/holdings/add-crypto-form", response_class=HTMLResponse)
+async def add_crypto_form(request: Request) -> HTMLResponse:
+    return _render(
+        request,
+        "partials/add_crypto_form.html",
+        {"supported_quotes": _SUPPORTED_QUOTES},
+    )
+
+
+@router.post("/crypto-holdings", response_class=HTMLResponse)
+async def htmx_create_crypto_holding(
+    request: Request,
+    symbol: str = Form(""),
+    quote: str = Form("EUR"),
+    quantity: str = Form(...),
+    db: AsyncSession = _DB,
+) -> HTMLResponse:
+    symbol = symbol.strip().upper()
+    quote = quote.strip().upper() or "EUR"
+
+    if not symbol:
+        return _render(
+            request,
+            "partials/add_crypto_form.html",
+            {
+                "error": "Please provide a crypto symbol (e.g. BTC).",
+                "quote": quote,
+                "quantity": quantity,
+                "supported_quotes": _SUPPORTED_QUOTES,
+            },
+        )
+    if quote not in _SUPPORTED_QUOTES:
+        return _render(
+            request,
+            "partials/add_crypto_form.html",
+            {
+                "error": f"Quote currency must be one of: {', '.join(_SUPPORTED_QUOTES)}.",
+                "symbol": symbol,
+                "quantity": quantity,
+                "supported_quotes": _SUPPORTED_QUOTES,
+            },
+        )
+
+    try:
+        qty = Decimal(quantity)
+        if qty <= 0:
+            raise ValueError
+    except (ValueError, Exception):
+        return _render(
+            request,
+            "partials/add_crypto_form.html",
+            {
+                "error": "Quantity must be a positive number.",
+                "symbol": symbol,
+                "quote": quote,
+                "quantity": quantity,
+                "supported_quotes": _SUPPORTED_QUOTES,
+            },
+        )
+
+    ticker = _build_crypto_ticker(symbol, quote)
+    return await _create_or_attach_holding(
+        request=request,
+        db=db,
+        ticker=ticker,
+        qty=qty,
+        asset_type=ASSET_TYPE_CRYPTO,
+        not_found_form="partials/add_crypto_form.html",
+        not_found_context={
+            "symbol": symbol,
+            "quote": quote,
+            "quantity": quantity,
+            "supported_quotes": _SUPPORTED_QUOTES,
         },
     )
 

--- a/app/schemas/holdings.py
+++ b/app/schemas/holdings.py
@@ -32,6 +32,7 @@ class HoldingSummaryItem(BaseModel):
     id: int
     ticker: str
     name: str
+    asset_type: str
     quantity: Decimal
     current_price: Decimal | None
     current_value: Decimal | None

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -64,6 +64,7 @@ class PortfolioService:
                     id=h.id,
                     ticker=h.stock.ticker,
                     name=h.stock.name,
+                    asset_type=h.stock.asset_type,
                     quantity=h.quantity,
                     current_price=eur_price,
                     current_value=current_value,

--- a/app/templates/partials/add_crypto_form.html
+++ b/app/templates/partials/add_crypto_form.html
@@ -1,0 +1,61 @@
+<div id="add-crypto-form" class="add-form-container">
+  <h2>Add Crypto</h2>
+  <form
+    hx-post="/htmx/crypto-holdings"
+    hx-target="#add-form-slot"
+    hx-swap="innerHTML">
+    {% if error %}
+    <div class="form-error">{{ error }}</div>
+    {% endif %}
+    <div class="form-row">
+      <label for="crypto-symbol">Symbol</label>
+      <div class="input-group">
+        <input
+          type="text"
+          id="crypto-symbol"
+          name="symbol"
+          value="{{ symbol or '' }}"
+          placeholder="e.g. BTC"
+          autocomplete="off"
+          class="input-mono input-glow"
+          hx-get="/htmx/validate-crypto"
+          hx-trigger="input changed delay:600ms, change from:#crypto-quote"
+          hx-include="[name='symbol'],[name='quote']"
+          hx-target="#crypto-hint"
+          hx-swap="innerHTML">
+        <span id="crypto-hint"></span>
+      </div>
+    </div>
+    <div class="form-row">
+      <label for="crypto-quote">Quote</label>
+      <select
+        id="crypto-quote"
+        name="quote"
+        class="input-mono input-glow">
+        {% for q in supported_quotes %}
+        <option value="{{ q }}" {% if quote == q %}selected{% endif %}>{{ q }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="form-row">
+      <label for="crypto-quantity">Quantity</label>
+      <input
+        type="number"
+        id="crypto-quantity"
+        name="quantity"
+        value="{{ quantity or '' }}"
+        min="0.00000001"
+        step="any"
+        placeholder="e.g. 0.05"
+        required
+        class="input-mono input-glow">
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="btn-primary">Add</button>
+      <button
+        type="button"
+        onclick="var s=document.getElementById('add-form-slot'); s.classList.remove('open'); setTimeout(function(){s.innerHTML='';},300)"
+        class="btn-ghost">Cancel</button>
+    </div>
+  </form>
+</div>

--- a/app/templates/partials/holding_row.html
+++ b/app/templates/partials/holding_row.html
@@ -2,6 +2,9 @@
   <td>
     <a href="/stocks/{{ holding.ticker }}" style="text-decoration: none;">
       <span class="holding-ticker">{{ holding.ticker }}</span>
+      {% if holding.asset_type == "CRYPTO" %}
+      <span class="asset-badge asset-badge-crypto">Crypto</span>
+      {% endif %}
       <span class="holding-name">{{ holding.name }}</span>
     </a>
   </td>

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -157,6 +157,23 @@
     font-weight: 400;
     margin-top: 0.1rem;
   }
+  .asset-badge {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+  }
+  .asset-badge-crypto {
+    background: rgba(247, 147, 26, 0.12);
+    color: #f7931a;
+    border: 1px solid rgba(247, 147, 26, 0.35);
+  }
   .holdings-table tfoot .total-row td {
     border-top: 2px solid var(--border);
     border-bottom: none;
@@ -254,6 +271,14 @@
       hx-on::after-swap="document.getElementById('add-form-slot').classList.add('open')">
       + Add Holding
     </button>
+    <button
+      class="btn-primary"
+      hx-get="/htmx/holdings/add-crypto-form"
+      hx-target="#add-form-slot"
+      hx-swap="innerHTML"
+      hx-on::after-swap="document.getElementById('add-form-slot').classList.add('open')">
+      + Add Crypto
+    </button>
     <a href="/import/pdf"><button class="btn-ghost">&#8593; Import PDF</button></a>
   </div>
 
@@ -290,6 +315,9 @@
         <td>
           <a href="/stocks/{{ row.ticker }}" style="text-decoration: none;">
             <span class="holding-ticker">{{ row.ticker }}</span>
+            {% if row.asset_type == "CRYPTO" %}
+            <span class="asset-badge asset-badge-crypto">Crypto</span>
+            {% endif %}
             <span class="holding-name">{{ row.name }}</span>
           </a>
         </td>

--- a/tests/test_htmx_crypto.py
+++ b/tests/test_htmx_crypto.py
@@ -1,0 +1,271 @@
+"""Tests for the HTMX crypto add flow — mock-based, no DB required."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.database import get_async_session
+from app.main import create_app
+from app.models.stock import ASSET_TYPE_CRYPTO, Stock
+from app.services.stock_lookup import StockInfo
+
+pytestmark = pytest.mark.asyncio
+
+
+_BTC_EUR = StockInfo(
+    ticker="BTC-EUR",
+    name="Bitcoin EUR",
+    currency="EUR",
+    current_price=Decimal("60000.00"),
+)
+
+
+def _settings() -> Settings:
+    return Settings(
+        app_env="development",
+        app_debug=False,
+        secret_key="test-secret-key-that-is-long-enough-32chars",
+        database_url="postgresql+asyncpg://unused/unused",
+    )
+
+
+def _mock_db(existing_stock: Stock | None = None) -> MagicMock:
+    """Build a mocked AsyncSession for the add-crypto code path."""
+    db = MagicMock()
+
+    stock_result = MagicMock()
+    stock_result.scalar_one_or_none.return_value = existing_stock
+
+    db.execute = AsyncMock(return_value=stock_result)
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock(side_effect=lambda obj: setattr(obj, "id", 42))
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+async def _client(db: MagicMock) -> AsyncClient:
+    """Build an AsyncClient that serves the app with a mocked DB dependency."""
+    app = create_app(settings=_settings())
+
+    async def _override() -> MagicMock:
+        return db
+
+    app.dependency_overrides[get_async_session] = _override
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def test_add_crypto_creates_stock_with_asset_type_crypto() -> None:
+    db = _mock_db(existing_stock=None)
+
+    created: list[Stock] = []
+
+    def _capture_add(obj: object) -> None:
+        if isinstance(obj, Stock):
+            obj.id = 7
+            created.append(obj)
+
+    db.add.side_effect = _capture_add
+
+    async with await _client(db) as client:
+        with patch(
+            "app.routers.htmx.fetch_stock_info", AsyncMock(return_value=_BTC_EUR)
+        ):
+            response = await client.post(
+                "/htmx/crypto-holdings",
+                data={"symbol": "BTC", "quote": "EUR", "quantity": "0.05"},
+            )
+
+    assert response.status_code == 200
+    assert "BTC-EUR" in response.text
+    assert "Crypto" in response.text
+    assert len(created) == 1
+    assert created[0].ticker == "BTC-EUR"
+    assert created[0].asset_type == ASSET_TYPE_CRYPTO
+    assert created[0].currency == "EUR"
+
+
+async def test_add_crypto_reuses_existing_stock_without_lookup() -> None:
+    existing = Stock(
+        ticker="BTC-EUR",
+        name="Bitcoin EUR",
+        currency="EUR",
+        asset_type=ASSET_TYPE_CRYPTO,
+        current_price=Decimal("50000"),
+    )
+    existing.id = 3
+    db = _mock_db(existing_stock=existing)
+
+    lookup = AsyncMock(return_value=None)
+    async with await _client(db) as client:
+        with patch("app.routers.htmx.fetch_stock_info", lookup):
+            response = await client.post(
+                "/htmx/crypto-holdings",
+                data={"symbol": "BTC", "quote": "EUR", "quantity": "0.2"},
+            )
+
+    assert response.status_code == 200
+    lookup.assert_not_awaited()
+
+
+async def test_add_crypto_normalises_symbol_and_quote() -> None:
+    db = _mock_db(existing_stock=None)
+
+    async with await _client(db) as client:
+        lookup = AsyncMock(return_value=_BTC_EUR)
+        with patch("app.routers.htmx.fetch_stock_info", lookup):
+            response = await client.post(
+                "/htmx/crypto-holdings",
+                data={"symbol": "  btc  ", "quote": "eur", "quantity": "0.1"},
+            )
+
+    assert response.status_code == 200
+    lookup.assert_awaited_once_with("BTC-EUR")
+
+
+async def test_add_crypto_rejects_unknown_quote() -> None:
+    db = _mock_db()
+    async with await _client(db) as client:
+        response = await client.post(
+            "/htmx/crypto-holdings",
+            data={"symbol": "BTC", "quote": "JPY", "quantity": "0.05"},
+        )
+
+    assert response.status_code == 200
+    assert "Quote currency must be one of" in response.text
+    assert 'id="add-crypto-form"' in response.text
+    db.add.assert_not_called()
+
+
+async def test_add_crypto_rejects_empty_symbol() -> None:
+    db = _mock_db()
+    async with await _client(db) as client:
+        response = await client.post(
+            "/htmx/crypto-holdings",
+            data={"symbol": "   ", "quote": "EUR", "quantity": "0.05"},
+        )
+
+    assert response.status_code == 200
+    assert "crypto symbol" in response.text.lower()
+    db.add.assert_not_called()
+
+
+@pytest.mark.parametrize("quantity", ["0", "-1", "abc"])
+async def test_add_crypto_rejects_invalid_quantity(quantity: str) -> None:
+    db = _mock_db()
+    async with await _client(db) as client:
+        response = await client.post(
+            "/htmx/crypto-holdings",
+            data={"symbol": "BTC", "quote": "EUR", "quantity": quantity},
+        )
+
+    assert response.status_code == 200
+    assert "Quantity must be a positive number" in response.text
+    db.add.assert_not_called()
+
+
+async def test_add_crypto_ticker_not_found_shows_error() -> None:
+    db = _mock_db(existing_stock=None)
+    async with await _client(db) as client:
+        with patch(
+            "app.routers.htmx.fetch_stock_info", AsyncMock(return_value=None)
+        ):
+            response = await client.post(
+                "/htmx/crypto-holdings",
+                data={"symbol": "ZZZ", "quote": "EUR", "quantity": "0.1"},
+            )
+
+    assert response.status_code == 200
+    assert "not found" in response.text.lower()
+    db.add.assert_not_called()
+
+
+async def test_add_crypto_form_renders() -> None:
+    db = _mock_db()
+    async with await _client(db) as client:
+        response = await client.get("/htmx/holdings/add-crypto-form")
+
+    assert response.status_code == 200
+    assert 'id="add-crypto-form"' in response.text
+    assert 'value="EUR"' in response.text
+    assert 'value="USD"' in response.text
+
+
+async def test_validate_crypto_empty_symbol_returns_empty() -> None:
+    db = _mock_db()
+    async with await _client(db) as client:
+        response = await client.get(
+            "/htmx/validate-crypto", params={"symbol": "", "quote": "EUR"}
+        )
+    assert response.status_code == 200
+    assert response.text == ""
+
+
+async def test_validate_crypto_invalid_quote_returns_invalid_hint() -> None:
+    db = _mock_db()
+    async with await _client(db) as client:
+        response = await client.get(
+            "/htmx/validate-crypto", params={"symbol": "BTC", "quote": "JPY"}
+        )
+
+    assert response.status_code == 200
+    assert "Ticker not found" in response.text
+    assert "ticker-hint negative" in response.text
+
+
+async def test_validate_crypto_hits_db_first() -> None:
+    existing = Stock(
+        ticker="BTC-EUR",
+        name="Bitcoin EUR",
+        currency="EUR",
+        asset_type=ASSET_TYPE_CRYPTO,
+        current_price=Decimal("50000"),
+    )
+    existing.id = 1
+    db = _mock_db(existing_stock=existing)
+    lookup = AsyncMock(return_value=None)
+
+    async with await _client(db) as client:
+        with patch("app.routers.htmx.fetch_stock_info", lookup):
+            response = await client.get(
+                "/htmx/validate-crypto", params={"symbol": "BTC", "quote": "EUR"}
+            )
+
+    assert response.status_code == 200
+    assert "Bitcoin EUR" in response.text
+    lookup.assert_not_awaited()
+
+
+async def test_validate_crypto_falls_back_to_yfinance() -> None:
+    db = _mock_db(existing_stock=None)
+    async with await _client(db) as client:
+        with patch(
+            "app.routers.htmx.fetch_stock_info", AsyncMock(return_value=_BTC_EUR)
+        ):
+            response = await client.get(
+                "/htmx/validate-crypto", params={"symbol": "BTC", "quote": "EUR"}
+            )
+
+    assert response.status_code == 200
+    assert "Bitcoin EUR" in response.text
+
+
+async def test_validate_crypto_unknown_symbol_returns_invalid() -> None:
+    db = _mock_db(existing_stock=None)
+    async with await _client(db) as client:
+        with patch(
+            "app.routers.htmx.fetch_stock_info", AsyncMock(return_value=None)
+        ):
+            response = await client.get(
+                "/htmx/validate-crypto",
+                params={"symbol": "NOTAREALCOIN", "quote": "EUR"},
+            )
+
+    assert response.status_code == 200
+    assert "Ticker not found" in response.text

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -17,11 +17,13 @@ def _make_holding(
     name: str,
     quantity: str,
     currency: str = "EUR",
+    asset_type: str = "STOCK",
 ) -> MagicMock:
     stock = MagicMock()
     stock.ticker = ticker
     stock.name = name
     stock.currency = currency
+    stock.asset_type = asset_type
 
     holding = MagicMock()
     holding.id = id
@@ -106,6 +108,24 @@ async def test_summary_mixed_holdings() -> None:
     assert len(summary.holdings) == 3
     assert summary.total_value == Decimal("2100.00")  # 10*150 + 2*300
     assert summary.holdings[1].current_value is None
+
+
+@pytest.mark.asyncio
+async def test_summary_preserves_asset_type() -> None:
+    """Each summary item carries the underlying stock's ``asset_type``."""
+    db = _make_db(
+        [
+            _make_holding(1, "AAPL", "Apple Inc.", "10", asset_type="STOCK"),
+            _make_holding(2, "BTC-EUR", "Bitcoin EUR", "0.5", asset_type="CRYPTO"),
+        ],
+        {"AAPL": "150.00", "BTC-EUR": "60000.00"},
+    )
+
+    summary = await PortfolioService().get_summary(db)
+
+    by_ticker = {item.ticker: item for item in summary.holdings}
+    assert by_ticker["AAPL"].asset_type == "STOCK"
+    assert by_ticker["BTC-EUR"].asset_type == "CRYPTO"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `asset_type` column (STOCK | CRYPTO) to `Stock` with an Alembic migration.
- New HTMX add-crypto flow: symbol + EUR/USD quote, inline validation, reuses existing stock on repeat adds.
- Portfolio table renders a `Crypto` badge next to the ticker and surfaces `asset_type` through the summary API.

## Test plan
- [x] `pytest tests/test_htmx_crypto.py tests/test_portfolio_service.py` — 21 passed (mock-based, no DB required)
- [x] Full suite (no DB): 117 passed, 8 skipped
- [ ] Manual: open `/` in Docker, add a BTC/EUR crypto holding, confirm badge + value render