### PR TITLE
fix(import): dedupe XML transactions within a single batch

### DIFF
--- a/app/services/transaction_import_service.py
+++ b/app/services/transaction_import_service.py
@@ -57,8 +57,15 @@ class TransactionImportService:
     ) -> ImportSummary:
         summary = ImportSummary()
 
+        # external_uuids already added in this run. The DB-level check below
+        # cannot see them yet because the session is autoflush=False, so two
+        # rows in the same XML that derive the same comdirect key (e.g. a shared
+        # Ordernummer) would both pass the "not existing" check and then collide
+        # on uq_transaction_external_uuid in the bulk flush.
+        seen_uuids: set[str] = set()
+
         for tx in result.transactions:
-            if not await self._persist(tx, db, summary):
+            if not await self._persist(tx, db, summary, seen_uuids):
                 continue
 
         await db.flush()
@@ -75,6 +82,7 @@ class TransactionImportService:
         tx: ParsedTransaction,
         db: AsyncSession,
         summary: ImportSummary,
+        seen_uuids: set[str],
     ) -> bool:
         mapped_type = _PP_TYPE_MAP.get(tx.type)
         if mapped_type is None:
@@ -118,6 +126,10 @@ class TransactionImportService:
         # their PP uuid, which is stable across XML re-imports.
         ref = parse_comdirect_order_ref(tx.note)
         external_uuid = build_comdirect_external_uuid(ref) if ref else tx.uuid
+
+        if external_uuid in seen_uuids:
+            summary.skipped_existing += 1
+            return False
 
         existing = await db.execute(
             select(Transaction.id).where(Transaction.external_uuid == external_uuid)
@@ -168,6 +180,7 @@ class TransactionImportService:
                 source=TX_SOURCE_XML,
             )
         )
+        seen_uuids.add(external_uuid)
         summary.created += 1
         if stock_id is not None:
             assert summary.affected_stock_ids is not None

--- a/tests/test_transaction_import_service.py
+++ b/tests/test_transaction_import_service.py
@@ -313,6 +313,30 @@ async def test_xml_skipped_when_pdf_already_imported() -> None:
 
 
 @pytest.mark.asyncio
+async def test_duplicate_within_same_batch_is_skipped() -> None:
+    """Two rows in one XML sharing a comdirect key must not both insert.
+
+    The session is autoflush=False, so the DB duplicate check cannot see a row
+    added earlier in the same run. Without batch-local dedup both rows reach the
+    flush and collide on uq_transaction_external_uuid.
+    """
+    db = _make_db(existing_tickers={"CBK.DE": 1})
+    note = "Ord.-Nr.: 000286017243-001 | R.-Nr.: 1234567890"
+    result = _result(
+        [
+            _tx(uuid="pp-a", type="BUY", note=note),
+            _tx(uuid="pp-b", type="BUY", note=note),
+        ]
+    )
+
+    summary = await TransactionImportService().import_xml_result(result, db)
+
+    assert summary.created == 1
+    assert summary.skipped_existing == 1
+    assert _added_tx(db).external_uuid == "pdf:comdirect:000286017243-001"
+
+
+@pytest.mark.asyncio
 async def test_non_comdirect_note_falls_back_to_pp_uuid() -> None:
     db = _make_db(existing_tickers={"CBK.DE": 1})
     result = _result(


### PR DESCRIPTION
## Problem

XML import aborted with:

```
sqlalchemy.exc.IntegrityError: UniqueViolationError: duplicate key value
violates unique constraint "uq_transaction_external_uuid"
DETAIL:  Key (external_uuid)=(pdf:comdirect:000286017243-001) already exists.
```

(Observed in `kubectl logs`, originating at `transaction_import_service.py:198` during the bulk flush.)

## Root cause

Two rows in a single Portfolio Performance XML can derive the **same** comdirect `external_uuid` because they share an Ordernummer (the cross-source key added in #115/#116). The per-row duplicate check does a `SELECT ... WHERE external_uuid = …`, but the session is `autoflush=False` (`app/database.py:56`), so that query never sees a row added earlier in the *same* batch. Both rows passed the "not existing" check, accumulated as pending, then collided on `uq_transaction_external_uuid` during the bulk flush — aborting the whole import.

The DB was truncated, confirming the collision was within the batch, not against pre-existing rows.

## Fix

Track the `external_uuid`s already added during the current run in a set and skip in-batch duplicates before the DB check. Cross-source (vs. prior PDF import) dedup via the DB query is unchanged.

## Tests

Added `test_duplicate_within_same_batch_is_skipped`. The existing `_make_db` mock only consults a static `existing_uuids` set, faithfully reproducing the `autoflush=False` invisibility of pending rows. All 14 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)