### PR TITLE
fix(xml-import): parse buy/sell legs serialised inline in crossEntry

### DIFF
--- a/app/services/portfolio_performance_importer.py
+++ b/app/services/portfolio_performance_importer.py
@@ -237,9 +237,20 @@ class PortfolioPerformanceImporter:
         out: list[ParsedTransaction] = []
         seen: set[str] = set()
 
+        # A buy/sell pairs a portfolio-leg with an account-leg.  XStream writes
+        # whichever leg it reaches first as a full object under its natural
+        # collection using the hyphenated alias (``portfolio-transaction`` /
+        # ``account-transaction``); the paired leg is serialised inline inside
+        # the <crossEntry> using the camelCase BuySellEntry field name
+        # (``portfolioTransaction`` / ``accountTransaction``).  We must walk
+        # both spellings or we silently drop every leg that happens to be the
+        # inline one — e.g. a BUY whose account-leg sorts first leaves its
+        # portfolio-leg (with the share count) only as <portfolioTransaction>.
         for tag, kind in (
             ("portfolio-transaction", "portfolio"),
+            ("portfolioTransaction", "portfolio"),
             ("account-transaction", "account"),
+            ("accountTransaction", "account"),
         ):
             for tx_el in root.iter(tag):
                 if tx_el.get("reference"):

--- a/app/services/transaction_import_service.py
+++ b/app/services/transaction_import_service.py
@@ -90,7 +90,8 @@ class TransactionImportService:
         if mapped_type in {"BUY", "SELL"} and tx.kind != "portfolio":
             summary.skipped_unsupported += 1
             logger.info(
-                "Skipped XML transaction %s — %s account-leg (paired with a portfolio entry, security=%s)",
+                "Skipped XML transaction %s — %s account-leg "
+                "(paired with a portfolio entry, security=%s)",
                 tx.uuid or "?",
                 mapped_type,
                 _describe_security(tx.security),
@@ -128,7 +129,8 @@ class TransactionImportService:
             elif not (tx.security.ticker or "").strip():
                 reason = (
                     f"security has no ticker symbol "
-                    f"(uuid={tx.security.uuid}, name={tx.security.name!r}, isin={tx.security.isin!r})"
+                    f"(uuid={tx.security.uuid}, name={tx.security.name!r}, "
+                    f"isin={tx.security.isin!r})"
                 )
             else:
                 reason = "stock upsert failed"

--- a/tests/test_portfolio_performance_importer.py
+++ b/tests/test_portfolio_performance_importer.py
@@ -306,6 +306,90 @@ def test_parser_finds_transactions_nested_in_crossentry() -> None:
     assert result.total_count == 3  # port-tx-1 (BUY), acct-tx-1 (BUY), acct-tx-2 (DEPOSIT)
 
 
+def test_parser_finds_portfolio_leg_inline_as_crossentry_field() -> None:
+    """When the account-leg sorts first, the portfolio-leg is serialised inline
+    inside <crossEntry> using the camelCase field name <portfolioTransaction>
+    (not the hyphenated <portfolio-transaction> alias).  The parser must still
+    find it, otherwise the position (and its share count) is dropped and only
+    the cash-side account-leg survives — which the importer then skips."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<client>
+  <version>69</version>
+  <baseCurrency>EUR</baseCurrency>
+  <securities>
+    <security>
+      <uuid>sec-eth</uuid>
+      <name>Ethereum</name>
+      <currencyCode>EUR</currencyCode>
+      <tickerSymbol>ETH</tickerSymbol>
+    </security>
+  </securities>
+  <accounts>
+    <account>
+      <uuid>acc-1</uuid>
+      <name>Cash</name>
+      <currencyCode>EUR</currencyCode>
+      <transactions>
+        <!-- Account-leg serialised first → full hyphenated element. -->
+        <account-transaction>
+          <uuid>acct-eth-1</uuid>
+          <date>2025-02-19T00:00</date>
+          <currencyCode>EUR</currencyCode>
+          <amount>50000</amount>
+          <security reference="../../../../../securities/security"/>
+          <shares>0</shares>
+          <crossEntry class="buysell">
+            <portfolio>
+              <uuid>port-1</uuid>
+              <name>Crypto</name>
+              <referenceAccount reference="../../../../.."/>
+              <transactions>
+                <!-- portfolio-leg is only a back-reference here -->
+                <portfolio-transaction reference="../../../portfolioTransaction"/>
+              </transactions>
+            </portfolio>
+            <!-- portfolio-leg serialised INLINE with the camelCase field name -->
+            <portfolioTransaction>
+              <uuid>port-eth-1</uuid>
+              <date>2025-02-19T00:00</date>
+              <currencyCode>EUR</currencyCode>
+              <amount>50000</amount>
+              <security reference="../../../../../../../securities/security"/>
+              <shares>20000000</shares>
+              <type>BUY</type>
+            </portfolioTransaction>
+            <account reference="../../../../.."/>
+            <accountTransaction reference="../.."/>
+          </crossEntry>
+          <type>BUY</type>
+        </account-transaction>
+      </transactions>
+    </account>
+  </accounts>
+  <portfolios>
+    <portfolio
+      reference="../accounts/account/transactions/account-transaction/crossEntry/portfolio"/>
+  </portfolios>
+</client>"""
+
+    result = PortfolioPerformanceImporter().parse_bytes(xml.encode())
+
+    buy_portfolio = next(
+        (t for t in result.transactions if t.type == "BUY" and t.kind == "portfolio"),
+        None,
+    )
+    assert buy_portfolio is not None, (
+        "inline <portfolioTransaction> (camelCase) portfolio-leg must be parsed"
+    )
+    assert buy_portfolio.uuid == "port-eth-1"
+    assert buy_portfolio.shares == Decimal("0.20000000")
+    assert buy_portfolio.security is not None
+    assert buy_portfolio.security.ticker == "ETH"
+
+    # Both legs are present; nothing is double-counted.
+    assert result.total_count == 2  # acct-eth-1 (account), port-eth-1 (portfolio)
+
+
 @pytest.mark.asyncio
 async def test_import_xml_post_shows_preview(client: AsyncClient) -> None:
     from decimal import Decimal


### PR DESCRIPTION
## Summary
- A buy/sell pairs a **portfolio-leg** (shares) with an **account-leg** (cash). XStream serialises whichever leg it reaches *first* under its natural collection using the hyphenated alias (`portfolio-transaction` / `account-transaction`), and the paired leg **inline inside `<crossEntry>`** using the camelCase `BuySellEntry` field name (`portfolioTransaction` / `accountTransaction`).
- The parser only walked the **hyphenated** tags, so any leg that happened to be the inline camelCase one was silently dropped. When a BUY's account-leg sorted first, its portfolio-leg (and the share count) lived only in `<portfolioTransaction>` and was lost — leaving just the cash-side leg, which the importer then skips. Result: the position never imported and no `stock` row was created.
- Observed in production for **ETH-EUR** (two BUYs, 2025-02-19 & 2025-04-15) while BTC-EUR / DOGE-EUR imported fine — those had the portfolio-leg serialised as the hyphenated outer element.

## Fix
- Walk both spellings (hyphenated alias + camelCase `crossEntry` field name) for each leg kind, deduping by UUID so neither leg is double-counted.

## Test plan
- [x] New regression test `test_parser_finds_portfolio_leg_inline_as_crossentry_field` — account-leg outer (hyphenated) + portfolio-leg inline (camelCase `<portfolioTransaction>`); asserts the portfolio-leg with its share count is parsed and total_count == 2.
- [x] Existing `test_parser_finds_transactions_nested_in_crossentry` (opposite direction) still passes.
- [x] `pytest tests/test_portfolio_performance_importer.py` (17 passed), plus transaction-import / cache / cleanup / resolver suites green.
- [x] `ruff` + `mypy` clean.
- [ ] Rebuild/redeploy the pod image, re-run the XML import, and confirm `ETH-EUR` appears in `finance.stock` with its two BUYs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)