### PR TITLE
Add admin button to clear XML-imported transactions

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.services.import_cleanup import clear_xml_imports
 
 router = APIRouter(prefix="/admin", tags=["admin"])
+
+_DB = Depends(get_async_session)
 
 
 @router.post("/trigger-report", status_code=200)
@@ -42,3 +49,16 @@ async def refresh_prices(response: Response) -> dict[str, str]:
 
     response.headers["HX-Refresh"] = "true"
     return {"status": "ok", "message": "Price cache and FX rates refreshed."}
+
+
+@router.post("/clear-xml-import", response_class=HTMLResponse)
+async def clear_xml_import(db: AsyncSession = _DB) -> HTMLResponse:
+    """Delete every transaction imported from XML, plus any orphaned stocks."""
+    summary = await clear_xml_imports(db)
+    return HTMLResponse(
+        f'<div class="ticker-hint positive" style="margin-top: 0.75rem;">'
+        f'<span class="ticker-hint-dot"></span> '
+        f"Cleared {summary.deleted_transactions} XML transaction(s) and "
+        f"{summary.deleted_stocks} orphaned stock(s)."
+        f"</div>"
+    )

--- a/app/services/import_cleanup.py
+++ b/app/services/import_cleanup.py
@@ -1,0 +1,57 @@
+"""Delete every transaction (and orphan stock) that came from an XML import.
+
+Intended for the "Clear XML-imported data" admin button on the import page —
+lets the user wipe a botched import without touching manual or PDF-sourced
+rows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import delete, exists, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.stock import Stock
+from app.models.transaction import TX_SOURCE_XML, Transaction
+from app.services.holdings_service import recompute_holdings
+
+
+@dataclass(slots=True)
+class CleanupSummary:
+    deleted_transactions: int
+    deleted_stocks: int
+
+
+async def clear_xml_imports(db: AsyncSession) -> CleanupSummary:
+    """Delete XML transactions, recompute affected holdings, drop orphan stocks."""
+    affected_ids_result = await db.execute(
+        select(Transaction.stock_id)
+        .where(Transaction.source == TX_SOURCE_XML)
+        .where(Transaction.stock_id.is_not(None))
+        .distinct()
+    )
+    affected_stock_ids: set[int] = {row[0] for row in affected_ids_result.all()}
+
+    deleted_tx_result = await db.execute(
+        delete(Transaction).where(Transaction.source == TX_SOURCE_XML)
+    )
+    deleted_transactions = deleted_tx_result.rowcount or 0
+
+    deleted_stocks = 0
+    if affected_stock_ids:
+        await recompute_holdings(db, affected_stock_ids)
+
+        orphan_filter = ~exists().where(Transaction.stock_id == Stock.id)
+        deleted_stock_result = await db.execute(
+            delete(Stock)
+            .where(Stock.id.in_(affected_stock_ids))
+            .where(orphan_filter)
+        )
+        deleted_stocks = deleted_stock_result.rowcount or 0
+
+    await db.flush()
+    return CleanupSummary(
+        deleted_transactions=deleted_transactions,
+        deleted_stocks=deleted_stocks,
+    )

--- a/app/services/import_cleanup.py
+++ b/app/services/import_cleanup.py
@@ -8,8 +8,9 @@ rows.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
-from sqlalchemy import delete, exists, select
+from sqlalchemy import CursorResult, delete, exists, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.stock import Stock
@@ -33,8 +34,9 @@ async def clear_xml_imports(db: AsyncSession) -> CleanupSummary:
     )
     affected_stock_ids: set[int] = {row[0] for row in affected_ids_result.all()}
 
-    deleted_tx_result = await db.execute(
-        delete(Transaction).where(Transaction.source == TX_SOURCE_XML)
+    deleted_tx_result = cast(
+        CursorResult[object],
+        await db.execute(delete(Transaction).where(Transaction.source == TX_SOURCE_XML)),
     )
     deleted_transactions = deleted_tx_result.rowcount or 0
 
@@ -43,10 +45,13 @@ async def clear_xml_imports(db: AsyncSession) -> CleanupSummary:
         await recompute_holdings(db, affected_stock_ids)
 
         orphan_filter = ~exists().where(Transaction.stock_id == Stock.id)
-        deleted_stock_result = await db.execute(
-            delete(Stock)
-            .where(Stock.id.in_(affected_stock_ids))
-            .where(orphan_filter)
+        deleted_stock_result = cast(
+            CursorResult[object],
+            await db.execute(
+                delete(Stock)
+                .where(Stock.id.in_(affected_stock_ids))
+                .where(orphan_filter)
+            ),
         )
         deleted_stocks = deleted_stock_result.rowcount or 0
 

--- a/app/templates/import_xml.html
+++ b/app/templates/import_xml.html
@@ -50,6 +50,25 @@
     </form>
   </div>
 
+  <div class="card" style="border-color: var(--danger); margin-top: 1.25rem;">
+    <h2 style="color: var(--danger);">Danger zone</h2>
+    <p class="note">
+      Deletes every transaction that was imported from XML, plus any stocks
+      that no longer have transactions after the cleanup. Manual and PDF
+      transactions are untouched.
+    </p>
+    <button
+      type="button"
+      class="btn-ghost"
+      hx-post="/admin/clear-xml-import"
+      hx-target="#clear-xml-result"
+      hx-swap="innerHTML"
+      hx-confirm="Delete all XML-imported transactions and their orphan stocks? This cannot be undone.">
+      Clear XML-imported data
+    </button>
+    <div id="clear-xml-result"></div>
+  </div>
+
   {% elif step == "preview" %}
   <div class="summary-card anim-fade-slide-down">
     <h2>File summary</h2>

--- a/tests/test_import_cleanup.py
+++ b/tests/test_import_cleanup.py
@@ -1,0 +1,86 @@
+"""Tests for the clear-xml-import admin flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.services.import_cleanup import CleanupSummary, clear_xml_imports
+
+
+def _result(rowcount: int = 0, rows: list | None = None) -> MagicMock:
+    result = MagicMock()
+    result.rowcount = rowcount
+    result.all.return_value = rows or []
+    return result
+
+
+@pytest.mark.asyncio
+async def test_clear_xml_imports_returns_counts_and_recomputes_holdings() -> None:
+    """Service deletes XML tx, runs recompute_holdings, drops orphan stocks."""
+    db = MagicMock()
+
+    # 1) select(stock_id distinct) → two affected stocks
+    # 2) delete(Transaction) → 5 rows deleted
+    # 3) delete(Stock) → 2 orphans deleted
+    db.execute = AsyncMock(
+        side_effect=[
+            _result(rows=[(10,), (20,)]),
+            _result(rowcount=5),
+            _result(rowcount=2),
+        ]
+    )
+    db.flush = AsyncMock()
+
+    with patch(
+        "app.services.import_cleanup.recompute_holdings",
+        new=AsyncMock(),
+    ) as mock_recompute:
+        summary = await clear_xml_imports(db)
+
+    assert summary == CleanupSummary(deleted_transactions=5, deleted_stocks=2)
+    mock_recompute.assert_awaited_once()
+    args, _ = mock_recompute.call_args
+    assert args[0] is db
+    assert args[1] == {10, 20}
+    db.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_clear_xml_imports_noop_when_no_xml_transactions() -> None:
+    db = MagicMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            _result(rows=[]),       # no affected stocks
+            _result(rowcount=0),    # no transactions to delete
+        ]
+    )
+    db.flush = AsyncMock()
+
+    with patch(
+        "app.services.import_cleanup.recompute_holdings",
+        new=AsyncMock(),
+    ) as mock_recompute:
+        summary = await clear_xml_imports(db)
+
+    assert summary.deleted_transactions == 0
+    assert summary.deleted_stocks == 0
+    mock_recompute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_admin_clear_xml_endpoint_returns_summary_fragment(
+    client: AsyncClient,
+) -> None:
+    """POST /admin/clear-xml-import returns an HTMX fragment with the counts."""
+    with patch(
+        "app.routers.admin.clear_xml_imports",
+        new=AsyncMock(return_value=CleanupSummary(deleted_transactions=7, deleted_stocks=3)),
+    ):
+        response = await client.post("/admin/clear-xml-import")
+
+    assert response.status_code == 200
+    assert "Cleared 7 XML transaction" in response.text
+    assert "3 orphaned stock" in response.text


### PR DESCRIPTION
## Summary
- `POST /admin/clear-xml-import` deletes every `Transaction` row with `source='XML'`, recomputes holdings for the affected stocks, and drops any stock rows that no longer have transactions
- Manual and PDF transactions are untouched
- New "Danger zone" card on the `/import/xml` upload step with an HTMX button (`hx-confirm` for safety) that calls the endpoint and renders the cleanup counts inline

Branched directly off `master` — independent of #102, so the two PRs can land in either order.

## Test plan
- [x] Unit tests for `clear_xml_imports` (with and without affected rows) + route-level fragment test
- [x] Full suite passes (149 tests)
- [x] Smoke-tested in Docker: button appears on `/import/xml`, POST returns the success fragment ("Cleared N XML transaction(s) and M orphaned stock(s).")

🤖 Generated with [Claude Code](https://claude.com/claude-code)