### PR TITLE
test: run entire suite against a mocked database

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dev = [
     "pytest-cov>=5.0.0",
     "httpx>=0.27.0",
     "anyio>=4.4.0",
-    "asgi-lifespan>=2.1.0",
     "ruff>=0.4.0",
     "mypy>=1.10.0",
     "types-passlib>=1.7.7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,58 +1,69 @@
 """Shared pytest fixtures for the test suite.
 
-The fixtures here create an in-process FastAPI test client backed by a
-real (but test-scoped) database session.  When TEST_DATABASE_URL is not set
-in the test environment, the tests that require a database are skipped
-automatically.
+All tests run against a mocked database session — no real PostgreSQL is
+required.  The FastAPI lifespan (which normally initialises the DB engine
+and APScheduler) is bypassed: ``ASGITransport`` does not fire lifespan
+events, and the ``get_async_session`` dependency is overridden with a
+``MagicMock`` that exposes the async methods real handlers call.
 """
 
 from __future__ import annotations
 
-import os
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
-from asgi_lifespan import LifespanManager
 from httpx import ASGITransport, AsyncClient
 
 from app.config import Settings
+from app.database import get_async_session
 from app.main import create_app
 
-_DB_URL = os.environ.get("TEST_DATABASE_URL")
 
-
-@pytest.fixture(scope="session")
-def test_settings() -> Settings:
-    """Return a Settings instance suitable for testing.
-
-    Override TEST_DATABASE_URL via environment variable in CI to point
-    at a real test database.
-    """
+def _make_test_settings() -> Settings:
     return Settings(
         app_env="development",
-        app_debug=True,
+        app_debug=False,
         secret_key="test-secret-key-that-is-long-enough-32chars",
-        database_url=_DB_URL or "postgresql+asyncpg://postgres:postgres@localhost:5432/portfolio_test",
+        database_url="postgresql+asyncpg://mock/mock",
     )
 
 
-@pytest_asyncio.fixture(scope="session")
-async def client(test_settings: Settings) -> AsyncGenerator[AsyncClient, None]:
-    """Yield an AsyncClient wired to the test FastAPI application.
-
-    The app's lifespan (database init/close) is executed automatically
-    via LifespanManager.
-    """
-    application = create_app(settings=test_settings)
-    async with LifespanManager(application):
-        transport = ASGITransport(app=application)  # type: ignore[arg-type]
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            yield ac
+def make_mock_session() -> MagicMock:
+    """Return a MagicMock shaped like an ``AsyncSession`` with no-op async methods."""
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.get = AsyncMock()
+    session.add = MagicMock()
+    session.delete = AsyncMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    return session
 
 
 @pytest.fixture
-def require_db(request: pytest.FixtureRequest) -> None:
-    """Skip the test automatically when TEST_DATABASE_URL is not configured."""
-    if not _DB_URL:
-        pytest.skip("TEST_DATABASE_URL not set — skipping database-dependent test")
+def mock_session() -> MagicMock:
+    """A fresh mocked ``AsyncSession`` — customise per-test as needed."""
+    return make_mock_session()
+
+
+@pytest_asyncio.fixture
+async def client(mock_session: MagicMock) -> AsyncIterator[AsyncClient]:
+    """An ``AsyncClient`` against a FastAPI app backed by ``mock_session``.
+
+    The app's lifespan is intentionally not triggered (ASGITransport skips
+    lifespan events), so no real database engine or scheduler is created.
+    """
+    app = create_app(settings=_make_test_settings())
+
+    async def _override() -> MagicMock:
+        return mock_session
+
+    app.dependency_overrides[get_async_session] = _override
+
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -2,31 +2,48 @@
 
 from __future__ import annotations
 
-import pytest
+from unittest.mock import MagicMock
+
 from httpx import AsyncClient
 
-pytestmark = pytest.mark.asyncio
 
+async def test_list_holdings_empty(client: AsyncClient, mock_session: MagicMock) -> None:
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    mock_session.execute.return_value = result
 
-async def test_list_holdings_empty(require_db: None, client: AsyncClient) -> None:
     response = await client.get("/api/v1/holdings")
     assert response.status_code == 200
     assert response.json() == []
 
 
-async def test_create_holding_unknown_ticker(require_db: None, client: AsyncClient) -> None:
+async def test_create_holding_unknown_ticker(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = result
+
     response = await client.post(
         "/api/v1/holdings", json={"ticker": "UNKNOWN", "quantity": "10.0"}
     )
     assert response.status_code == 404
 
 
-async def test_delete_holding_not_found(require_db: None, client: AsyncClient) -> None:
+async def test_delete_holding_not_found(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    mock_session.get.return_value = None
+
     response = await client.delete("/api/v1/holdings/99999")
     assert response.status_code == 404
 
 
-async def test_update_holding_not_found(require_db: None, client: AsyncClient) -> None:
+async def test_update_holding_not_found(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    mock_session.get.return_value = None
+
     response = await client.put(
         "/api/v1/holdings/99999", json={"quantity": "5.0"}
     )

--- a/tests/test_portfolio_page.py
+++ b/tests/test_portfolio_page.py
@@ -2,21 +2,41 @@
 
 from __future__ import annotations
 
-import pytest
+from unittest.mock import MagicMock
+
 from httpx import AsyncClient
 
-pytestmark = pytest.mark.asyncio
+
+def _configure_empty_portfolio(mock_session: MagicMock) -> None:
+    """Wire the session so get_summary returns no holdings and last_refresh is None.
+
+    The route issues two db.execute() calls: one for the holdings select and
+    one for the max(PriceCache.date) scalar.
+    """
+    holdings_result = MagicMock()
+    holdings_result.scalars.return_value.all.return_value = []
+
+    last_refresh_result = MagicMock()
+    last_refresh_result.scalar.return_value = None
+
+    mock_session.execute.side_effect = [holdings_result, last_refresh_result]
 
 
-async def test_portfolio_page_returns_html(require_db: None, client: AsyncClient) -> None:
+async def test_portfolio_page_returns_html(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    _configure_empty_portfolio(mock_session)
+
     response = await client.get("/")
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
 
 
 async def test_portfolio_page_contains_expected_elements(
-    require_db: None, client: AsyncClient
+    client: AsyncClient, mock_session: MagicMock
 ) -> None:
+    _configure_empty_portfolio(mock_session)
+
     response = await client.get("/")
     html = response.text
     assert "Portfolio Overview" in html

--- a/tests/test_portfolio_summary.py
+++ b/tests/test_portfolio_summary.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
-import pytest
+from unittest.mock import MagicMock
+
 from httpx import AsyncClient
 
-pytestmark = pytest.mark.asyncio
+
+def _empty_holdings_result() -> MagicMock:
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    return result
 
 
-async def test_summary_empty(require_db: None, client: AsyncClient) -> None:
+async def test_summary_empty(client: AsyncClient, mock_session: MagicMock) -> None:
+    mock_session.execute.return_value = _empty_holdings_result()
+
     response = await client.get("/api/v1/holdings/summary")
     assert response.status_code == 200
     data = response.json()
@@ -16,8 +23,12 @@ async def test_summary_empty(require_db: None, client: AsyncClient) -> None:
     assert data["total_value"] is None
 
 
-async def test_summary_response_shape(require_db: None, client: AsyncClient) -> None:
+async def test_summary_response_shape(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
     """Summary endpoint returns expected top-level keys."""
+    mock_session.execute.return_value = _empty_holdings_result()
+
     response = await client.get("/api/v1/holdings/summary")
     assert response.status_code == 200
     data = response.json()


### PR DESCRIPTION
## Summary
- Remove `require_db` and the `TEST_DATABASE_URL`-gated integration path from `tests/conftest.py`; the new `client` fixture builds the app without firing the lifespan and overrides `get_async_session` with a per-test `MagicMock`.
- Rewrite `test_holdings.py`, `test_portfolio_summary.py`, and `test_portfolio_page.py` to drive the endpoints through the mocked session instead of a live PostgreSQL instance.
- Drop the now-unused `asgi-lifespan` dev dependency.

## Test plan
- [x] `.venv/bin/python -m pytest --no-cov` → 125 passed with no `TEST_DATABASE_URL` set and no DB process required