### PR TITLE
feat(import): cache prices for freshly imported tickers

### DIFF
--- a/app/routers/import_xml.py
+++ b/app/routers/import_xml.py
@@ -8,16 +8,18 @@ from xml.etree.ElementTree import ParseError
 from fastapi import APIRouter, Depends, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_async_session
-from app.models.stock import ASSET_TYPE_CRYPTO, ASSET_TYPE_STOCK
+from app.models.stock import ASSET_TYPE_CRYPTO, ASSET_TYPE_STOCK, Stock
 from app.services import import_cache
 from app.services.holdings_service import recompute_holdings
 from app.services.portfolio_performance_importer import (
     ParseResult,
     PortfolioPerformanceImporter,
 )
+from app.services.price_service import ensure_prices_cached
 from app.services.stock_lookup import fetch_stock_info
 from app.services.transaction_import_service import TransactionImportService
 from app.services.xml_security_resolver import (
@@ -143,6 +145,10 @@ async def import_xml_confirm(
 
     if summary.affected_stock_ids:
         await recompute_holdings(db, summary.affected_stock_ids)
+        ticker_rows = await db.execute(
+            select(Stock.ticker).where(Stock.id.in_(summary.affected_stock_ids))
+        )
+        await ensure_prices_cached(list(ticker_rows.scalars().all()), db)
 
     import_cache.delete(token)
 

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -16,6 +16,7 @@ from app.services.comdirect_parser import ParsedTrade
 from app.services.comdirect_ref import build_comdirect_external_uuid
 from app.services.holdings_service import recompute_holdings
 from app.services.pdf_parser import BaseBrokerParser
+from app.services.price_service import ensure_prices_cached
 
 TradeImportStatus = Literal["created", "duplicate", "unknown_ticker"]
 
@@ -52,6 +53,7 @@ class ImportService:
         """Insert a transaction per pair, then rebuild the holding snapshot."""
         processed: list[tuple[str, Decimal]] = []
         affected_stock_ids: set[int] = set()
+        affected_tickers: set[str] = set()
         now = datetime.datetime.now(datetime.UTC)
 
         for idx, (ticker, qty) in enumerate(pairs):
@@ -68,6 +70,7 @@ class ImportService:
             if existing.scalar_one_or_none() is not None:
                 processed.append((ticker, qty))
                 affected_stock_ids.add(stock.id)
+                affected_tickers.add(stock.ticker)
                 continue
 
             db.add(
@@ -87,10 +90,12 @@ class ImportService:
             )
             processed.append((ticker, qty))
             affected_stock_ids.add(stock.id)
+            affected_tickers.add(stock.ticker)
 
         await db.flush()
         if affected_stock_ids:
             await recompute_holdings(db, affected_stock_ids)
+            await ensure_prices_cached(affected_tickers, db)
         return processed
 
     async def import_trade(
@@ -161,6 +166,7 @@ class ImportService:
         )
         await db.flush()
         await recompute_holdings(db, {stock.id})
+        await ensure_prices_cached([stock.ticker], db)
         return "created"
 
     async def _find_duplicate_trade(

--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+from collections.abc import Iterable
 from decimal import Decimal
 from functools import partial
 
@@ -40,6 +41,25 @@ async def _fetch_history(ticker: str) -> dict[datetime.date, Decimal]:
     return await loop.run_in_executor(None, partial(_fetch_history_sync, ticker))
 
 
+async def _upsert_history(
+    ticker: str, history: dict[datetime.date, Decimal], db: AsyncSession
+) -> None:
+    """Upsert a ticker's ``{date: close}`` history into PriceCache (no commit)."""
+    rows = [
+        {"ticker": ticker.upper(), "date": date, "close_price": price}
+        for date, price in history.items()
+    ]
+    stmt = (
+        insert(PriceCache)
+        .values(rows)
+        .on_conflict_do_update(
+            constraint="uq_price_cache_ticker_date",
+            set_={"close_price": insert(PriceCache).excluded.close_price},
+        )
+    )
+    await db.execute(stmt)
+
+
 async def refresh_price_cache(tickers: list[str], db: AsyncSession) -> None:
     """Fetch 1Y of daily closes for each ticker and upsert into PriceCache.
 
@@ -56,22 +76,53 @@ async def refresh_price_cache(tickers: list[str], db: AsyncSession) -> None:
             logger.warning("No history returned for %s", ticker)
             continue
 
-        rows = [
-            {"ticker": ticker.upper(), "date": date, "close_price": price}
-            for date, price in history.items()
-        ]
-        stmt = (
-            insert(PriceCache)
-            .values(rows)
-            .on_conflict_do_update(
-                constraint="uq_price_cache_ticker_date",
-                set_={"close_price": insert(PriceCache).excluded.close_price},
-            )
-        )
-        await db.execute(stmt)
+        await _upsert_history(ticker, history, db)
 
     await db.commit()
     logger.info("Price cache refreshed for %d ticker(s).", len(tickers))
+
+
+async def ensure_prices_cached(tickers: Iterable[str], db: AsyncSession) -> list[str]:
+    """Fetch and cache 1Y of closes for any *tickers* not yet in PriceCache.
+
+    Called right after an import so a freshly added ticker contributes to the
+    portfolio total immediately, instead of showing no value until the daily
+    scheduler runs.  Tickers that already have a cached close are skipped, so
+    re-imports stay cheap and only genuinely-new securities hit the network.
+
+    Unlike :func:`refresh_price_cache`, this does *not* commit — the caller's
+    request-scoped session owns the transaction boundary.  Returns the tickers
+    that were freshly fetched.
+    """
+    wanted = sorted({t.strip().upper() for t in tickers if t and t.strip()})
+    if not wanted:
+        return []
+
+    existing = await db.execute(
+        select(PriceCache.ticker).where(PriceCache.ticker.in_(wanted)).distinct()
+    )
+    already_cached = set(existing.scalars().all())
+    missing = [t for t in wanted if t not in already_cached]
+
+    fetched: list[str] = []
+    for ticker in missing:
+        try:
+            history = await _fetch_history(ticker)
+        except Exception:
+            logger.exception("Failed to fetch history for %s", ticker)
+            continue
+
+        if not history:
+            logger.warning("No history returned for %s", ticker)
+            continue
+
+        await _upsert_history(ticker, history, db)
+        fetched.append(ticker)
+
+    if fetched:
+        await db.flush()
+        logger.info("Cached prices for freshly imported ticker(s): %s", fetched)
+    return fetched
 
 
 async def get_price(ticker: str, date: datetime.date, db: AsyncSession) -> Decimal | None:

--- a/tests/test_comdirect_parser.py
+++ b/tests/test_comdirect_parser.py
@@ -5,13 +5,24 @@ from __future__ import annotations
 import datetime
 from decimal import Decimal
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from app.services import comdirect_parser as cp_mod
 from app.services.comdirect_parser import ComdirectParser, ParsedTrade
 from app.services.import_service import ImportService
+
+
+@pytest.fixture(autouse=True)
+def _stub_price_warmup():
+    """Keep import_trade unit tests offline: the post-import price-cache warmup
+    would otherwise call yfinance for each freshly created ticker."""
+    with patch(
+        "app.services.import_service.ensure_prices_cached",
+        new=AsyncMock(return_value=[]),
+    ):
+        yield
 
 FIXTURE_PDF = Path(__file__).parent / "fixtures" / "sample_comdirect_kauf.pdf"
 
@@ -263,6 +274,22 @@ async def test_import_trade_writes_full_transaction() -> None:
     assert tx.source == "PDF"
     assert tx.date == datetime.datetime(2026, 3, 23, tzinfo=datetime.UTC)
     assert tx.external_uuid == "pdf:comdirect:000512215771-001"
+
+
+@pytest.mark.asyncio
+async def test_import_trade_warms_price_cache_on_create() -> None:
+    """A newly created trade triggers a price-cache warmup for its ticker."""
+    db = _make_db({"XDWD.DE": 7})
+
+    with patch(
+        "app.services.import_service.ensure_prices_cached",
+        new=AsyncMock(return_value=["XDWD.DE"]),
+    ) as mock_ensure:
+        status = await ImportService().import_trade(_trade(), "XDWD.DE", db)
+
+    assert status == "created"
+    mock_ensure.assert_awaited_once()
+    assert list(mock_ensure.call_args.args[0]) == ["XDWD.DE"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_import_pdf.py
+++ b/tests/test_import_pdf.py
@@ -217,9 +217,13 @@ async def test_import_from_holdings_inserts_transaction() -> None:
     db = _stub_pdf_db(known_tickers={"AAPL": 1})
 
     service = ImportService()
-    result = await service.import_from_holdings(
-        [("AAPL", Decimal("5"))], db, source_file="report.pdf"
-    )
+    with patch(
+        "app.services.import_service.ensure_prices_cached",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await service.import_from_holdings(
+            [("AAPL", Decimal("5"))], db, source_file="report.pdf"
+        )
 
     assert result == [("AAPL", Decimal("5"))]
     added = [
@@ -246,9 +250,13 @@ async def test_import_from_holdings_is_idempotent_on_reimport() -> None:
     )
 
     service = ImportService()
-    result = await service.import_from_holdings(
-        [("MSFT", Decimal("3"))], db, source_file="report.pdf"
-    )
+    with patch(
+        "app.services.import_service.ensure_prices_cached",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await service.import_from_holdings(
+            [("MSFT", Decimal("3"))], db, source_file="report.pdf"
+        )
 
     assert result == [("MSFT", Decimal("3"))]
     added_tx = [
@@ -257,6 +265,28 @@ async def test_import_from_holdings_is_idempotent_on_reimport() -> None:
         if call.args[0].__class__.__name__ == "Transaction"
     ]
     assert added_tx == []  # nothing inserted on second run
+
+
+@pytest.mark.asyncio
+async def test_import_from_holdings_caches_prices_for_imported_tickers() -> None:
+    """A freshly imported ticker triggers a price-cache warmup so it shows a
+    value immediately instead of waiting for the daily scheduler."""
+    from app.services.import_service import ImportService
+
+    db = _stub_pdf_db(known_tickers={"AAPL": 1})
+
+    service = ImportService()
+    with patch(
+        "app.services.import_service.ensure_prices_cached",
+        new=AsyncMock(return_value=["AAPL"]),
+    ) as mock_ensure:
+        await service.import_from_holdings(
+            [("AAPL", Decimal("5"))], db, source_file="report.pdf"
+        )
+
+    mock_ensure.assert_awaited_once()
+    tickers = mock_ensure.call_args.args[0]
+    assert set(tickers) == {"AAPL"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -9,7 +9,22 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.services.price_service import get_price, refresh_price_cache
+from app.services.price_service import (
+    ensure_prices_cached,
+    get_price,
+    refresh_price_cache,
+)
+
+
+def _make_existing_db(cached_tickers: list[str]) -> AsyncMock:
+    """Mock AsyncSession whose ticker-existence query returns *cached_tickers*."""
+    existing = MagicMock()
+    existing.scalars.return_value.all.return_value = cached_tickers
+    db = AsyncMock(spec=AsyncSession)
+    db.execute = AsyncMock(return_value=existing)
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    return db
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -135,3 +150,70 @@ async def test_refresh_price_cache_multiple_tickers() -> None:
 
     assert db.execute.await_count == 2
     db.commit.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# ensure_prices_cached
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_prices_cached_skips_already_cached() -> None:
+    """A ticker that already has cached closes is not re-fetched."""
+    db = _make_existing_db(["AAPL"])
+
+    with patch(
+        "app.services.price_service._fetch_history", AsyncMock()
+    ) as fetch:
+        fetched = await ensure_prices_cached(["AAPL"], db)
+
+    fetch.assert_not_called()
+    assert fetched == []
+    db.flush.assert_not_awaited()
+    db.commit.assert_not_awaited()  # never commits — caller owns the transaction
+
+
+@pytest.mark.asyncio
+async def test_ensure_prices_cached_fetches_missing() -> None:
+    """A ticker with no cached close is fetched, upserted, and flushed."""
+    db = _make_existing_db([])  # nothing cached yet
+
+    with patch(
+        "app.services.price_service._fetch_history",
+        AsyncMock(return_value=_HISTORY),
+    ) as fetch:
+        fetched = await ensure_prices_cached(["NEW"], db)
+
+    fetch.assert_awaited_once_with("NEW")
+    assert fetched == ["NEW"]
+    db.flush.assert_awaited_once()
+    db.commit.assert_not_awaited()
+    # one execute for the existence check + one for the upsert insert
+    assert db.execute.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_prices_cached_empty_input_is_noop() -> None:
+    db = _make_existing_db([])
+
+    fetched = await ensure_prices_cached([], db)
+
+    assert fetched == []
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_prices_cached_skips_ticker_with_empty_history() -> None:
+    """If yfinance returns nothing, the ticker is skipped (no flush, no row)."""
+    db = _make_existing_db([])
+
+    with patch(
+        "app.services.price_service._fetch_history",
+        AsyncMock(return_value={}),
+    ):
+        fetched = await ensure_prices_cached(["DELISTED"], db)
+
+    assert fetched == []
+    db.flush.assert_not_awaited()
+    # only the existence check ran; no upsert
+    assert db.execute.await_count == 1


### PR DESCRIPTION
## Problem

A holding whose ticker had no cached close price was **silently excluded** from `total_value` (`portfolio_service.py:62` skips `None`-valued holdings). So a freshly imported security showed **no value** until the daily `07:00` price-cache scheduler ran.

## Fix

After an import creates transactions, warm the price cache for the affected tickers via a new `ensure_prices_cached()`:

- Fetches 1Y of closes **only for tickers not already cached**, so re-imports stay cheap and only genuinely-new securities hit the network.
- Unlike `refresh_price_cache`, it **does not commit** — the request-scoped session owns the transaction boundary. It flushes so the new rows are visible immediately.

Wired into all three import seams:
- PDF / manual holdings (`ImportService.import_from_holdings`)
- comdirect single trade (`ImportService.import_trade`)
- Portfolio Performance XML confirm (`/import/xml/confirm`)

## Tests

- New `ensure_prices_cached` unit tests: skips already-cached, fetches missing, empty input no-op, skips empty history.
- New assertions that `import_from_holdings` and `import_trade` warm the cache for their tickers.
- Existing import unit tests stub the warmup to stay offline.

Full suite: 209 passed. `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)