### PR TITLE
feat: add monthly report web pages with history

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.routers import (
     import_pdf,
     import_xml,
     portfolio,
+    reports,
     stocks,
 )
 
@@ -128,6 +129,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(import_pdf.router)
     app.include_router(import_xml.router)
     app.include_router(admin.router)
+    app.include_router(reports.router)
     # Future routers (uncomment as implemented):
     # app.include_router(auth.router,       prefix="/api/v1/auth",       tags=["auth"])
     # app.include_router(portfolios.router, prefix="/api/v1/portfolios", tags=["portfolios"])

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -1,0 +1,73 @@
+"""HTML routes for the monthly report history and detail pages."""
+
+from __future__ import annotations
+
+import calendar
+import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.services.report_service import ReportService
+
+router = APIRouter(prefix="/reports", tags=["reports-ui"])
+
+_TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+
+_DB = Depends(get_async_session)
+
+
+@router.get("", response_class=HTMLResponse)
+async def reports_history(
+    request: Request,
+    db: AsyncSession = _DB,
+) -> HTMLResponse:
+    """Render the monthly report history page."""
+    available = await ReportService().get_available_months(db)
+    months = [
+        {
+            "year": y,
+            "month": m,
+            "label": datetime.date(y, m, 1).strftime("%B %Y"),
+            "period_start": datetime.date(y, m, 1),
+            "period_end": datetime.date(y, m, calendar.monthrange(y, m)[1]),
+        }
+        for y, m in available
+    ]
+    return templates.TemplateResponse(
+        request=request,
+        name="reports.html",
+        context={"months": months},
+    )
+
+
+@router.get("/{year}/{month}", response_class=HTMLResponse)
+async def report_detail(
+    year: int,
+    month: int,
+    request: Request,
+    db: AsyncSession = _DB,
+) -> HTMLResponse:
+    """Render the detail page for a specific month's report."""
+    if not (1 <= month <= 12):
+        raise HTTPException(status_code=404, detail="Invalid month")
+    if datetime.date(year, month, 1) >= datetime.date.today().replace(day=1):
+        raise HTTPException(status_code=404, detail="Month not yet complete")
+
+    report = await ReportService().generate_report_for_month(db, year, month)
+    month_label = datetime.date(year, month, 1).strftime("%B %Y")
+    return templates.TemplateResponse(
+        request=request,
+        name="report_detail.html",
+        context={
+            "report": report,
+            "year": year,
+            "month": month,
+            "month_label": month_label,
+        },
+    )

--- a/app/services/report_service.py
+++ b/app/services/report_service.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import calendar
 import datetime
 import logging
 from dataclasses import dataclass
 from decimal import Decimal
 
 from jinja2 import Environment, PackageLoader, select_autoescape
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -50,6 +51,27 @@ class MonthlyReportData:
 class ReportService:
     """Generates the monthly portfolio wealth report."""
 
+    async def get_available_months(
+        self, db: AsyncSession
+    ) -> list[tuple[int, int]]:
+        """Return distinct (year, month) tuples that have price data, newest first.
+
+        Only completed months (strictly before the current calendar month) are
+        returned.
+        """
+        current_month_start = datetime.date.today().replace(day=1)
+        subq = (
+            select(func.date_trunc("month", PriceCache.date).label("month_start"))
+            .where(PriceCache.date < current_month_start)
+            .distinct()
+            .subquery()
+        )
+        result = await db.execute(
+            select(subq.c.month_start).order_by(subq.c.month_start.desc())
+        )
+        rows = result.scalars().all()
+        return [(row.year, row.month) for row in rows]
+
     async def generate_monthly_report(
         self, db: AsyncSession, reference_date: datetime.date | None = None
     ) -> MonthlyReportData | None:
@@ -66,7 +88,27 @@ class ReportService:
         today = reference_date or datetime.date.today()
         period_end = today.replace(day=1) - datetime.timedelta(days=1)
         period_start = period_end.replace(day=1)
+        return await self._build_report(db, period_start, period_end)
 
+    async def generate_report_for_month(
+        self, db: AsyncSession, year: int, month: int
+    ) -> MonthlyReportData | None:
+        """Build the monthly report for an explicit calendar month.
+
+        Returns ``None`` when there are no holdings.
+        """
+        period_start = datetime.date(year, month, 1)
+        last_day = calendar.monthrange(year, month)[1]
+        period_end = datetime.date(year, month, last_day)
+        return await self._build_report(db, period_start, period_end)
+
+    async def _build_report(
+        self,
+        db: AsyncSession,
+        period_start: datetime.date,
+        period_end: datetime.date,
+    ) -> MonthlyReportData | None:
+        """Core report-building logic shared by all public methods."""
         rows = await db.execute(select(Holding).options(selectinload(Holding.stock)))
         holdings = rows.scalars().all()
 
@@ -75,7 +117,6 @@ class ReportService:
 
         tickers = [h.stock.ticker for h in holdings]
 
-        # Fetch all cached prices for those tickers within the previous month.
         price_rows = await db.execute(
             select(PriceCache.ticker, PriceCache.date, PriceCache.close_price)
             .where(
@@ -85,7 +126,6 @@ class ReportService:
             )
         )
 
-        # Build {ticker: {date: price}} mapping.
         prices: dict[str, dict[datetime.date, Decimal]] = {}
         for ticker, date, close_price in price_rows:
             prices.setdefault(ticker, {})[date] = close_price

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -468,6 +468,8 @@
     <a href="/import/pdf" class="nav-link">Import PDF</a>
     <span class="nav-sep">/</span>
     <a href="/import/xml" class="nav-link">Import XML</a>
+    <span class="nav-sep">/</span>
+    <a href="/reports" class="nav-link">Reports</a>
   </nav>
   <main class="{% block page_class %}page{% endblock %}">
     {% block content %}{% endblock %}

--- a/app/templates/report_detail.html
+++ b/app/templates/report_detail.html
@@ -1,0 +1,241 @@
+{% extends "base.html" %}
+
+{% block title %}{{ month_label }} Report — Terminal Ledger{% endblock %}
+
+{% block extra_head %}
+<style>
+  /* ── Back nav ────────────────────────────────────────────────── */
+  .back-nav {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--muted);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.25rem 0.65rem;
+    margin-bottom: 2rem;
+    text-decoration: none;
+    transition: color 120ms ease, border-color 120ms ease;
+  }
+  .back-nav:hover {
+    color: var(--text);
+    border-color: var(--muted);
+    text-decoration: none;
+    opacity: 1;
+  }
+
+  /* ── Stats strip ─────────────────────────────────────────────── */
+  .stats-strip {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  @media (max-width: 640px) {
+    .stats-strip { grid-template-columns: repeat(2, 1fr); }
+  }
+  .stat-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .stat-label {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+  .stat-value {
+    font-family: var(--font-mono);
+    font-size: 1.35rem;
+    font-weight: 600;
+    color: var(--accent);
+    line-height: 1.1;
+  }
+  .stat-value.na {
+    color: var(--muted);
+    font-weight: 400;
+    font-size: 1.1rem;
+  }
+  .stat-value.positive { color: var(--accent); }
+  .stat-value.negative { color: var(--danger); }
+  .stat-value.neutral  { color: var(--text); }
+
+  /* ── Report header ───────────────────────────────────────────── */
+  .report-header {
+    margin-bottom: 2rem;
+  }
+  .report-period {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--muted);
+    margin-top: 0.25rem;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<a href="/reports" class="back-nav">&#8592; All Reports</a>
+
+{% if report is none %}
+<div style="text-align: center; padding: 3rem 1.5rem; border: 1px dashed var(--border); border-radius: var(--radius);">
+  <p style="font-family: var(--font-mono); font-size: 2rem; color: var(--border); margin-bottom: 1rem;">[ ]</p>
+  <p style="font-weight: 600; color: var(--text); margin-bottom: 0.5rem;">No data for {{ month_label }}</p>
+  <p style="font-size: 0.9rem;">No holdings were found. Add stocks to your portfolio to generate reports.</p>
+</div>
+{% else %}
+
+<div class="report-header">
+  <h1>{{ report.month_label }}</h1>
+  <p class="report-period">{{ report.period_start.strftime("%d %b %Y") }} – {{ report.period_end.strftime("%d %b %Y") }}</p>
+</div>
+
+<div class="stats-strip">
+  <div class="stat-card">
+    <span class="stat-label">Value on {{ report.period_start.strftime("%-d %b") }}</span>
+    {% if report.total_value_1st is not none %}
+      <span class="stat-value neutral">€{{ "%.2f"|format(report.total_value_1st) }}</span>
+    {% else %}
+      <span class="stat-value na">—</span>
+    {% endif %}
+  </div>
+
+  <div class="stat-card">
+    <span class="stat-label">Value on {{ report.period_end.strftime("%-d %b") }}</span>
+    {% if report.total_value_last is not none %}
+      <span class="stat-value neutral">€{{ "%.2f"|format(report.total_value_last) }}</span>
+    {% else %}
+      <span class="stat-value na">—</span>
+    {% endif %}
+  </div>
+
+  <div class="stat-card">
+    <span class="stat-label">Delta (€)</span>
+    {% if report.total_delta_eur is not none %}
+      {% set sign = "+" if report.total_delta_eur >= 0 else "" %}
+      {% set css  = "positive" if report.total_delta_eur >= 0 else "negative" %}
+      <span class="stat-value {{ css }}">{{ sign }}€{{ "%.2f"|format(report.total_delta_eur) }}</span>
+    {% else %}
+      <span class="stat-value na">—</span>
+    {% endif %}
+  </div>
+
+  <div class="stat-card">
+    <span class="stat-label">Delta (%)</span>
+    {% if report.total_delta_pct is not none %}
+      {% set sign = "+" if report.total_delta_pct >= 0 else "" %}
+      {% set css  = "positive" if report.total_delta_pct >= 0 else "negative" %}
+      <span class="stat-value {{ css }}">{{ sign }}{{ report.total_delta_pct }}%</span>
+    {% else %}
+      <span class="stat-value na">—</span>
+    {% endif %}
+  </div>
+</div>
+
+<div class="card">
+  <h2>Per-Stock Breakdown</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Stock</th>
+        <th class="number">Qty</th>
+        <th class="number">Price 1st</th>
+        <th class="number">Price Last</th>
+        <th class="number">Delta (€)</th>
+        <th class="number">Delta (%)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for line in report.lines %}
+      <tr>
+        <td>
+          <span style="font-family: var(--font-mono); font-weight: 600;">{{ line.ticker }}</span>
+          <br>
+          <span style="font-size: 0.8rem; color: var(--muted);">{{ line.name }}</span>
+        </td>
+        <td class="number">{{ line.quantity }}</td>
+        <td class="number">
+          {% if line.price_1st is not none %}
+            €{{ "%.2f"|format(line.price_1st) }}
+          {% else %}
+            <span class="na">—</span>
+          {% endif %}
+        </td>
+        <td class="number">
+          {% if line.price_last is not none %}
+            €{{ "%.2f"|format(line.price_last) }}
+          {% else %}
+            <span class="na">—</span>
+          {% endif %}
+        </td>
+        <td class="number">
+          {% if line.delta_eur is not none %}
+            {% set sign = "+" if line.delta_eur >= 0 else "" %}
+            {% set css  = "positive" if line.delta_eur >= 0 else "negative" %}
+            <span class="{{ css }}">{{ sign }}€{{ "%.2f"|format(line.delta_eur) }}</span>
+          {% else %}
+            <span class="na">—</span>
+          {% endif %}
+        </td>
+        <td class="number">
+          {% if line.delta_pct is not none %}
+            {% set sign = "+" if line.delta_pct >= 0 else "" %}
+            {% set css  = "positive" if line.delta_pct >= 0 else "negative" %}
+            <span class="{{ css }}">{{ sign }}{{ line.delta_pct }}%</span>
+          {% else %}
+            <span class="na">—</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+    <tfoot>
+      <tr class="total-row">
+        <td><strong>Total</strong></td>
+        <td class="number"></td>
+        <td class="number">
+          {% if report.total_value_1st is not none %}
+            €{{ "%.2f"|format(report.total_value_1st) }}
+          {% else %}
+            <span class="na">—</span>
+          {% endif %}
+        </td>
+        <td class="number">
+          {% if report.total_value_last is not none %}
+            €{{ "%.2f"|format(report.total_value_last) }}
+          {% else %}
+            <span class="na">—</span>
+          {% endif %}
+        </td>
+        <td class="number">
+          {% if report.total_delta_eur is not none %}
+            {% set sign = "+" if report.total_delta_eur >= 0 else "" %}
+            {% set css  = "positive" if report.total_delta_eur >= 0 else "negative" %}
+            <span class="{{ css }}"><strong>{{ sign }}€{{ "%.2f"|format(report.total_delta_eur) }}</strong></span>
+          {% else %}
+            <span class="na">—</span>
+          {% endif %}
+        </td>
+        <td class="number">
+          {% if report.total_delta_pct is not none %}
+            {% set sign = "+" if report.total_delta_pct >= 0 else "" %}
+            {% set css  = "positive" if report.total_delta_pct >= 0 else "negative" %}
+            <span class="{{ css }}"><strong>{{ sign }}{{ report.total_delta_pct }}%</strong></span>
+          {% else %}
+            <span class="na">—</span>
+          {% endif %}
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+
+{% endif %}
+{% endblock %}

--- a/app/templates/reports.html
+++ b/app/templates/reports.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}Monthly Reports — Terminal Ledger{% endblock %}
+
+{% block content %}
+<h1>Monthly Reports</h1>
+<p>Historical portfolio performance, one month at a time.</p>
+
+{% if months %}
+<table style="margin-top: 1.5rem;">
+  <thead>
+    <tr>
+      <th>Period</th>
+      <th>Date Range</th>
+      <th class="actions"></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for m in months %}
+    <tr>
+      <td><span class="text-mono" style="font-weight: 600;">{{ m.label }}</span></td>
+      <td style="color: var(--muted); font-family: var(--font-mono); font-size: 0.85rem;">
+        {{ m.period_start.strftime("%d %b %Y") }} – {{ m.period_end.strftime("%d %b %Y") }}
+      </td>
+      <td class="actions">
+        <a href="/reports/{{ m.year }}/{{ '%02d'|format(m.month) }}"
+           style="font-family: var(--font-mono); font-size: 0.85rem; font-weight: 600;">
+          View &rarr;
+        </a>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div style="margin-top: 2rem; text-align: center; padding: 3rem 1.5rem; border: 1px dashed var(--border); border-radius: var(--radius);">
+  <p style="font-family: var(--font-mono); font-size: 2rem; color: var(--border); margin-bottom: 1rem;">[ ]</p>
+  <p style="font-weight: 600; color: var(--text); margin-bottom: 0.5rem;">No reports yet</p>
+  <p style="font-size: 0.9rem;">Reports will appear here once a full calendar month of price data has been recorded.</p>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary

- Adds `/reports` history page listing all completed months that have price data in `PriceCache`, each linking to its full report
- Adds `/reports/{year}/{month}` detail page rendering the monthly report in the app's dark theme (extending `base.html`), with a 4-column KPI stats strip and a per-stock breakdown table
- Adds a "Reports" nav link to the global navigation bar
- Refactors `ReportService` to extract shared logic into `_build_report()` and adds `get_available_months()` + `generate_report_for_month(year, month)` methods; existing `generate_monthly_report()` is unchanged (scheduler compatibility preserved)

## Test plan

- [ ] Navigate to `/reports` — history table renders (or empty state if no price data yet)
- [ ] Navigate to `/reports/{year}/{month}` for a month with data — dark-themed page shows KPI strip and breakdown table with correct sign-colored deltas
- [ ] `/reports/2026/13` returns 404 (invalid month)
- [ ] `/reports/2026/04` (current month) returns 404
- [ ] "Reports" nav link visible on all pages
- [ ] `125 passed` in test suite (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)