### PR TITLE
fix(chart): forward-fill prices in performance history

### DIFF
--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -155,6 +155,13 @@ class PortfolioService:
         positions: dict[int, Decimal] = {sid: Decimal("0") for sid in stock_ids}
         event_ptrs: dict[int, int] = {sid: 0 for sid in stock_ids}
 
+        # Carry each ticker's most recent close forward.  Holdings have
+        # different date coverage in the cache (different exchange calendars,
+        # plus crypto trading on weekends), so without forward-fill a date
+        # where some ticker lacks a close would drop that position from the
+        # total — producing a sawtooth.  See issue with the Performance chart.
+        last_price: dict[str, Decimal] = {}
+
         performance: list[tuple[datetime.date, Decimal]] = []
         for date in sorted(prices_by_date):
             for sid, events in events_by_stock.items():
@@ -164,14 +171,17 @@ class PortfolioService:
                     ptr += 1
                 event_ptrs[sid] = ptr
 
-            day_prices = prices_by_date[date]
+            for tkr, close in prices_by_date[date].items():
+                last_price[tkr] = close
+
             total = Decimal("0")
             for sid, qty in positions.items():
                 if qty == 0:
                     continue
                 ticker, currency = stock_info[sid]
-                price = day_prices.get(ticker)
+                price = last_price.get(ticker)
                 if price is None:
+                    # Ticker has no cached close yet — value genuinely unknown.
                     continue
                 total += qty * to_eur(price, currency)
 

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -236,6 +236,39 @@ async def test_history_sell_halves_value() -> None:
 
 
 @pytest.mark.asyncio
+async def test_history_forward_fills_missing_price() -> None:
+    """A ticker missing a close on one date keeps its last value (no dip).
+
+    Both stocks are bought on day 1 and priced on days 1 and 3, but BTC-EUR
+    has no close on day 2.  Without forward-fill, day 2 would drop BTC-EUR and
+    collapse the total — the sawtooth.  Day 2 must equal days 1 and 3.
+    """
+    base = datetime.date(2025, 1, 1)
+    day = lambda n: base + datetime.timedelta(days=n - 1)  # noqa: E731
+
+    db = _history_db(
+        events=[
+            (1, datetime.datetime(2025, 1, 1), "BUY", "10"),
+            (2, datetime.datetime(2025, 1, 1), "BUY", "1"),
+        ],
+        stocks={1: ("AAPL", "EUR"), 2: ("BTC-EUR", "EUR")},
+        prices={
+            day(1): {"AAPL": "100.00", "BTC-EUR": "50000.00"},
+            day(2): {"AAPL": "100.00"},  # BTC-EUR missing
+            day(3): {"AAPL": "100.00", "BTC-EUR": "50000.00"},
+        },
+    )
+
+    history = await PortfolioService().get_performance_history(db)
+
+    by_date = dict(history)
+    expected = Decimal("51000.00")  # 10*100 + 1*50000
+    assert by_date[day(1)] == expected
+    assert by_date[day(2)] == expected
+    assert by_date[day(3)] == expected
+
+
+@pytest.mark.asyncio
 async def test_history_returns_empty_when_no_position_events() -> None:
     db = _history_db(events=[], stocks={}, prices={})
 


### PR DESCRIPTION
## Problem

The Performance chart rendered as a dense sawtooth — the line repeatedly collapsed to a fraction of the portfolio value and snapped back, instead of a smooth connected line.

## Root cause

`PortfolioService.get_performance_history()` walked every date that had **at least one** cached close and valued each holding only if its ticker had a close on **that exact date** (`day_prices.get(ticker)` → `continue` if missing).

Holdings have different date coverage in `price_cache`: stocks on different exchanges have different trading calendars/holidays, and crypto (e.g. `BTC-EUR`) trades 7 days/week while equities don't. So on any date with partial price coverage, some positions were dropped from the total — collapsing the value, then snapping back on full-coverage days.

## Fix

Forward-fill: carry each ticker's most recent cached close forward while walking the dates, so every charted date values **all** held positions. With no holes in the `y` series, the Plotly `mode: lines` trace draws a continuous line — no frontend change needed.

## Tests

Added `test_history_forward_fills_missing_price`: two holdings, one missing a close on a middle date — the total stays flat instead of dipping. Existing history tests (single ticker priced daily) are unaffected.

- `pytest tests/test_portfolio_service.py` → 10 passed
- `ruff` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)