### PR TITLE
refactor(xml-import): drop routine skip logs to DEBUG

### DIFF
--- a/app/services/transaction_import_service.py
+++ b/app/services/transaction_import_service.py
@@ -75,7 +75,7 @@ class TransactionImportService:
         mapped_type = _PP_TYPE_MAP.get(tx.type)
         if mapped_type is None:
             summary.skipped_unsupported += 1
-            logger.info(
+            logger.debug(
                 "Skipped XML transaction %s — unsupported PP type %r (kind=%s, security=%s)",
                 tx.uuid or "?",
                 tx.type,
@@ -89,7 +89,7 @@ class TransactionImportService:
         # double-counted as a position change.
         if mapped_type in {"BUY", "SELL"} and tx.kind != "portfolio":
             summary.skipped_unsupported += 1
-            logger.info(
+            logger.debug(
                 "Skipped XML transaction %s — %s account-leg "
                 "(paired with a portfolio entry, security=%s)",
                 tx.uuid or "?",


### PR DESCRIPTION
## Problem
The XML importer logged one `INFO` line per *skipped* transaction. After `266cecf` started parsing buy/sell legs serialised inline in `crossEntry`, the previously-invisible account-legs began getting logged on every import, flooding the pod logs (~166 of 200 recent lines were two routine skip messages).

## Change
Drop the two **routine** skips in `transaction_import_service.py` to `DEBUG`:
- `unsupported PP type` (DEPOSIT/REMOVAL) — never imported by design
- paired `BUY/SELL account-leg` — intentionally skipped to avoid double-counting

Kept at `INFO`:
- the per-import summary line (aggregate counts)
- the actionable data-quality skips: `missing UUID` and `without resolvable stock`

No behavior change — only log levels. Skip counters are unchanged.

## Testing
`pytest tests/test_transaction_import_service.py tests/test_portfolio_performance_importer.py` → 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)