### PR TITLE
fix(logging): configure root logger so app.* INFO logs are emitted

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -91,6 +91,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     """
     cfg = settings or get_settings()
 
+    # Uvicorn's default LOGGING_CONFIG only wires handlers onto the `uvicorn.*`
+    # loggers, leaving the root logger handler-less. Without this, every
+    # `logger.info(...)` in `app.*` modules is dropped at the WARNING fallback.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+    )
+    # SQLAlchemy's echo=True attaches its own handler; stop propagation so
+    # statements aren't printed twice once a root handler exists.
+    logging.getLogger("sqlalchemy.engine").propagate = False
+
     app = FastAPI(
         title="Stock Portfolio Tracker",
         description=(


### PR DESCRIPTION
## Summary
- Uvicorn's default `LOGGING_CONFIG` only wires handlers onto `uvicorn.*` loggers, leaving the root logger handler-less — so every `logger.info(...)` from `app.*` modules (including the per-transaction skip reasons added in #104) was silently dropped at Python's default WARNING fallback.
- Call `logging.basicConfig(level=INFO, format=...)` in `create_app()` to install a root handler.
- Set `propagate=False` on `sqlalchemy.engine` so its `echo=True` output isn't printed twice now that root has a handler.

## Test plan
- [x] Rebuild container and confirm app-level logs now appear (`app.services.fx_service - FX cache warmed...`, `app.scheduler - Price cache refresh...`).
- [x] Confirm SQLAlchemy statements appear exactly once.
- [ ] Re-run XML import in the UI and confirm one `Skipped XML transaction ...` line is emitted per skipped entry, plus the final `XML import done: ...` summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)