### PR TITLE
fix(xml-import): classify crypto from Yahoo quoteType

### DIFF
--- a/app/services/stock_lookup.py
+++ b/app/services/stock_lookup.py
@@ -14,6 +14,7 @@ class StockInfo:
     name: str
     currency: str
     current_price: Decimal | None
+    quote_type: str | None = None
 
 
 def _fetch_stock_info_sync(ticker: str) -> StockInfo | None:
@@ -31,12 +32,15 @@ def _fetch_stock_info_sync(ticker: str) -> StockInfo | None:
     currency = info.get("currency") or "USD"
     price_raw = info.get("currentPrice") or info.get("regularMarketPrice")
     current_price = Decimal(str(price_raw)) if price_raw is not None else None
+    quote_type_raw = info.get("quoteType")
+    quote_type = str(quote_type_raw).upper() if quote_type_raw else None
 
     return StockInfo(
         ticker=ticker.upper(),
         name=name,
         currency=currency,
         current_price=current_price,
+        quote_type=quote_type,
     )
 
 

--- a/app/services/xml_security_resolver.py
+++ b/app/services/xml_security_resolver.py
@@ -33,6 +33,10 @@ _CRYPTO_SYMBOL_RE = re.compile(r"^[A-Z0-9]{2,6}$")
 _MAX_CONCURRENT = 8
 
 
+def _asset_type_from_quote(qt: str | None) -> str:
+    return ASSET_TYPE_CRYPTO if (qt or "").upper() == "CRYPTOCURRENCY" else ASSET_TYPE_STOCK
+
+
 @dataclass(slots=True)
 class ResolvedSecurity:
     uuid: str
@@ -78,7 +82,7 @@ async def resolve_security(
             return _valid(
                 security,
                 resolved_ticker=raw_ticker,
-                asset_type=ASSET_TYPE_STOCK,
+                asset_type=_asset_type_from_quote(info.quote_type),
                 source="xml",
                 yahoo_name=info.name,
                 currency=info.currency,
@@ -93,7 +97,7 @@ async def resolve_security(
                 return _valid(
                     security,
                     resolved_ticker=candidate.upper(),
-                    asset_type=ASSET_TYPE_STOCK,
+                    asset_type=_asset_type_from_quote(info.quote_type),
                     source="openfigi",
                     yahoo_name=info.name,
                     currency=info.currency,
@@ -112,7 +116,7 @@ async def resolve_security(
                 return _valid(
                     security,
                     resolved_ticker=candidate,
-                    asset_type=ASSET_TYPE_CRYPTO,
+                    asset_type=_asset_type_from_quote(info.quote_type),
                     source="crypto_pair",
                     yahoo_name=info.name,
                     currency=info.currency,

--- a/app/templates/partials/security_row.html
+++ b/app/templates/partials/security_row.html
@@ -18,18 +18,31 @@
   </td>
   <td>
     {% if r.status == "valid" %}
-      <span class="text-mono">{{ r.resolved_ticker }}</span>
-      {% if r.yahoo_name %}
-      <span style="color: var(--muted); font-size: 0.78rem;"> · {{ r.yahoo_name }}</span>
-      {% endif %}
-      <span class="file-badge" style="margin-left: 0.4rem;">
-        {% if r.suggestion_source == "xml" %}from XML
-        {% elif r.suggestion_source == "openfigi" %}via OpenFIGI
-        {% elif r.suggestion_source == "crypto_pair" %}crypto pair
-        {% else %}manual
+      <form class="sec-fix-form"
+            hx-post="/import/xml/resolve-row"
+            hx-target="#sec-row-{{ r.uuid }}"
+            hx-swap="outerHTML"
+            hx-trigger="change from:find select"
+            style="display: flex; gap: 0.4rem; flex-wrap: wrap; align-items: center;">
+        <input type="hidden" name="token" value="{{ token }}">
+        <input type="hidden" name="uuid" value="{{ r.uuid }}">
+        <input type="hidden" name="ticker" value="{{ r.resolved_ticker }}">
+        <span class="text-mono">{{ r.resolved_ticker }}</span>
+        {% if r.yahoo_name %}
+        <span style="color: var(--muted); font-size: 0.78rem;"> · {{ r.yahoo_name }}</span>
         {% endif %}
-      </span>
-      <span class="file-badge" style="margin-left: 0.25rem;">{{ r.asset_type }}</span>
+        <span class="file-badge" style="margin-left: 0.4rem;">
+          {% if r.suggestion_source == "xml" %}from XML
+          {% elif r.suggestion_source == "openfigi" %}via OpenFIGI
+          {% elif r.suggestion_source == "crypto_pair" %}crypto pair
+          {% else %}manual
+          {% endif %}
+        </span>
+        <select name="asset_type" class="input-mono" style="margin-left: 0.25rem;">
+          <option value="STOCK" {% if r.asset_type == "STOCK" %}selected{% endif %}>STOCK</option>
+          <option value="CRYPTO" {% if r.asset_type == "CRYPTO" %}selected{% endif %}>CRYPTO</option>
+        </select>
+      </form>
     {% else %}
       <form class="sec-fix-form"
             hx-post="/import/xml/resolve-row"

--- a/tests/test_xml_security_resolver.py
+++ b/tests/test_xml_security_resolver.py
@@ -15,8 +15,18 @@ from app.services.xml_security_resolver import (
 )
 
 
-def _info(name: str = "Stock", currency: str = "EUR") -> StockInfo:
-    return StockInfo(ticker="T", name=name, currency=currency, current_price=Decimal("1"))
+def _info(
+    name: str = "Stock",
+    currency: str = "EUR",
+    quote_type: str | None = "EQUITY",
+) -> StockInfo:
+    return StockInfo(
+        ticker="T",
+        name=name,
+        currency=currency,
+        current_price=Decimal("1"),
+        quote_type=quote_type,
+    )
 
 
 def _security(**overrides):  # type: ignore[no-untyped-def]
@@ -67,7 +77,12 @@ async def test_crypto_pair_heuristic_for_short_symbol_without_isin() -> None:
     sec = _security(ticker="DOGE", isin=None)
     with patch(
         "app.services.xml_security_resolver.fetch_stock_info",
-        new=AsyncMock(side_effect=[None, _info("Dogecoin EUR", currency="EUR")]),
+        new=AsyncMock(
+            side_effect=[
+                None,
+                _info("Dogecoin EUR", currency="EUR", quote_type="CRYPTOCURRENCY"),
+            ]
+        ),
     ):
         result = await resolve_security(sec)
 
@@ -83,7 +98,11 @@ async def test_crypto_tries_usd_when_eur_pair_unknown() -> None:
     with patch(
         "app.services.xml_security_resolver.fetch_stock_info",
         new=AsyncMock(
-            side_effect=[None, None, _info("IOTA USD", currency="USD")]
+            side_effect=[
+                None,
+                None,
+                _info("IOTA USD", currency="USD", quote_type="CRYPTOCURRENCY"),
+            ]
         ),
     ):
         result = await resolve_security(sec)
@@ -91,6 +110,48 @@ async def test_crypto_tries_usd_when_eur_pair_unknown() -> None:
     assert result.status == "valid"
     assert result.resolved_ticker == "IOTA-USD"
     assert result.asset_type == "CRYPTO"
+
+
+@pytest.mark.asyncio
+async def test_raw_ticker_marked_crypto_when_yahoo_says_cryptocurrency() -> None:
+    """BTC-EUR resolves via Step 1 but Yahoo's quoteType drives the classification."""
+    sec = _security(ticker="BTC-EUR", isin=None)
+    with patch(
+        "app.services.xml_security_resolver.fetch_stock_info",
+        new=AsyncMock(
+            side_effect=[_info("Bitcoin EUR", quote_type="CRYPTOCURRENCY")]
+        ),
+    ):
+        result = await resolve_security(sec)
+
+    assert result.status == "valid"
+    assert result.suggestion_source == "xml"
+    assert result.resolved_ticker == "BTC-EUR"
+    assert result.asset_type == "CRYPTO"
+
+
+@pytest.mark.asyncio
+async def test_openfigi_resolved_etp_stays_stock() -> None:
+    """A crypto ETP resolved via OpenFIGI has quoteType=EQUITY → STOCK."""
+    sec = _security(ticker=None, isin="DE000A27Z304")
+    with (
+        patch(
+            "app.services.xml_security_resolver.fetch_stock_info",
+            new=AsyncMock(
+                side_effect=[_info("BTCetc Physical Bitcoin", quote_type="EQUITY")]
+            ),
+        ),
+        patch(
+            "app.services.xml_security_resolver.resolve_isin",
+            new=AsyncMock(return_value="BTCE.DE"),
+        ),
+    ):
+        result = await resolve_security(sec, openfigi_api_key="k")
+
+    assert result.status == "valid"
+    assert result.suggestion_source == "openfigi"
+    assert result.resolved_ticker == "BTCE.DE"
+    assert result.asset_type == "STOCK"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Bitcoin imports were misclassified as `STOCK` because the resolver picked `asset_type` based on **which branch fired first**, not on what Yahoo Finance said about the security. A direct ticker like `BTC-EUR` would hit Step 1 and be hardcoded as `STOCK` regardless of its actual nature.
- Surface `quoteType` from yfinance on `StockInfo` and replace the per-branch hardcodes in `xml_security_resolver.py` with a single mapping: `quoteType == "CRYPTOCURRENCY"` → `CRYPTO`, otherwise `STOCK`. The 4-step probing chain stays — only the classification source changes.
- Widen the preview UI's `STOCK | CRYPTO` toggle to valid rows too, so misclassifications can be corrected before confirm. The existing `/xml/resolve-row` endpoint already accepts the new `asset_type`; no router or DB changes needed.
- Bitcoin ETPs (e.g. BTCetc `DE000A27Z304`) intentionally stay as `STOCK` — they are equity wrappers. Users can flip them to `CRYPTO` per-row in the preview if they want.

## Test plan

- [x] `pytest tests/test_xml_security_resolver.py tests/test_transaction_import_service.py` — 17 passed
- [x] Full suite — 165 passed
- [x] `mypy app` — clean
- [ ] Upload a Portfolio Performance XML in the browser containing `BTC-EUR`, a Bitcoin ETP, and a regular equity → confirm preview shows `CRYPTO`, `STOCK`, `STOCK` respectively, toggle visible on all three rows
- [ ] Flip ETP to `CRYPTO` in the preview, confirm, verify `finance.stock.asset_type='CRYPTO'` for that ISIN

🤖 Generated with [Claude Code](https://claude.com/claude-code)