### PR TITLE
fix(prices): drop NaN closes so holdings don't show N/A

### DIFF
--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -32,7 +32,12 @@ class PortfolioService:
         stmt = (
             select(PriceCache.ticker, PriceCache.close_price)
             .distinct(PriceCache.ticker)
-            .where(PriceCache.ticker.in_(tickers))
+            .where(
+                PriceCache.ticker.in_(tickers),
+                # Ignore any non-finite (NaN) close so a bad bar can't become
+                # the "latest" price and blank the holding's value.
+                PriceCache.close_price != Decimal("NaN"),
+            )
             .order_by(PriceCache.ticker, PriceCache.date.desc())
         )
         result = await db.execute(stmt)

--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+import math
 from collections.abc import Iterable
 from decimal import Decimal
 from functools import partial
@@ -31,8 +32,15 @@ def _fetch_history_sync(ticker: str) -> dict[datetime.date, Decimal]:
         return {}
     result: dict[datetime.date, Decimal] = {}
     for ts, row in hist["Close"].items():
+        close = float(row)
+        # yfinance occasionally returns a NaN close for a non-trading bar
+        # (e.g. a thinly-traded ETF on a partial-holiday session).  Storing
+        # it as Decimal('NaN') makes it the "latest" close and blanks the
+        # holding's value, so drop non-finite closes here.
+        if not math.isfinite(close):
+            continue
         date = ts.date() if hasattr(ts, "date") else ts
-        result[date] = Decimal(str(round(float(row), 4)))
+        result[date] = Decimal(str(round(close, 4)))
     return result
 
 
@@ -141,7 +149,11 @@ async def get_latest_close(ticker: str, db: AsyncSession) -> Decimal | None:
     """Return the most recently cached close price for *ticker*, or None."""
     result = await db.execute(
         select(PriceCache.close_price)
-        .where(PriceCache.ticker == ticker.upper())
+        .where(
+            PriceCache.ticker == ticker.upper(),
+            # Skip non-finite (NaN) closes so a bad bar can't be the latest.
+            PriceCache.close_price != Decimal("NaN"),
+        )
         .order_by(PriceCache.date.desc())
         .limit(1)
     )

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import datetime
 from decimal import Decimal
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pandas as pd
 import pytest
 
-from app.services.price_service import StockPriceService
+from app.services.price_service import StockPriceService, _fetch_history_sync
 from app.services.stock_lookup import StockInfo
 
 _APPLE = StockInfo(
@@ -61,3 +63,17 @@ async def test_validate_ticker_valid(service: StockPriceService) -> None:
 async def test_validate_ticker_invalid(service: StockPriceService) -> None:
     with patch("app.services.price_service.fetch_stock_info", AsyncMock(return_value=None)):
         assert await service.validate_ticker("INVALID") is False
+
+
+def test_fetch_history_skips_nan_close() -> None:
+    """A NaN close (e.g. a partial-holiday bar) must not be stored."""
+    index = pd.to_datetime(["2026-05-22", "2026-05-25"])
+    hist = pd.DataFrame({"Close": [102.37, float("nan")]}, index=index)
+    fake_ticker = MagicMock()
+    fake_ticker.history.return_value = hist
+
+    with patch("yfinance.Ticker", return_value=fake_ticker):
+        result = _fetch_history_sync("EUNL.DE")
+
+    assert result == {datetime.date(2026, 5, 22): Decimal("102.37")}
+    assert datetime.date(2026, 5, 25) not in result


### PR DESCRIPTION
## Problem
EUNL.DE, EUNM.DE and XDWD.DE showed **N/A** as their current value while other holdings were fine. yfinance returned a `NaN` close for the 2026-05-25 bar (a partial-holiday session for these ETFs). `_fetch_history_sync` stored it as `Decimal('NaN')`, which then became the *latest* cached close. `PortfolioService.get_summary` rejects it via `close_price.is_finite()`, so `current_value` was `None` → template rendered "N/A".

The daily refresh logged "19 ticker(s)" with no warnings because the history wasn't empty — it just contained a NaN bar, so neither the empty-history nor exception guard fired.

## Fix
- **Root cause:** skip non-finite closes in `_fetch_history_sync` so NaN is never stored.
- **Hardening:** filter `close_price <> 'NaN'` in `PortfolioService._latest_close_prices` and `get_latest_close`, so a future bad bar can never blank a holding's value.
- Added a unit test covering the NaN skip.

The 3 existing NaN rows were already cleaned up in the cluster DB to clear the N/A immediately.

## Test
- `pytest tests/test_price_service.py tests/test_portfolio_service.py tests/test_portfolio_summary.py` → 19 passed
- `ruff` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)