### PR TITLE
fix(xml-import): wrap OOB confirm form in <template> to survive table parsing

### DIFF
--- a/app/templates/partials/confirm_button.html
+++ b/app/templates/partials/confirm_button.html
@@ -1,4 +1,8 @@
-{# Confirm form/button — also rendered as an OOB swap from /import/xml/resolve-row. #}
+{# Confirm form/button — also rendered as an OOB swap from /import/xml/resolve-row.
+   When rendered OOB, the response is parsed in a <tbody> context (the main swap
+   target is a <tr>), which mangles a sibling <form>. Wrapping in <template>
+   lets htmx extract the form unharmed and perform the outerHTML OOB swap. #}
+{% if oob %}<template>{% endif %}
 <form id="confirm-import-form"
       method="post"
       action="/import/xml/confirm"
@@ -15,3 +19,4 @@
   </span>
   {% endif %}
 </form>
+{% if oob %}</template>{% endif %}


### PR DESCRIPTION
## Summary

- PR #106 added a STOCK/CRYPTO toggle to **valid** preview rows. Changing it fires an HTMX request whose response includes the new `<tr>` plus an OOB swap of the bottom *Confirm Import* button.
- Because the swap target is a `<tr>`, htmx parses the response fragment in a `<tbody>` context. The HTML parser mangles the sibling `<form>`, so the OOB swap never landed: a stray "Confirm Import" button appeared **inside the changed row**, clicking it did nothing, and the real bottom button never updated its `disabled` state.
- Fix: wrap the OOB `<form id="confirm-import-form">` in a `<template>` tag. htmx 2.x extracts elements out of `<template>` regardless of surrounding parser context, so the OOB swap of the bottom button now succeeds. The non-OOB page-load render (`oob=False`) stays unwrapped.

## Test plan

- [ ] `docker compose up -d --build app`, open `/import/xml`, upload a Portfolio Performance XML.
- [ ] On a valid row, toggle STOCK ↔ CRYPTO: no duplicate Confirm Import button appears under the row.
- [ ] If the toggled lookup succeeds, the row stays valid and the bottom button stays enabled.
- [ ] If the toggled lookup fails (e.g. STOCK → CRYPTO on a stock-only ticker), the row flips to *Needs ticker* and the bottom Confirm Import button becomes `disabled` with the "Resolve all securities to enable import." hint.
- [ ] With all rows valid, clicking the bottom Confirm Import button submits successfully and reaches the *Import complete* step.
- [ ] Regression: on a *Needs ticker* row, type a ticker and click **Check** — no duplicate button, bottom button updates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)