### PR TITLE
Dedupe comdirect trades cross-source via shared external_uuid

### DIFF
--- a/app/services/comdirect_ref.py
+++ b/app/services/comdirect_ref.py
@@ -1,0 +1,49 @@
+"""Shared comdirect order-reference helpers.
+
+The comdirect *Ordernummer* is the only stable identifier shared between the
+two import paths for the same trade:
+
+* the comdirect settlement **PDF** (parsed by :mod:`app.services.comdirect_parser`),
+  which reads ``Ordernummer : 000512215771-001``; and
+* the Portfolio Performance **XML** export, whose ``ComdirectPDFExtractor``
+  writes the same number into the transaction *note* as
+  ``Ord.-Nr.: 072324316214-001 | R.-Nr.: <rechnungsnr>``.
+
+Deriving the same ``external_uuid`` from this reference on both sides lets the
+``uq_transaction_external_uuid`` constraint dedupe a trade across sources,
+regardless of which file is imported first.  This module is the single source
+of truth for both the parsing and the key format, so the two importers can
+never drift apart.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Modern PP note prefix, e.g. "Ord.-Nr.: 072324316214-001 | R.-Nr.: 1234567".
+# The reference is digits and dashes and stops before the " | R.-Nr.:" segment.
+# The legacy " / "-separated "Order-Nr.: 71871368321 / 001" form has no
+# cross-source PDF counterpart and deliberately does not match (returns None):
+# "Order-Nr." has no dot after "Ord", so the anchored pattern never fires.
+_ORDER_REF_RE = re.compile(r"^Ord\.-Nr\.:\s*([0-9][0-9-]*)")
+
+
+def parse_comdirect_order_ref(note: str | None) -> str | None:
+    """Extract the comdirect Ordernummer from a Portfolio Performance *note*.
+
+    Returns the normalised reference (e.g. ``"072324316214-001"``) or ``None``
+    when *note* is empty, not a comdirect note, or uses the legacy ``Order-Nr.``
+    ``/``-separated form (which the PDF importer does not parse, so it has no
+    cross-source counterpart to dedupe against).
+    """
+    if not note:
+        return None
+    m = _ORDER_REF_RE.match(note.strip())
+    if m is None:
+        return None
+    return m.group(1)
+
+
+def build_comdirect_external_uuid(ref: str) -> str:
+    """Return the shared ``external_uuid`` key for a comdirect order *ref*."""
+    return f"pdf:comdirect:{ref}"

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.stock import Stock
 from app.models.transaction import TX_SOURCE_PDF, TX_TYPE_BUY, Transaction
 from app.services.comdirect_parser import ParsedTrade
+from app.services.comdirect_ref import build_comdirect_external_uuid
 from app.services.holdings_service import recompute_holdings
 from app.services.pdf_parser import BaseBrokerParser
 
@@ -109,9 +110,13 @@ class ImportService:
 
         Duplicate protection runs across *all* sources, not just prior PDF
         imports: the same purchase may already be in the database from a
-        Portfolio Performance XML import (under a different ``external_uuid``).
-        A trade is treated as already imported when a transaction for the same
-        stock, type and share count exists on the same calendar day — see
+        Portfolio Performance XML import. When the trade carries a comdirect
+        ``order_ref`` we build the shared ``pdf:comdirect:{ref}`` key (the same
+        one the XML importer derives from the note's *Ordernummer*) and look it
+        up exactly — so an XML-first then PDF-second import dedupes
+        deterministically without tripping the unique constraint, and two
+        genuinely distinct same-day trades keep distinct keys. Only when no
+        order ref is available do we fall back to the fuzzy same-day probe in
         :meth:`_find_duplicate_trade`.
 
         Returns ``"created"`` when a new transaction was inserted,
@@ -122,13 +127,26 @@ class ImportService:
         if stock is None:
             return "unknown_ticker"
 
-        if await self._find_duplicate_trade(db, stock.id, trade):
-            return "duplicate"
+        if trade.order_ref:
+            external_uuid = build_comdirect_external_uuid(trade.order_ref)
+            existing = await db.execute(
+                select(Transaction.id).where(
+                    Transaction.external_uuid == external_uuid
+                )
+            )
+            if existing.scalar_one_or_none() is not None:
+                return "duplicate"
+        else:
+            # No stable order reference — fall back to the fuzzy same-day probe.
+            if await self._find_duplicate_trade(db, stock.id, trade):
+                return "duplicate"
+            external_uuid = build_comdirect_external_uuid(
+                f"{trade.isin or trade.wkn}:{trade.date.date()}"
+            )
 
-        ref = trade.order_ref or f"{trade.isin or trade.wkn}:{trade.date.date()}"
         db.add(
             Transaction(
-                external_uuid=f"pdf:comdirect:{ref}",
+                external_uuid=external_uuid,
                 stock_id=stock.id,
                 date=trade.date,
                 type=trade.trade_type,

--- a/app/services/transaction_import_service.py
+++ b/app/services/transaction_import_service.py
@@ -10,6 +10,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.stock import ASSET_TYPE_STOCK, Stock
 from app.models.transaction import TX_SOURCE_XML, Transaction
+from app.services.comdirect_ref import (
+    build_comdirect_external_uuid,
+    parse_comdirect_order_ref,
+)
 from app.services.portfolio_performance_importer import (
     ParsedTransaction,
     ParseResult,
@@ -108,8 +112,15 @@ class TransactionImportService:
             )
             return False
 
+        # Prefer the cross-source comdirect key (derived from the Ordernummer in
+        # the note) over PP's random per-export uuid, so an XML row dedupes
+        # against a prior PDF import of the same trade. Non-comdirect rows keep
+        # their PP uuid, which is stable across XML re-imports.
+        ref = parse_comdirect_order_ref(tx.note)
+        external_uuid = build_comdirect_external_uuid(ref) if ref else tx.uuid
+
         existing = await db.execute(
-            select(Transaction.id).where(Transaction.external_uuid == tx.uuid)
+            select(Transaction.id).where(Transaction.external_uuid == external_uuid)
         )
         if existing.scalar_one_or_none() is not None:
             summary.skipped_existing += 1
@@ -144,7 +155,7 @@ class TransactionImportService:
 
         db.add(
             Transaction(
-                external_uuid=tx.uuid,
+                external_uuid=external_uuid,
                 stock_id=stock_id,
                 date=tx.date,
                 type=mapped_type,

--- a/tests/test_comdirect_parser.py
+++ b/tests/test_comdirect_parser.py
@@ -112,7 +112,13 @@ def test_parse_text_returns_none_for_non_comdirect() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_db(known_tickers: dict[str, int], *, duplicate_exists: bool = False) -> AsyncMock:
+def _make_db(
+    known_tickers: dict[str, int],
+    *,
+    duplicate_exists: bool = False,
+    existing_external_uuids: set[str] | None = None,
+) -> AsyncMock:
+    existing_external_uuids = existing_external_uuids or set()
     db = AsyncMock()
     db.add = MagicMock()
     db.flush = AsyncMock()
@@ -122,10 +128,18 @@ def _make_db(known_tickers: dict[str, int], *, duplicate_exists: bool = False) -
         compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
         result = MagicMock()
 
-        # The cross-source duplicate probe is the only query that filters on
+        # The fuzzy fallback probe is the only query that filters on
         # transaction.date — distinguish it from the recompute_holdings queries.
         if "transaction.date" in compiled or 'transaction"."date"' in compiled:
             result.scalar_one_or_none.return_value = 99 if duplicate_exists else None
+            return result
+
+        # Exact external_uuid lookup — the order-ref dedupe (issue #114).
+        if "external_uuid" in compiled:
+            found = next(
+                (u for u in existing_external_uuids if u in compiled), None
+            )
+            result.scalar_one_or_none.return_value = 1 if found else None
             return result
 
         if "stock.ticker" in compiled or 'stock"."ticker' in compiled:
@@ -149,20 +163,24 @@ def _make_db(known_tickers: dict[str, int], *, duplicate_exists: bool = False) -
     return db
 
 
-def _trade() -> ParsedTrade:
+def _trade(
+    *,
+    order_ref: str | None = "000512215771-001",
+    shares: str = "8",
+) -> ParsedTrade:
     return ParsedTrade(
         trade_type="BUY",
         name="Xtr.(IE) - MSCI World",
         wkn="A1XB5U",
         isin="IE00BJ0KDQ92",
-        shares=Decimal("8"),
+        shares=Decimal(shares),
         price=Decimal("117.5406"),
         amount=Decimal("940.32"),
         fee=Decimal("15.30"),
         tax=Decimal("0"),
         currency="EUR",
         date=datetime.datetime(2026, 3, 23, tzinfo=datetime.UTC),
-        order_ref="000512215771-001",
+        order_ref=order_ref,
     )
 
 
@@ -207,11 +225,60 @@ async def test_import_trade_skips_unknown_ticker() -> None:
 
 
 @pytest.mark.asyncio
-async def test_import_trade_skips_cross_source_duplicate() -> None:
-    """A trade already in the DB (e.g. from XML) must not be re-inserted."""
-    db = _make_db({"XDWD.DE": 7}, duplicate_exists=True)
+async def test_import_trade_skips_cross_source_duplicate_by_exact_key() -> None:
+    """A trade already imported from XML under the shared comdirect key must not
+    be re-inserted — the exact ``pdf:comdirect:{ref}`` lookup catches it, so no
+    IntegrityError on the unique constraint (issue #114)."""
+    db = _make_db(
+        {"XDWD.DE": 7},
+        existing_external_uuids={"pdf:comdirect:000512215771-001"},
+    )
 
     status = await ImportService().import_trade(_trade(), "XDWD.DE", db)
+
+    assert status == "duplicate"
+    added = [
+        c.args[0]
+        for c in db.add.call_args_list
+        if c.args[0].__class__.__name__ == "Transaction"
+    ]
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_import_trade_distinct_order_refs_both_insert() -> None:
+    """Two distinct same-day, same-share comdirect trades with *different*
+    order refs both get distinct keys and both insert (issue #114)."""
+    db = _make_db({"XDWD.DE": 7})
+
+    first = await ImportService().import_trade(
+        _trade(order_ref="000512215771-001"), "XDWD.DE", db
+    )
+    second = await ImportService().import_trade(
+        _trade(order_ref="000512215771-002"), "XDWD.DE", db
+    )
+
+    assert first == "created"
+    assert second == "created"
+    keys = {
+        c.args[0].external_uuid
+        for c in db.add.call_args_list
+        if c.args[0].__class__.__name__ == "Transaction"
+    }
+    assert keys == {
+        "pdf:comdirect:000512215771-001",
+        "pdf:comdirect:000512215771-002",
+    }
+
+
+@pytest.mark.asyncio
+async def test_import_trade_without_order_ref_uses_fuzzy_fallback() -> None:
+    """A ref-less trade still dedupes via the fuzzy same-day probe."""
+    db = _make_db({"XDWD.DE": 7}, duplicate_exists=True)
+
+    status = await ImportService().import_trade(
+        _trade(order_ref=None), "XDWD.DE", db
+    )
 
     assert status == "duplicate"
     added = [

--- a/tests/test_comdirect_ref.py
+++ b/tests/test_comdirect_ref.py
@@ -1,0 +1,48 @@
+"""Tests for the shared comdirect order-reference helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.comdirect_ref import (
+    build_comdirect_external_uuid,
+    parse_comdirect_order_ref,
+)
+
+
+@pytest.mark.parametrize(
+    ("note", "expected"),
+    [
+        # Modern PP note → reference, stopping before " | R.-Nr.:".
+        ("Ord.-Nr.: 072324316214-001 | R.-Nr.: 9988776655", "072324316214-001"),
+        # Leading/trailing whitespace is trimmed.
+        ("  Ord.-Nr.: 000512215771-001 | R.-Nr.: 1 ", "000512215771-001"),
+        # Note without the rechnungsnr segment.
+        ("Ord.-Nr.: 072324316214-001", "072324316214-001"),
+        # No note at all.
+        (None, None),
+        ("", None),
+        # Non-comdirect notes.
+        ("Dividend Payment", None),
+        ("Purchase via Sparplan", None),
+        # Legacy " / "-separated form has no PDF counterpart → fall back.
+        ("Order-Nr.: 71871368321 / 001", None),
+    ],
+)
+def test_parse_comdirect_order_ref(note: str | None, expected: str | None) -> None:
+    assert parse_comdirect_order_ref(note) == expected
+
+
+def test_build_comdirect_external_uuid() -> None:
+    assert (
+        build_comdirect_external_uuid("072324316214-001")
+        == "pdf:comdirect:072324316214-001"
+    )
+
+
+def test_roundtrip_note_to_key() -> None:
+    """A PP note maps to the same key the PDF importer builds from the raw ref."""
+    note = "Ord.-Nr.: 000512215771-001 | R.-Nr.: 42"
+    ref = parse_comdirect_order_ref(note)
+    assert ref is not None
+    assert build_comdirect_external_uuid(ref) == "pdf:comdirect:000512215771-001"

--- a/tests/test_transaction_import_service.py
+++ b/tests/test_transaction_import_service.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.models.transaction import Transaction
 from app.services.portfolio_performance_importer import (
     ParsedTransaction,
     ParseResult,
@@ -38,6 +40,7 @@ def _tx(
     shares: str = "1",
     amount: str = "100",
     currency: str = "EUR",
+    note: str | None = None,
     security: SecurityInfo | None | object = _DEFAULT,
     units: list[Unit] | None = None,
 ) -> ParsedTransaction:
@@ -52,7 +55,7 @@ def _tx(
         amount=Decimal(amount),
         currency=currency,
         shares=Decimal(shares),
-        note=None,
+        note=note,
         security=sec,
         units=units or [],
     )
@@ -262,6 +265,78 @@ async def test_asset_type_from_security_is_propagated_to_stock() -> None:
     ]
     assert len(inserted_stocks) == 1
     assert inserted_stocks[0].asset_type == "CRYPTO"
+
+
+# ---------------------------------------------------------------------------
+# Cross-source comdirect keying — derive the shared key from the PP note (#113)
+# ---------------------------------------------------------------------------
+
+
+def _added_tx(db: AsyncMock) -> Transaction:
+    tx = next(
+        call.args[0]
+        for call in db.add.call_args_list
+        if call.args[0].__class__.__name__ == "Transaction"
+    )
+    return cast(Transaction, tx)
+
+
+@pytest.mark.asyncio
+async def test_comdirect_note_yields_shared_key() -> None:
+    """A comdirect PP note is keyed by the shared pdf:comdirect:{ref} key,
+    not PP's random uuid."""
+    db = _make_db(existing_tickers={"CBK.DE": 1})
+    note = "Ord.-Nr.: 072324316214-001 | R.-Nr.: 9988776655"
+    result = _result([_tx(uuid="pp-random-uuid", type="BUY", note=note)])
+
+    summary = await TransactionImportService().import_xml_result(result, db)
+
+    assert summary.created == 1
+    assert _added_tx(db).external_uuid == "pdf:comdirect:072324316214-001"
+
+
+@pytest.mark.asyncio
+async def test_xml_skipped_when_pdf_already_imported() -> None:
+    """An XML row imported after the matching PDF dedupes via the shared key."""
+    db = _make_db(
+        existing_uuids={"pdf:comdirect:072324316214-001"},
+        existing_tickers={"CBK.DE": 1},
+    )
+    note = "Ord.-Nr.: 072324316214-001 | R.-Nr.: 9988776655"
+    result = _result([_tx(uuid="pp-random-uuid", type="BUY", note=note)])
+
+    summary = await TransactionImportService().import_xml_result(result, db)
+
+    assert summary.created == 0
+    assert summary.skipped_existing == 1
+    db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_comdirect_note_falls_back_to_pp_uuid() -> None:
+    db = _make_db(existing_tickers={"CBK.DE": 1})
+    result = _result(
+        [_tx(uuid="pp-uuid-x", type="BUY", note="Purchase via Sparplan")]
+    )
+
+    summary = await TransactionImportService().import_xml_result(result, db)
+
+    assert summary.created == 1
+    assert _added_tx(db).external_uuid == "pp-uuid-x"
+
+
+@pytest.mark.asyncio
+async def test_legacy_order_form_falls_back_to_pp_uuid() -> None:
+    """The legacy ' / '-separated Order-Nr. form has no PDF counterpart."""
+    db = _make_db(existing_tickers={"CBK.DE": 1})
+    result = _result(
+        [_tx(uuid="pp-uuid-y", type="BUY", note="Order-Nr.: 71871368321 / 001")]
+    )
+
+    summary = await TransactionImportService().import_xml_result(result, db)
+
+    assert summary.created == 1
+    assert _added_tx(db).external_uuid == "pp-uuid-y"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #113 and #114. The comdirect PDF importer and the Portfolio Performance (PP) XML importer previously assigned **different** `external_uuid`s to the same trade, so `uq_transaction_external_uuid` never fired across sources. The fuzzy `stock + type + shares` same-day workaround could also wrongly collapse two genuinely separate same-day trades into one.

Both paths now derive the **same** `pdf:comdirect:{ref}` key from the comdirect **Ordernummer**, the one stable identifier shared between them.

## Changes

- **New `app/services/comdirect_ref.py`** — single source of truth for the key:
  - `parse_comdirect_order_ref(note)` reads the `Ord.-Nr.: <ref> | R.-Nr.: …` segment of a PP note. Returns `None` for non-comdirect notes and the legacy ` / `-separated `Order-Nr.` form (which the PDF importer doesn't parse, so it has no cross-source counterpart).
  - `build_comdirect_external_uuid(ref)` builds `pdf:comdirect:{ref}`.
- **XML side (`transaction_import_service`)** — comdirect rows are keyed by the derived shared key (PP `uuid` otherwise), and that computed value drives the idempotency lookup, so an XML row imported *after* the matching PDF dedupes. Non-comdirect rows and XML re-imports are unchanged.
- **PDF side (`import_service.import_trade`)** — when an order ref is present, look the exact key up before inserting (no `IntegrityError` on XML-first → PDF-second). The fuzzy same-day probe is now only a **fallback** for ref-less trades, so two distinct same-day, same-share trades with different refs both insert.

## Tests

- Unit tests for the helper (note → key, fallbacks, legacy form).
- XML: comdirect note yields shared key; XML-after-PDF skipped as existing; non-comdirect & legacy notes fall back to PP uuid; re-import still idempotent.
- PDF: XML-then-PDF returns `"duplicate"` via exact key; two distinct refs both insert; ref-less trade still hits the fuzzy fallback.

## Verification

- `pytest`: 198 passed
- `ruff check`: clean
- `mypy app`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)