### PR TITLE
XML import: validate & resolve tickers in preview (closes #101)

### DIFF
--- a/app/routers/import_xml.py
+++ b/app/routers/import_xml.py
@@ -5,15 +5,23 @@ from __future__ import annotations
 from pathlib import Path
 from xml.etree.ElementTree import ParseError
 
-from fastapi import APIRouter, Depends, Request, UploadFile
+from fastapi import APIRouter, Depends, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import get_settings
 from app.database import get_async_session
+from app.models.stock import ASSET_TYPE_CRYPTO, ASSET_TYPE_STOCK
+from app.services import import_cache
 from app.services.holdings_service import recompute_holdings
 from app.services.portfolio_performance_importer import PortfolioPerformanceImporter
+from app.services.stock_lookup import fetch_stock_info
 from app.services.transaction_import_service import TransactionImportService
+from app.services.xml_security_resolver import (
+    ResolvedSecurity,
+    resolve_securities,
+)
 
 router = APIRouter(prefix="/import", tags=["import"])
 
@@ -73,59 +81,66 @@ async def import_xml_preview(
             {"step": "upload", "error": str(exc)},
         )
 
+    settings = get_settings()
+    resolutions = await resolve_securities(
+        result.unique_securities, openfigi_api_key=settings.openfigi_api_key
+    )
+
+    token = import_cache.store(
+        import_cache.ImportPreviewEntry(
+            parse_result=result,
+            resolutions=resolutions,
+            filename=file.filename or "",
+        )
+    )
+
     return _render(
         request,
         "import_xml.html",
-        {
-            "step": "preview",
-            "result": result,
-            "filename": file.filename,
-        },
+        _preview_context(result, resolutions, token, file.filename or ""),
     )
 
 
 @router.post("/xml/confirm", response_class=HTMLResponse)
 async def import_xml_confirm(
     request: Request,
-    file: UploadFile,
+    token: str = Form(...),
     db: AsyncSession = _DB,
 ) -> HTMLResponse:
-    """Re-parse the uploaded XML and persist its transactions."""
-    filename = (file.filename or "").lower()
-    if not (filename.endswith(".xml") or filename.endswith(".zip")):
+    """Persist the cached preview using the (possibly user-edited) resolutions."""
+    entry = import_cache.get(token)
+    if entry is None:
         return _render(
             request,
             "import_xml.html",
-            {"step": "upload", "error": "Please upload a .xml or .zip file."},
+            {
+                "step": "upload",
+                "error": "Your preview expired. Please upload the file again.",
+            },
         )
 
-    contents = await file.read()
-    if not contents:
+    unresolved = [r for r in entry.resolutions.values() if r.status != "valid"]
+    if unresolved:
         return _render(
             request,
             "import_xml.html",
-            {"step": "upload", "error": "The uploaded file is empty."},
+            _preview_context(
+                entry.parse_result,
+                entry.resolutions,
+                token,
+                entry.filename,
+                error="Resolve every security before confirming the import.",
+            ),
         )
 
-    try:
-        result = _importer.parse_bytes(contents)
-    except ParseError as exc:
-        return _render(
-            request,
-            "import_xml.html",
-            {"step": "upload", "error": f"Invalid XML: {exc}"},
-        )
-    except ValueError as exc:
-        return _render(
-            request,
-            "import_xml.html",
-            {"step": "upload", "error": str(exc)},
-        )
+    _apply_resolutions(entry.parse_result, entry.resolutions)
 
-    summary = await _transaction_import.import_xml_result(result, db)
+    summary = await _transaction_import.import_xml_result(entry.parse_result, db)
 
     if summary.affected_stock_ids:
         await recompute_holdings(db, summary.affected_stock_ids)
+
+    import_cache.delete(token)
 
     return _render(
         request,
@@ -133,6 +148,123 @@ async def import_xml_confirm(
         {
             "step": "done",
             "summary": summary,
-            "filename": file.filename,
+            "filename": entry.filename,
         },
     )
+
+
+@router.post("/xml/resolve-row", response_class=HTMLResponse)
+async def import_xml_resolve_row(
+    request: Request,
+    token: str = Form(...),
+    uuid: str = Form(...),
+    ticker: str = Form(""),
+    asset_type: str = Form(ASSET_TYPE_STOCK),
+) -> HTMLResponse:
+    """Validate a manually-entered ticker and update the cached resolution."""
+    entry = import_cache.get(token)
+    if entry is None:
+        return HTMLResponse(
+            '<div class="error">Preview expired — please re-upload the file.</div>',
+            status_code=410,
+        )
+
+    current = entry.resolutions.get(uuid)
+    if current is None:
+        return HTMLResponse(status_code=404)
+
+    ticker = ticker.strip().upper()
+    asset_type = (asset_type or ASSET_TYPE_STOCK).strip().upper()
+    if asset_type not in {ASSET_TYPE_STOCK, ASSET_TYPE_CRYPTO}:
+        asset_type = ASSET_TYPE_STOCK
+
+    if not ticker:
+        updated = ResolvedSecurity(
+            uuid=current.uuid,
+            original_ticker=current.original_ticker,
+            original_name=current.original_name,
+            isin=current.isin,
+            status="needs_attention",
+            resolved_ticker=None,
+            asset_type=asset_type,
+            suggestion_source="manual",
+            yahoo_name=None,
+            currency=current.currency,
+        )
+    else:
+        info = await fetch_stock_info(ticker)
+        if info is None:
+            updated = ResolvedSecurity(
+                uuid=current.uuid,
+                original_ticker=current.original_ticker,
+                original_name=current.original_name,
+                isin=current.isin,
+                status="needs_attention",
+                resolved_ticker=ticker,
+                asset_type=asset_type,
+                suggestion_source="manual",
+                yahoo_name=None,
+                currency=current.currency,
+            )
+        else:
+            updated = ResolvedSecurity(
+                uuid=current.uuid,
+                original_ticker=current.original_ticker,
+                original_name=current.original_name,
+                isin=current.isin,
+                status="valid",
+                resolved_ticker=ticker,
+                asset_type=asset_type,
+                suggestion_source="manual",
+                yahoo_name=info.name,
+                currency=info.currency or current.currency,
+            )
+
+    import_cache.update_resolution(token, uuid, updated)
+
+    all_valid = all(r.status == "valid" for r in entry.resolutions.values())
+
+    row_html = templates.get_template("partials/security_row.html").render(
+        resolution=updated, token=token
+    )
+    # OOB swap keeps the Confirm button in sync as rows resolve.
+    confirm_html = templates.get_template("partials/confirm_button.html").render(
+        all_valid=all_valid, token=token, oob=True
+    )
+    return HTMLResponse(row_html + confirm_html)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _preview_context(
+    result, resolutions, token, filename, *, error: str | None = None  # type: ignore[no-untyped-def]
+) -> dict:  # type: ignore[type-arg]
+    securities = sorted(
+        resolutions.values(),
+        key=lambda r: (r.status != "needs_attention", (r.original_name or "").lower()),
+    )
+    all_valid = all(r.status == "valid" for r in resolutions.values())
+    return {
+        "step": "preview",
+        "result": result,
+        "filename": filename,
+        "token": token,
+        "securities": securities,
+        "all_valid": all_valid,
+        "error": error,
+    }
+
+
+def _apply_resolutions(result, resolutions) -> None:  # type: ignore[no-untyped-def]
+    """Push resolved tickers + asset_type back onto SecurityInfo before persist."""
+    for sec in result.securities.values():
+        resolution = resolutions.get(sec.uuid)
+        if resolution is None or resolution.status != "valid":
+            continue
+        sec.ticker = resolution.resolved_ticker
+        sec.asset_type = resolution.asset_type
+        if resolution.currency:
+            sec.currency = resolution.currency

--- a/app/routers/import_xml.py
+++ b/app/routers/import_xml.py
@@ -15,7 +15,10 @@ from app.database import get_async_session
 from app.models.stock import ASSET_TYPE_CRYPTO, ASSET_TYPE_STOCK
 from app.services import import_cache
 from app.services.holdings_service import recompute_holdings
-from app.services.portfolio_performance_importer import PortfolioPerformanceImporter
+from app.services.portfolio_performance_importer import (
+    ParseResult,
+    PortfolioPerformanceImporter,
+)
 from app.services.stock_lookup import fetch_stock_info
 from app.services.transaction_import_service import TransactionImportService
 from app.services.xml_security_resolver import (
@@ -240,8 +243,13 @@ async def import_xml_resolve_row(
 
 
 def _preview_context(
-    result, resolutions, token, filename, *, error: str | None = None  # type: ignore[no-untyped-def]
-) -> dict:  # type: ignore[type-arg]
+    result: ParseResult,
+    resolutions: dict[str, ResolvedSecurity],
+    token: str,
+    filename: str,
+    *,
+    error: str | None = None,
+) -> dict[str, object]:
     securities = sorted(
         resolutions.values(),
         key=lambda r: (r.status != "needs_attention", (r.original_name or "").lower()),
@@ -258,7 +266,9 @@ def _preview_context(
     }
 
 
-def _apply_resolutions(result, resolutions) -> None:  # type: ignore[no-untyped-def]
+def _apply_resolutions(
+    result: ParseResult, resolutions: dict[str, ResolvedSecurity]
+) -> None:
     """Push resolved tickers + asset_type back onto SecurityInfo before persist."""
     for sec in result.securities.values():
         resolution = resolutions.get(sec.uuid)

--- a/app/routers/import_xml.py
+++ b/app/routers/import_xml.py
@@ -10,7 +10,6 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import get_settings
 from app.database import get_async_session
 from app.models.stock import ASSET_TYPE_CRYPTO, ASSET_TYPE_STOCK
 from app.services import import_cache
@@ -84,9 +83,9 @@ async def import_xml_preview(
             {"step": "upload", "error": str(exc)},
         )
 
-    settings = get_settings()
+    openfigi_api_key = getattr(request.app.state.settings, "openfigi_api_key", "")
     resolutions = await resolve_securities(
-        result.unique_securities, openfigi_api_key=settings.openfigi_api_key
+        result.unique_securities, openfigi_api_key=openfigi_api_key
     )
 
     token = import_cache.store(

--- a/app/services/import_cache.py
+++ b/app/services/import_cache.py
@@ -1,0 +1,71 @@
+"""In-memory store that bridges the XML preview and confirm steps.
+
+The preview step parses the XML and resolves each security against Yahoo
+Finance — work we do not want to repeat at confirm time, and the manual
+ticker overrides the user enters in the preview need somewhere to live
+until they click Confirm.  A single-process FastAPI app is enough here;
+no Redis required.
+
+Entries expire 30 minutes after their last touch (lazy eviction on read).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+
+from app.services.portfolio_performance_importer import ParseResult
+from app.services.xml_security_resolver import ResolvedSecurity
+
+_TTL_SECONDS = 30 * 60
+
+
+@dataclass(slots=True)
+class ImportPreviewEntry:
+    parse_result: ParseResult
+    resolutions: dict[str, ResolvedSecurity]  # keyed by security UUID
+    filename: str
+    created_at: float = field(default_factory=time.monotonic)
+
+
+_store: dict[str, ImportPreviewEntry] = {}
+_lock = threading.Lock()
+
+
+def store(entry: ImportPreviewEntry) -> str:
+    token = uuid.uuid4().hex
+    with _lock:
+        _evict_expired_locked()
+        _store[token] = entry
+    return token
+
+
+def get(token: str) -> ImportPreviewEntry | None:
+    with _lock:
+        _evict_expired_locked()
+        return _store.get(token)
+
+
+def update_resolution(token: str, security_uuid: str, resolution: ResolvedSecurity) -> bool:
+    with _lock:
+        _evict_expired_locked()
+        entry = _store.get(token)
+        if entry is None:
+            return False
+        entry.resolutions[security_uuid] = resolution
+        entry.created_at = time.monotonic()  # refresh TTL on activity
+        return True
+
+
+def delete(token: str) -> None:
+    with _lock:
+        _store.pop(token, None)
+
+
+def _evict_expired_locked() -> None:
+    now = time.monotonic()
+    expired = [k for k, e in _store.items() if now - e.created_at > _TTL_SECONDS]
+    for k in expired:
+        _store.pop(k, None)

--- a/app/services/openfigi_lookup.py
+++ b/app/services/openfigi_lookup.py
@@ -87,31 +87,15 @@ def _build_yfinance_ticker(ticker: str, exch_code: str) -> str:
     return f"{ticker}{suffix}"
 
 
-async def resolve_wkn(wkn: str, api_key: str = "") -> str | None:
-    """Return the ticker symbol for a WKN, or None if it cannot be resolved.
-
-    The returned ticker includes the yfinance exchange suffix (e.g. ``RHM.DE``
-    for Rheinmetall AG on XETRA) so that yfinance can unambiguously identify
-    the correct security.
-
-    Args:
-        wkn: The 6-character WKN (Wertpapierkennnummer) to resolve.
-        api_key: Optional OpenFIGI API key for higher rate limits.
-                 Unauthenticated requests are limited to 25 req/min.
-
-    Returns:
-        The resolved ticker symbol (upper-case, with exchange suffix), or None
-        on failure.
-    """
-    wkn = wkn.strip().upper()
-    if not wkn:
-        return None
-
+async def _resolve_via_openfigi(
+    id_type: str, id_value: str, api_key: str
+) -> str | None:
+    """Post one id to OpenFIGI and return the preferred yfinance ticker."""
     headers: dict[str, str] = {"Content-Type": "application/json"}
     if api_key:
         headers["X-OPENFIGI-APIKEY"] = api_key
 
-    payload = [{"idType": "ID_WERTPAPIER", "idValue": wkn}]
+    payload = [{"idType": id_type, "idValue": id_value}]
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
@@ -119,13 +103,17 @@ async def resolve_wkn(wkn: str, api_key: str = "") -> str | None:
             response.raise_for_status()
             data = response.json()
     except httpx.HTTPError as exc:
-        logger.warning("OpenFIGI request failed for WKN %s: %s", wkn, exc)
+        logger.warning("OpenFIGI request failed for %s %s: %s", id_type, id_value, exc)
         return None
     except Exception as exc:  # noqa: BLE001
-        logger.warning("Unexpected error during OpenFIGI lookup for WKN %s: %s", wkn, exc)
+        logger.warning(
+            "Unexpected error during OpenFIGI lookup for %s %s: %s",
+            id_type,
+            id_value,
+            exc,
+        )
         return None
 
-    # Response shape: [{"data": [{"ticker": "RHM", "exchCode": "GR", ...}]}]
     try:
         results: list[dict[str, Any]] = data[0]["data"]
     except (KeyError, IndexError, TypeError):
@@ -134,21 +122,18 @@ async def resolve_wkn(wkn: str, api_key: str = "") -> str | None:
     if not results:
         return None
 
-    # Build a lookup: exchCode → first matching result
     by_exch: dict[str, dict[str, Any]] = {}
     for item in results:
         code = item.get("exchCode", "")
         if code and code not in by_exch:
             by_exch[code] = item
 
-    # Pick the best result according to our preference order
     chosen: dict[str, Any] | None = None
     for preferred in _PREFERRED_EXCHCODES:
         if preferred in by_exch:
             chosen = by_exch[preferred]
             break
 
-    # Fall back to the first result if none of the preferred codes matched
     if chosen is None:
         chosen = results[0]
 
@@ -159,10 +144,27 @@ async def resolve_wkn(wkn: str, api_key: str = "") -> str | None:
     exch_code = str(chosen.get("exchCode", ""))
     yf_ticker = _build_yfinance_ticker(str(ticker).upper(), exch_code)
     logger.debug(
-        "WKN %s resolved to OpenFIGI ticker %s (exchCode=%s) → yfinance ticker %s",
-        wkn,
+        "%s %s resolved to OpenFIGI ticker %s (exchCode=%s) → yfinance ticker %s",
+        id_type,
+        id_value,
         ticker,
         exch_code,
         yf_ticker,
     )
     return yf_ticker
+
+
+async def resolve_wkn(wkn: str, api_key: str = "") -> str | None:
+    """Return the yfinance ticker for a WKN, or None if it cannot be resolved."""
+    wkn = wkn.strip().upper()
+    if not wkn:
+        return None
+    return await _resolve_via_openfigi("ID_WERTPAPIER", wkn, api_key)
+
+
+async def resolve_isin(isin: str, api_key: str = "") -> str | None:
+    """Return the yfinance ticker for an ISIN, or None if it cannot be resolved."""
+    isin = isin.strip().upper()
+    if not isin:
+        return None
+    return await _resolve_via_openfigi("ID_ISIN", isin, api_key)

--- a/app/services/portfolio_performance_importer.py
+++ b/app/services/portfolio_performance_importer.py
@@ -31,6 +31,7 @@ class SecurityInfo:
     isin: str | None = None
     ticker: str | None = None
     currency: str | None = None
+    asset_type: str | None = None
 
     @property
     def display(self) -> str:

--- a/app/services/transaction_import_service.py
+++ b/app/services/transaction_import_service.py
@@ -136,7 +136,7 @@ class TransactionImportService:
             ticker=ticker,
             name=security.name or ticker,
             currency=(security.currency or "EUR").upper(),
-            asset_type=ASSET_TYPE_STOCK,
+            asset_type=(security.asset_type or ASSET_TYPE_STOCK).upper(),
         )
         db.add(stock)
         await db.flush()

--- a/app/services/xml_security_resolver.py
+++ b/app/services/xml_security_resolver.py
@@ -1,0 +1,155 @@
+"""Resolve each unique XML security to a yfinance-valid ticker.
+
+The Portfolio Performance XML carries ticker strings that Yahoo Finance
+often cannot resolve directly:
+
+* German exchange suffixes such as ``.TG`` (Tradegate) — Yahoo uses
+  ``.DE``/``.SG``/``.F``.
+* Cryptocurrencies as bare symbols (``DOGE``, ``IOTA``) — Yahoo needs
+  ``DOGE-EUR``/``IOTA-EUR``.
+
+This module probes Yahoo Finance for every unique ``SecurityInfo`` and
+returns a ``ResolvedSecurity`` whose ``status`` is either ``valid`` or
+``needs_attention``.  The router then drives the preview UI from that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from app.models.stock import ASSET_TYPE_CRYPTO, ASSET_TYPE_STOCK
+from app.services.openfigi_lookup import resolve_isin
+from app.services.portfolio_performance_importer import SecurityInfo
+from app.services.stock_lookup import fetch_stock_info
+
+Status = Literal["valid", "needs_attention"]
+Source = Literal["xml", "openfigi", "crypto_pair", "manual"]
+
+_CRYPTO_QUOTES: tuple[str, ...] = ("EUR", "USD")
+_CRYPTO_SYMBOL_RE = re.compile(r"^[A-Z0-9]{2,6}$")
+_MAX_CONCURRENT = 8
+
+
+@dataclass(slots=True)
+class ResolvedSecurity:
+    uuid: str
+    original_ticker: str | None
+    original_name: str | None
+    isin: str | None
+    status: Status
+    resolved_ticker: str | None
+    asset_type: str  # ASSET_TYPE_STOCK | ASSET_TYPE_CRYPTO
+    suggestion_source: Source
+    yahoo_name: str | None
+    currency: str | None
+
+    @property
+    def display(self) -> str:
+        parts = [p for p in (self.original_name, self.original_ticker, self.isin) if p]
+        return " · ".join(parts) if parts else self.uuid
+
+
+async def resolve_securities(
+    securities: list[SecurityInfo], *, openfigi_api_key: str = ""
+) -> dict[str, ResolvedSecurity]:
+    """Resolve every security concurrently. Keyed by UUID."""
+    sem = asyncio.Semaphore(_MAX_CONCURRENT)
+
+    async def _one(sec: SecurityInfo) -> tuple[str, ResolvedSecurity]:
+        async with sem:
+            return sec.uuid, await resolve_security(sec, openfigi_api_key=openfigi_api_key)
+
+    pairs = await asyncio.gather(*(_one(s) for s in securities))
+    return dict(pairs)
+
+
+async def resolve_security(
+    security: SecurityInfo, *, openfigi_api_key: str = ""
+) -> ResolvedSecurity:
+    raw_ticker = (security.ticker or "").strip().upper() or None
+
+    # 1) Try the raw XML ticker as-is.
+    if raw_ticker:
+        info = await fetch_stock_info(raw_ticker)
+        if info:
+            return _valid(
+                security,
+                resolved_ticker=raw_ticker,
+                asset_type=ASSET_TYPE_STOCK,
+                source="xml",
+                yahoo_name=info.name,
+                currency=info.currency,
+            )
+
+    # 2) ISIN → OpenFIGI → ticker.
+    if security.isin:
+        candidate = await resolve_isin(security.isin, api_key=openfigi_api_key)
+        if candidate:
+            info = await fetch_stock_info(candidate)
+            if info:
+                return _valid(
+                    security,
+                    resolved_ticker=candidate.upper(),
+                    asset_type=ASSET_TYPE_STOCK,
+                    source="openfigi",
+                    yahoo_name=info.name,
+                    currency=info.currency,
+                )
+
+    # 3) Crypto heuristic — short symbol, no ISIN.
+    if (
+        raw_ticker
+        and not security.isin
+        and _CRYPTO_SYMBOL_RE.match(raw_ticker)
+    ):
+        for quote in _CRYPTO_QUOTES:
+            candidate = f"{raw_ticker}-{quote}"
+            info = await fetch_stock_info(candidate)
+            if info:
+                return _valid(
+                    security,
+                    resolved_ticker=candidate,
+                    asset_type=ASSET_TYPE_CRYPTO,
+                    source="crypto_pair",
+                    yahoo_name=info.name,
+                    currency=info.currency,
+                )
+
+    return ResolvedSecurity(
+        uuid=security.uuid,
+        original_ticker=raw_ticker,
+        original_name=security.name,
+        isin=security.isin,
+        status="needs_attention",
+        resolved_ticker=None,
+        asset_type=ASSET_TYPE_STOCK,
+        suggestion_source="manual",
+        yahoo_name=None,
+        currency=security.currency,
+    )
+
+
+def _valid(
+    security: SecurityInfo,
+    *,
+    resolved_ticker: str,
+    asset_type: str,
+    source: Source,
+    yahoo_name: str,
+    currency: str | None,
+) -> ResolvedSecurity:
+    return ResolvedSecurity(
+        uuid=security.uuid,
+        original_ticker=(security.ticker or "").strip().upper() or None,
+        original_name=security.name,
+        isin=security.isin,
+        status="valid",
+        resolved_ticker=resolved_ticker,
+        asset_type=asset_type,
+        suggestion_source=source,
+        yahoo_name=yahoo_name,
+        currency=currency or security.currency,
+    )

--- a/app/templates/import_xml.html
+++ b/app/templates/import_xml.html
@@ -104,6 +104,39 @@
   </div>
   {% endif %}
 
+  {% if error %}
+  <div class="card anim-fade-slide-down" style="border-color: var(--danger);">
+    <div class="error">{{ error }}</div>
+  </div>
+  {% endif %}
+
+  <div class="card anim-fade-slide-up">
+    <h2>Securities ({{ securities | length }})</h2>
+    <p class="note">
+      Each security in the XML is checked against Yahoo Finance. Rows marked
+      <strong>Needs ticker</strong> require a manual ticker before you can
+      confirm the import (e.g. Tradegate <code>.TG</code> tickers should be
+      replaced with their <code>.DE</code> equivalent; bare crypto symbols
+      need a quote pair like <code>DOGE-EUR</code>).
+    </p>
+    <div style="overflow-x: auto;">
+      <table class="table-striped" id="sec-table">
+        <thead>
+          <tr>
+            <th style="width: 9rem;">Status</th>
+            <th>Original (from XML)</th>
+            <th>Resolved ticker</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for resolution in securities %}
+            {% include "partials/security_row.html" %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
   <div class="card anim-fade-slide-up">
     <h2>Transactions ({{ result.total_count }})</h2>
     {% if result.transactions %}
@@ -164,15 +197,13 @@
       <a href="/import/xml"><button type="button" class="btn-ghost">Upload another file</button></a>
     </div>
 
-    <form method="post" action="/import/xml/confirm" enctype="multipart/form-data"
-          style="margin-top: 1.25rem; padding: 1rem; border-top: 1px solid var(--border);">
+    <div style="margin-top: 1.25rem; padding: 1rem; border-top: 1px solid var(--border);">
       <p class="note" style="margin-bottom: 0.5rem;">
-        Re-select the same file and click <strong>Confirm Import</strong> to persist these transactions.
+        Click <strong>Confirm Import</strong> to persist these transactions.
         Duplicates (by UUID) are skipped automatically.
       </p>
-      <input type="file" name="file" accept=".xml,.zip" required style="margin-bottom: 0.75rem;">
-      <button type="submit" class="btn-primary">Confirm Import</button>
-    </form>
+      {% include "partials/confirm_button.html" %}
+    </div>
   </div>
 
   {% elif step == "done" %}

--- a/app/templates/partials/confirm_button.html
+++ b/app/templates/partials/confirm_button.html
@@ -1,0 +1,17 @@
+{# Confirm form/button — also rendered as an OOB swap from /import/xml/resolve-row. #}
+<form id="confirm-import-form"
+      method="post"
+      action="/import/xml/confirm"
+      {% if oob %}hx-swap-oob="outerHTML"{% endif %}
+      style="margin-top: 1.25rem;">
+  <input type="hidden" name="token" value="{{ token }}">
+  <button type="submit" class="btn-primary"
+          {% if not all_valid %}disabled title="Resolve every security first"{% endif %}>
+    Confirm Import
+  </button>
+  {% if not all_valid %}
+  <span style="color: var(--muted); font-size: 0.85rem; margin-left: 0.6rem;">
+    Resolve all securities to enable import.
+  </span>
+  {% endif %}
+</form>

--- a/app/templates/partials/security_row.html
+++ b/app/templates/partials/security_row.html
@@ -1,0 +1,62 @@
+{% set r = resolution %}
+<tr id="sec-row-{{ r.uuid }}" class="sec-row sec-row--{{ r.status }}"
+    data-status="{{ r.status }}">
+  <td>
+    {% if r.status == "valid" %}
+    <span class="ticker-hint positive"><span class="ticker-hint-dot"></span> Valid</span>
+    {% else %}
+    <span class="ticker-hint negative"><span class="ticker-hint-dot"></span> Needs ticker</span>
+    {% endif %}
+  </td>
+  <td>
+    <div style="display: flex; flex-direction: column; gap: 0.15rem;">
+      <span>{{ r.original_name or "—" }}</span>
+      <span class="text-mono" style="color: var(--muted); font-size: 0.78rem;">
+        XML: {{ r.original_ticker or "—" }}{% if r.isin %} · ISIN {{ r.isin }}{% endif %}
+      </span>
+    </div>
+  </td>
+  <td>
+    {% if r.status == "valid" %}
+      <span class="text-mono">{{ r.resolved_ticker }}</span>
+      {% if r.yahoo_name %}
+      <span style="color: var(--muted); font-size: 0.78rem;"> · {{ r.yahoo_name }}</span>
+      {% endif %}
+      <span class="file-badge" style="margin-left: 0.4rem;">
+        {% if r.suggestion_source == "xml" %}from XML
+        {% elif r.suggestion_source == "openfigi" %}via OpenFIGI
+        {% elif r.suggestion_source == "crypto_pair" %}crypto pair
+        {% else %}manual
+        {% endif %}
+      </span>
+      <span class="file-badge" style="margin-left: 0.25rem;">{{ r.asset_type }}</span>
+    {% else %}
+      <form class="sec-fix-form"
+            hx-post="/import/xml/resolve-row"
+            hx-target="#sec-row-{{ r.uuid }}"
+            hx-swap="outerHTML"
+            style="display: flex; gap: 0.4rem; flex-wrap: wrap; align-items: center;">
+        <input type="hidden" name="token" value="{{ token }}">
+        <input type="hidden" name="uuid" value="{{ r.uuid }}">
+        <input
+          type="text"
+          name="ticker"
+          value="{{ r.resolved_ticker or '' }}"
+          placeholder="e.g. SYK.DE or DOGE-EUR"
+          autocomplete="off"
+          class="input-mono input-glow"
+          style="min-width: 10rem;">
+        <select name="asset_type" class="input-mono">
+          <option value="STOCK" {% if r.asset_type == "STOCK" %}selected{% endif %}>STOCK</option>
+          <option value="CRYPTO" {% if r.asset_type == "CRYPTO" %}selected{% endif %}>CRYPTO</option>
+        </select>
+        <button type="submit" class="btn-ghost">Check</button>
+        {% if r.resolved_ticker %}
+        <span class="ticker-hint negative" style="margin-left: 0.25rem;">
+          <span class="ticker-hint-dot"></span> "{{ r.resolved_ticker }}" not found on Yahoo
+        </span>
+        {% endif %}
+      </form>
+    {% endif %}
+  </td>
+</tr>

--- a/tests/test_import_cache.py
+++ b/tests/test_import_cache.py
@@ -1,0 +1,98 @@
+"""Tests for the XML preview in-memory cache."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from app.services import import_cache
+from app.services.import_cache import ImportPreviewEntry
+from app.services.portfolio_performance_importer import ParseResult
+
+
+def _entry() -> ImportPreviewEntry:
+    return ImportPreviewEntry(
+        parse_result=ParseResult(
+            version="69",
+            base_currency="EUR",
+            transactions=[],
+            securities={},
+        ),
+        resolutions={},
+        filename="x.xml",
+    )
+
+
+def test_store_and_get_returns_same_entry() -> None:
+    entry = _entry()
+    token = import_cache.store(entry)
+    assert import_cache.get(token) is entry
+
+
+def test_get_returns_none_for_unknown_token() -> None:
+    assert import_cache.get("not-a-token") is None
+
+
+def test_delete_removes_entry() -> None:
+    token = import_cache.store(_entry())
+    import_cache.delete(token)
+    assert import_cache.get(token) is None
+
+
+def test_expired_entries_are_evicted_on_read() -> None:
+    token = import_cache.store(_entry())
+    # Fast-forward beyond the 30-min TTL.
+    with patch.object(time, "monotonic", return_value=time.monotonic() + 60 * 60):
+        assert import_cache.get(token) is None
+
+
+def test_update_resolution_refreshes_ttl_and_replaces_entry() -> None:
+    from app.services.xml_security_resolver import ResolvedSecurity
+
+    entry = _entry()
+    entry.resolutions["u1"] = ResolvedSecurity(
+        uuid="u1",
+        original_ticker="X",
+        original_name="X",
+        isin=None,
+        status="needs_attention",
+        resolved_ticker=None,
+        asset_type="STOCK",
+        suggestion_source="manual",
+        yahoo_name=None,
+        currency="EUR",
+    )
+    token = import_cache.store(entry)
+
+    fixed = ResolvedSecurity(
+        uuid="u1",
+        original_ticker="X",
+        original_name="X",
+        isin=None,
+        status="valid",
+        resolved_ticker="X.DE",
+        asset_type="STOCK",
+        suggestion_source="manual",
+        yahoo_name="X AG",
+        currency="EUR",
+    )
+    assert import_cache.update_resolution(token, "u1", fixed) is True
+    assert import_cache.get(token).resolutions["u1"].status == "valid"
+
+
+def test_update_resolution_returns_false_for_unknown_token() -> None:
+    from app.services.xml_security_resolver import ResolvedSecurity
+
+    res = ResolvedSecurity(
+        uuid="x",
+        original_ticker=None,
+        original_name=None,
+        isin=None,
+        status="valid",
+        resolved_ticker="X",
+        asset_type="STOCK",
+        suggestion_source="manual",
+        yahoo_name=None,
+        currency=None,
+    )
+    assert import_cache.update_resolution("missing", "x", res) is False

--- a/tests/test_portfolio_performance_importer.py
+++ b/tests/test_portfolio_performance_importer.py
@@ -308,46 +308,105 @@ def test_parser_finds_transactions_nested_in_crossentry() -> None:
 
 @pytest.mark.asyncio
 async def test_import_xml_post_shows_preview(client: AsyncClient) -> None:
-    response = await client.post(
-        "/import/xml",
-        files={"file": ("portfolio.xml", SAMPLE_XML.encode("utf-8"), "application/xml")},
-    )
-    assert response.status_code == 200
-    assert "File summary" in response.text
-    assert "CBK.DE" in response.text
-    assert "SAP.DE" in response.text
-    assert "DIVIDENDS" in response.text
-    assert "BUY" in response.text
-
-
-@pytest.mark.asyncio
-async def test_import_xml_confirm_persists_transactions(client: AsyncClient) -> None:
-    """POST /import/xml/confirm re-parses the file and calls the import service."""
+    from decimal import Decimal
     from unittest.mock import AsyncMock, patch
 
-    from app.services.transaction_import_service import ImportSummary
+    from app.services.stock_lookup import StockInfo
 
-    summary = ImportSummary(created=3, skipped_existing=0, skipped_unsupported=0)
+    # Both XML tickers resolve cleanly via yfinance.
+    fake_info = StockInfo(
+        ticker="X", name="Mocked", currency="EUR", current_price=Decimal("1")
+    )
     with patch(
-        "app.routers.import_xml._transaction_import.import_xml_result",
-        new=AsyncMock(return_value=summary),
-    ) as mock_import:
+        "app.services.xml_security_resolver.fetch_stock_info",
+        new=AsyncMock(return_value=fake_info),
+    ):
         response = await client.post(
-            "/import/xml/confirm",
+            "/import/xml",
             files={"file": ("portfolio.xml", SAMPLE_XML.encode("utf-8"), "application/xml")},
         )
 
     assert response.status_code == 200
+    assert "File summary" in response.text
+    assert "Securities" in response.text
+    assert "CBK.DE" in response.text
+    assert "SAP.DE" in response.text
+    assert "DIVIDENDS" in response.text
+    assert "BUY" in response.text
+    # Token-based confirm form is rendered.
+    assert 'name="token"' in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_xml_confirm_persists_via_token(client: AsyncClient) -> None:
+    """POST /import/xml/confirm reads the cached parse result via token."""
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.services.stock_lookup import StockInfo
+    from app.services.transaction_import_service import ImportSummary
+
+    fake_info = StockInfo(
+        ticker="X", name="Mocked", currency="EUR", current_price=Decimal("1")
+    )
+    summary = ImportSummary(created=3, skipped_existing=0, skipped_unsupported=0)
+
+    with patch(
+        "app.services.xml_security_resolver.fetch_stock_info",
+        new=AsyncMock(return_value=fake_info),
+    ):
+        preview = await client.post(
+            "/import/xml",
+            files={"file": ("portfolio.xml", SAMPLE_XML.encode("utf-8"), "application/xml")},
+        )
+    token = _extract_token(preview.text)
+    assert token
+
+    with patch(
+        "app.routers.import_xml._transaction_import.import_xml_result",
+        new=AsyncMock(return_value=summary),
+    ) as mock_import:
+        response = await client.post("/import/xml/confirm", data={"token": token})
+
+    assert response.status_code == 200
     assert "Import complete" in response.text
-    assert "3" in response.text
     assert mock_import.await_count == 1
 
 
 @pytest.mark.asyncio
-async def test_import_xml_confirm_rejects_bad_filename(client: AsyncClient) -> None:
-    response = await client.post(
-        "/import/xml/confirm",
-        files={"file": ("report.txt", b"hello", "text/plain")},
-    )
+async def test_import_xml_confirm_refuses_when_unresolved(client: AsyncClient) -> None:
+    """Confirm rerenders the preview with an error when any row is unresolved."""
+    from unittest.mock import AsyncMock, patch
+
+    with patch(
+        "app.services.xml_security_resolver.fetch_stock_info",
+        new=AsyncMock(return_value=None),  # every lookup fails → all needs_attention
+    ), patch(
+        "app.services.xml_security_resolver.resolve_isin",
+        new=AsyncMock(return_value=None),
+    ):
+        preview = await client.post(
+            "/import/xml",
+            files={"file": ("portfolio.xml", SAMPLE_XML.encode("utf-8"), "application/xml")},
+        )
+    token = _extract_token(preview.text)
+    assert token
+
+    response = await client.post("/import/xml/confirm", data={"token": token})
     assert response.status_code == 200
-    assert ".xml or .zip" in response.text
+    assert "Resolve every security" in response.text
+
+
+@pytest.mark.asyncio
+async def test_import_xml_confirm_rejects_unknown_token(client: AsyncClient) -> None:
+    response = await client.post("/import/xml/confirm", data={"token": "garbage"})
+    assert response.status_code == 200
+    assert "expired" in response.text.lower()
+
+
+def _extract_token(html: str) -> str | None:
+    """Pull the hidden token field out of the confirm form."""
+    import re
+
+    m = re.search(r'name="token"\s+value="([^"]+)"', html)
+    return m.group(1) if m else None

--- a/tests/test_transaction_import_service.py
+++ b/tests/test_transaction_import_service.py
@@ -239,6 +239,31 @@ async def test_buy_without_security_is_skipped() -> None:
     assert summary.skipped_unsupported == 1
 
 
+@pytest.mark.asyncio
+async def test_asset_type_from_security_is_propagated_to_stock() -> None:
+    """When SecurityInfo.asset_type is CRYPTO, the new Stock row must reflect it."""
+    db = _make_db()
+    crypto_sec = SecurityInfo(
+        uuid="sec-crypto",
+        name="Dogecoin EUR",
+        isin=None,
+        ticker="DOGE-EUR",
+        currency="EUR",
+        asset_type="CRYPTO",
+    )
+    tx = _tx(uuid="buy-doge", type="BUY", security=crypto_sec)
+
+    await TransactionImportService().import_xml_result(_result([tx]), db)
+
+    inserted_stocks = [
+        call.args[0]
+        for call in db.add.call_args_list
+        if call.args[0].__class__.__name__ == "Stock"
+    ]
+    assert len(inserted_stocks) == 1
+    assert inserted_stocks[0].asset_type == "CRYPTO"
+
+
 # ---------------------------------------------------------------------------
 # Idempotency on re-import — service-level integration with the parser
 # ---------------------------------------------------------------------------

--- a/tests/test_xml_security_resolver.py
+++ b/tests/test_xml_security_resolver.py
@@ -1,0 +1,127 @@
+"""Tests for the XML security resolver — verifies the 4-step fallback chain."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.portfolio_performance_importer import SecurityInfo
+from app.services.stock_lookup import StockInfo
+from app.services.xml_security_resolver import (
+    resolve_securities,
+    resolve_security,
+)
+
+
+def _info(name: str = "Stock", currency: str = "EUR") -> StockInfo:
+    return StockInfo(ticker="T", name=name, currency=currency, current_price=Decimal("1"))
+
+
+def _security(**overrides):  # type: ignore[no-untyped-def]
+    base = dict(uuid="u", name="X", isin="DE0001", ticker="X", currency="EUR")
+    base.update(overrides)
+    return SecurityInfo(**base)
+
+
+@pytest.mark.asyncio
+async def test_resolves_via_raw_xml_ticker_when_yahoo_knows_it() -> None:
+    sec = _security(ticker="SAP.DE")
+    with patch(
+        "app.services.xml_security_resolver.fetch_stock_info",
+        new=AsyncMock(side_effect=[_info("SAP SE")]),
+    ) as mock_fetch:
+        result = await resolve_security(sec)
+
+    assert result.status == "valid"
+    assert result.suggestion_source == "xml"
+    assert result.resolved_ticker == "SAP.DE"
+    assert result.asset_type == "STOCK"
+    assert mock_fetch.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_openfigi_when_raw_ticker_unknown() -> None:
+    sec = _security(ticker="SYK.TG", isin="US58933Y1055")
+    with (
+        patch(
+            "app.services.xml_security_resolver.fetch_stock_info",
+            new=AsyncMock(side_effect=[None, _info("Stryker Corp")]),
+        ),
+        patch(
+            "app.services.xml_security_resolver.resolve_isin",
+            new=AsyncMock(return_value="SYK"),
+        ) as mock_isin,
+    ):
+        result = await resolve_security(sec, openfigi_api_key="k")
+
+    assert result.status == "valid"
+    assert result.suggestion_source == "openfigi"
+    assert result.resolved_ticker == "SYK"
+    mock_isin.assert_awaited_once_with("US58933Y1055", api_key="k")
+
+
+@pytest.mark.asyncio
+async def test_crypto_pair_heuristic_for_short_symbol_without_isin() -> None:
+    sec = _security(ticker="DOGE", isin=None)
+    with patch(
+        "app.services.xml_security_resolver.fetch_stock_info",
+        new=AsyncMock(side_effect=[None, _info("Dogecoin EUR", currency="EUR")]),
+    ):
+        result = await resolve_security(sec)
+
+    assert result.status == "valid"
+    assert result.suggestion_source == "crypto_pair"
+    assert result.resolved_ticker == "DOGE-EUR"
+    assert result.asset_type == "CRYPTO"
+
+
+@pytest.mark.asyncio
+async def test_crypto_tries_usd_when_eur_pair_unknown() -> None:
+    sec = _security(ticker="IOTA", isin=None)
+    with patch(
+        "app.services.xml_security_resolver.fetch_stock_info",
+        new=AsyncMock(
+            side_effect=[None, None, _info("IOTA USD", currency="USD")]
+        ),
+    ):
+        result = await resolve_security(sec)
+
+    assert result.status == "valid"
+    assert result.resolved_ticker == "IOTA-USD"
+    assert result.asset_type == "CRYPTO"
+
+
+@pytest.mark.asyncio
+async def test_marks_needs_attention_when_everything_fails() -> None:
+    sec = _security(ticker="ZZZ.UNKNOWN", isin="DE0000000000")
+    with (
+        patch(
+            "app.services.xml_security_resolver.fetch_stock_info",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.xml_security_resolver.resolve_isin",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await resolve_security(sec)
+
+    assert result.status == "needs_attention"
+    assert result.resolved_ticker is None
+    assert result.suggestion_source == "manual"
+
+
+@pytest.mark.asyncio
+async def test_resolve_securities_runs_in_parallel_and_keys_by_uuid() -> None:
+    secs = [_security(uuid="a", ticker="AAA"), _security(uuid="b", ticker="BBB")]
+    with patch(
+        "app.services.xml_security_resolver.fetch_stock_info",
+        new=AsyncMock(side_effect=[_info("A"), _info("B")]),
+    ):
+        out = await resolve_securities(secs)
+
+    assert set(out.keys()) == {"a", "b"}
+    assert out["a"].status == "valid"
+    assert out["b"].status == "valid"


### PR DESCRIPTION
## Summary
- Resolve every XML security against Yahoo Finance at preview time (4-step fallback: raw ticker → ISIN/OpenFIGI → crypto pair → manual)
- New Securities card in the preview UI with inline per-row ticker override; Confirm Import disabled until every row is valid
- Confirm step now uses a server-side cache token (30-min TTL) instead of a re-upload, and propagates the resolved `asset_type` (STOCK/CRYPTO) onto the created Stock row

Fixes the silent skip behaviour reported in #101 — Tradegate (`.TG`) tickers and bare crypto symbols (`DOGE`, `IOTA`) were created as Stocks and only failed downstream in the price-refresh job.

## Test plan
- [x] Unit tests for `xml_security_resolver` (all four resolution branches) and `import_cache` (TTL + update)
- [x] Updated end-to-end import tests cover token-based confirm, refusal when any row is unresolved, and asset_type propagation
- [x] Full suite passes (160 tests)
- [x] Manual smoke test in Docker with a fixture XML containing SAP.DE (XML), SYK.TG (OpenFIGI → SYK.DE), DOGE (crypto pair → DOGE-EUR), NOPE.ZZ (needs_attention); manual override of NOPE.ZZ to AAPL via `/import/xml/resolve-row` flipped the row to valid and OOB-swapped the Confirm button into the enabled state

🤖 Generated with [Claude Code](https://claude.com/claude-code)