### PR TITLE
feat(charts): Total P/L gain/loss chart since first transaction

### DIFF
--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import datetime
+
 import plotly.graph_objects as go
 import plotly.io as pio
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -19,6 +21,34 @@ from app.services.portfolio_service import PortfolioService
 router = APIRouter(prefix="/holdings", tags=["holdings"])
 
 _DB = Depends(get_async_session)
+
+
+def _add_year_boundaries(fig: go.Figure, dates: list[str]) -> None:
+    """Draw a faint dotted vertical line at each Jan-1 within the series span.
+
+    *dates* are ISO date strings (``YYYY-MM-DD``) sorted ascending, as sent to
+    Plotly's date x-axis.  For every calendar year that starts inside the data
+    range a separator is added, labelled with the year at the top of the plot,
+    so the time-series charts read clearly across year boundaries.
+    """
+    if len(dates) < 2:
+        return
+    first = datetime.date.fromisoformat(dates[0])
+    last = datetime.date.fromisoformat(dates[-1])
+    for year in range(first.year + 1, last.year + 1):
+        boundary = datetime.date(year, 1, 1).isoformat()
+        fig.add_vline(x=boundary, line={"color": "#6e7681", "width": 1, "dash": "dot"})
+        fig.add_annotation(
+            x=boundary,
+            yref="paper",
+            y=1,
+            text=str(year),
+            showarrow=False,
+            font={"color": "#8b949e", "size": 11},
+            yanchor="bottom",
+            xanchor="left",
+            xshift=3,
+        )
 
 
 async def _get_or_404(holding_id: int, db: AsyncSession) -> Holding:
@@ -50,6 +80,7 @@ async def get_performance_chart(
             hovertemplate="%{x}<br>Value: %{y:,.2f}<extra></extra>",
         )
     )
+    _add_year_boundaries(fig, dates)
     fig.update_layout(
         margin={"t": 20, "b": 40, "l": 60, "r": 20},
         xaxis={"showgrid": False},
@@ -85,6 +116,7 @@ async def get_gain_loss_chart(
     )
     # Break-even baseline so the crossover between gain and loss is obvious.
     fig.add_hline(y=0, line={"color": "#888", "width": 1, "dash": "dash"})
+    _add_year_boundaries(fig, dates)
     fig.update_layout(
         margin={"t": 20, "b": 40, "l": 60, "r": 20},
         xaxis={"showgrid": False},

--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -61,6 +61,41 @@ async def get_performance_chart(
     return Response(content=pio.to_json(fig), media_type="application/json")
 
 
+@router.get("/chart/gain-loss")
+async def get_gain_loss_chart(
+    db: AsyncSession = _DB,
+) -> Response:
+    """Return a Plotly line chart of Total P/L since the first transaction."""
+    history = await PortfolioService().get_gain_loss_history(db)
+
+    if not history:
+        return JSONResponse(content={})
+
+    dates = [str(d) for d, _ in history]
+    values = [float(v) for _, v in history]
+
+    fig = go.Figure(
+        go.Scatter(
+            x=dates,
+            y=values,
+            mode="lines",
+            line={"color": "#0066cc", "width": 2},
+            hovertemplate="%{x}<br>P/L: %{y:,.2f}<extra></extra>",
+        )
+    )
+    # Break-even baseline so the crossover between gain and loss is obvious.
+    fig.add_hline(y=0, line={"color": "#888", "width": 1, "dash": "dash"})
+    fig.update_layout(
+        margin={"t": 20, "b": 40, "l": 60, "r": 20},
+        xaxis={"showgrid": False},
+        yaxis={"tickformat": ",.0f", "showgrid": True, "gridcolor": "#eee"},
+        hovermode="x unified",
+        plot_bgcolor="#fff",
+        paper_bgcolor="#fff",
+    )
+    return Response(content=pio.to_json(fig), media_type="application/json")
+
+
 @router.get("/chart/allocation")
 async def get_allocation_chart(
     db: AsyncSession = _DB,

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -5,19 +5,37 @@ from __future__ import annotations
 import datetime
 from decimal import Decimal
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.holding import Holding
 from app.models.price_cache import PriceCache
 from app.models.stock import Stock
-from app.models.transaction import Transaction
+from app.models.transaction import (
+    TX_TYPE_BUY,
+    TX_TYPE_DIVIDEND,
+    TX_TYPE_FEE,
+    TX_TYPE_SELL,
+    TX_TYPE_TAX,
+    Transaction,
+)
 from app.schemas.holdings import HoldingSummaryItem, PortfolioSummary
 from app.services.fx_service import to_eur
 
 _POSITION_TYPES = ("BUY", "SELL", "TRANSFER_IN", "TRANSFER_OUT")
 _POSITIVE_TYPES = {"BUY", "TRANSFER_IN"}
+
+# Transaction types that move cash in or out of the portfolio, used to derive
+# the net-invested baseline for the gain/loss series.  TRANSFER_IN/OUT are
+# excluded — they shift securities, not cash (and don't occur in this data set).
+_CASH_FLOW_TYPES = (
+    TX_TYPE_BUY,
+    TX_TYPE_SELL,
+    TX_TYPE_DIVIDEND,
+    TX_TYPE_FEE,
+    TX_TYPE_TAX,
+)
 
 
 class PortfolioService:
@@ -84,9 +102,12 @@ class PortfolioService:
         return PortfolioSummary(holdings=items, total_value=total_value)
 
     async def get_performance_history(
-        self, db: AsyncSession
+        self, db: AsyncSession, since: datetime.date | None = None
     ) -> list[tuple[datetime.date, Decimal]]:
-        """Return daily total portfolio values for the past year.
+        """Return daily total portfolio values.
+
+        Spans the trailing year by default; pass *since* to start the walk on
+        an earlier date (e.g. the first transaction for the gain/loss chart).
 
         Replays the transaction history so each chart date reflects the
         positions that were actually held on that day — not today's
@@ -139,12 +160,12 @@ class PortfolioService:
         if not tickers_upper:
             return []
 
-        one_year_ago = datetime.date.today() - datetime.timedelta(days=365)
+        lower_bound = since or (datetime.date.today() - datetime.timedelta(days=365))
         price_rows = await db.execute(
             select(PriceCache.ticker, PriceCache.date, PriceCache.close_price)
             .where(
                 PriceCache.ticker.in_(tickers_upper),
-                PriceCache.date >= one_year_ago,
+                PriceCache.date >= lower_bound,
             )
             .order_by(PriceCache.date)
         )
@@ -193,3 +214,95 @@ class PortfolioService:
             performance.append((date, total))
 
         return performance
+
+    @staticmethod
+    def _net_invested_delta(
+        tx_type: str, amount: Decimal, fee: Decimal, tax: Decimal
+    ) -> Decimal:
+        """Signed contribution of a transaction to *net invested* (native ccy).
+
+        Positive = cash flowed out of your pocket into the portfolio (raises
+        net invested); negative = cash flowed back to you (lowers it).
+
+        - BUY: ``amount + fee + tax`` (the full cost paid).
+        - SELL: ``-(amount - fee)`` (net proceeds received).
+        - DIVIDEND: ``-amount`` (cash received).
+        - FEE / TAX: ``amount + fee + tax`` (standalone cost; the value sits in
+          whichever column the importer used, so summing all three is robust).
+        """
+        if tx_type == TX_TYPE_BUY:
+            return amount + fee + tax
+        if tx_type == TX_TYPE_SELL:
+            return -(amount - fee)
+        if tx_type == TX_TYPE_DIVIDEND:
+            return -amount
+        if tx_type in (TX_TYPE_FEE, TX_TYPE_TAX):
+            return amount + fee + tax
+        return Decimal("0")
+
+    async def get_gain_loss_history(
+        self, db: AsyncSession
+    ) -> list[tuple[datetime.date, Decimal]]:
+        """Return the daily Total P/L series since the first transaction.
+
+        ``P/L(t) = market_value(t) − net_invested(t)``, where *net invested* is
+        the running sum of cash paid in (BUY cost, standalone FEE/TAX) minus
+        cash taken out (SELL proceeds, DIVIDEND).  This keeps realized gains
+        correct: a fully-sold position has zero market value but its profit
+        lives on as a negative net-invested balance, so the line stays up.
+
+        All amounts are FX-converted to EUR.  The series shares the
+        forward-filled market-value walk used by the Performance chart, but
+        spans from the earliest transaction rather than the trailing year.
+        """
+        since = await self._earliest_transaction_date(db)
+        market_values = await self.get_performance_history(db, since=since)
+        if not market_values:
+            return []
+
+        flow_rows = await db.execute(
+            select(
+                Transaction.date,
+                Transaction.type,
+                Transaction.amount,
+                Transaction.fee,
+                Transaction.tax,
+                Transaction.currency,
+            )
+            .where(Transaction.type.in_(_CASH_FLOW_TYPES))
+            .order_by(Transaction.date)
+        )
+
+        flows: list[tuple[datetime.date, Decimal]] = []
+        for dt, tx_type, amount, fee, tax, currency in flow_rows:
+            delta = self._net_invested_delta(tx_type, amount, fee, tax)
+            if delta == 0:
+                continue
+            flow_date = dt.date() if hasattr(dt, "date") else dt
+            flows.append((flow_date, to_eur(delta, currency)))
+        flows.sort(key=lambda f: f[0])
+
+        gain_loss: list[tuple[datetime.date, Decimal]] = []
+        ptr = 0
+        net_invested = Decimal("0")
+        for date, market_value in market_values:
+            while ptr < len(flows) and flows[ptr][0] <= date:
+                net_invested += flows[ptr][1]
+                ptr += 1
+            gain_loss.append((date, market_value - net_invested))
+
+        return gain_loss
+
+    async def _earliest_transaction_date(
+        self, db: AsyncSession
+    ) -> datetime.date | None:
+        """Return the date of the earliest stock transaction, or None."""
+        result = await db.execute(
+            select(func.min(Transaction.date)).where(
+                Transaction.stock_id.is_not(None)
+            )
+        )
+        earliest = result.scalar_one_or_none()
+        if earliest is None:
+            return None
+        return earliest.date() if hasattr(earliest, "date") else earliest

--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -10,24 +10,47 @@ from collections.abc import Iterable
 from decimal import Decimal
 from functools import partial
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.price_cache import PriceCache
+from app.models.transaction import Transaction
 from app.services.stock_lookup import fetch_stock_info
 
 logger = logging.getLogger(__name__)
 
 
-def _fetch_history_sync(ticker: str) -> dict[datetime.date, Decimal]:
-    """Fetch 1Y of daily closing prices via yfinance (blocking).
+async def earliest_transaction_date(db: AsyncSession) -> datetime.date | None:
+    """Return the date of the earliest stock transaction, or None if none exist.
 
-    Returns a mapping of {date: close_price}.
+    Used to backfill the price cache far enough for a gain/loss chart that
+    spans "since the first transaction" rather than the default trailing year.
+    """
+    result = await db.execute(
+        select(func.min(Transaction.date)).where(Transaction.stock_id.is_not(None))
+    )
+    earliest = result.scalar_one_or_none()
+    if earliest is None:
+        return None
+    return earliest.date() if hasattr(earliest, "date") else earliest
+
+
+def _fetch_history_sync(
+    ticker: str, start: datetime.date | None = None
+) -> dict[datetime.date, Decimal]:
+    """Fetch daily closing prices via yfinance (blocking).
+
+    With *start* set, fetches from that date forward; otherwise the trailing
+    year.  Returns a mapping of {date: close_price}.
     """
     import yfinance as yf  # type: ignore[import-untyped]
 
-    hist = yf.Ticker(ticker.upper()).history(period="1y")
+    yf_ticker = yf.Ticker(ticker.upper())
+    if start is not None:
+        hist = yf_ticker.history(start=start.isoformat())
+    else:
+        hist = yf_ticker.history(period="1y")
     if hist.empty:
         return {}
     result: dict[datetime.date, Decimal] = {}
@@ -44,9 +67,11 @@ def _fetch_history_sync(ticker: str) -> dict[datetime.date, Decimal]:
     return result
 
 
-async def _fetch_history(ticker: str) -> dict[datetime.date, Decimal]:
+async def _fetch_history(
+    ticker: str, start: datetime.date | None = None
+) -> dict[datetime.date, Decimal]:
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, partial(_fetch_history_sync, ticker))
+    return await loop.run_in_executor(None, partial(_fetch_history_sync, ticker, start))
 
 
 async def _upsert_history(
@@ -69,13 +94,18 @@ async def _upsert_history(
 
 
 async def refresh_price_cache(tickers: list[str], db: AsyncSession) -> None:
-    """Fetch 1Y of daily closes for each ticker and upsert into PriceCache.
+    """Fetch daily closes for each ticker and upsert into PriceCache.
+
+    Closes are fetched from the earliest transaction date forward so the
+    gain/loss chart can span the full holding period; with no transactions
+    yet, falls back to the trailing year.
 
     Intended to be called on startup and once per day via the scheduler.
     """
+    start = await earliest_transaction_date(db)
     for ticker in tickers:
         try:
-            history = await _fetch_history(ticker)
+            history = await _fetch_history(ticker, start)
         except Exception:
             logger.exception("Failed to fetch history for %s", ticker)
             continue
@@ -91,7 +121,11 @@ async def refresh_price_cache(tickers: list[str], db: AsyncSession) -> None:
 
 
 async def ensure_prices_cached(tickers: Iterable[str], db: AsyncSession) -> list[str]:
-    """Fetch and cache 1Y of closes for any *tickers* not yet in PriceCache.
+    """Fetch and cache closes for any *tickers* not yet in PriceCache.
+
+    Closes are backfilled from the earliest transaction date forward (falling
+    back to the trailing year when there are no transactions) so a freshly
+    imported ticker has the deep history the gain/loss chart needs.
 
     Called right after an import so a freshly added ticker contributes to the
     portfolio total immediately, instead of showing no value until the daily
@@ -111,11 +145,14 @@ async def ensure_prices_cached(tickers: Iterable[str], db: AsyncSession) -> list
     )
     already_cached = set(existing.scalars().all())
     missing = [t for t in wanted if t not in already_cached]
+    if not missing:
+        return []
 
+    start = await earliest_transaction_date(db)
     fetched: list[str] = []
     for ticker in missing:
         try:
-            history = await _fetch_history(ticker)
+            history = await _fetch_history(ticker, start)
         except Exception:
             logger.exception("Failed to fetch history for %s", ticker)
             continue

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -292,6 +292,11 @@
     <div id="performance-chart" style="height: 300px;"></div>
   </div>
 
+  <div class="chart-card anim-fade-in" style="animation-delay: 425ms">
+    <h2>Gain / Loss</h2>
+    <div id="gain-loss-chart" style="height: 300px;"></div>
+  </div>
+
   <div class="chart-card anim-fade-in" style="animation-delay: 500ms">
     <h2>Allocation</h2>
     <div id="allocation-chart" style="height: 350px;"></div>
@@ -414,6 +419,28 @@
         fig.data[0].line = Object.assign({}, fig.data[0].line, { color: '#22d3a0' });
       }
       Plotly.newPlot('performance-chart', fig.data, layout, {
+        responsive: true,
+        displayModeBar: false,
+      });
+    }
+  })();
+
+  (async () => {
+    const resp = await fetch('/api/v1/holdings/chart/gain-loss');
+    const fig = await resp.json();
+    if (fig && fig.data) {
+      const layout = Object.assign({}, fig.layout, DARK_LAYOUT, {
+        xaxis: Object.assign({}, (fig.layout || {}).xaxis, DARK_LAYOUT.xaxis),
+        yaxis: Object.assign({}, (fig.layout || {}).yaxis, DARK_LAYOUT.yaxis),
+      });
+      if (fig.data[0]) {
+        // Green when in profit, red when underwater (based on the latest point).
+        const y = fig.data[0].y || [];
+        const last = y.length ? y[y.length - 1] : 0;
+        const color = last >= 0 ? '#22d3a0' : '#f85149';
+        fig.data[0].line = Object.assign({}, fig.data[0].line, { color });
+      }
+      Plotly.newPlot('gain-loss-chart', fig.data, layout, {
         responsive: true,
         displayModeBar: false,
       });

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import AsyncClient
+
+from app.services.portfolio_service import PortfolioService
+
+
+def _vline_shapes(fig: dict) -> list[dict]:
+    """Vertical-line shapes (x0 == x1) from a Plotly figure dict."""
+    return [s for s in fig.get("layout", {}).get("shapes", []) if s.get("x0") == s.get("x1")]
 
 
 async def test_list_holdings_empty(client: AsyncClient, mock_session: MagicMock) -> None:
@@ -48,3 +57,63 @@ async def test_update_holding_not_found(
         "/api/v1/holdings/99999", json={"quantity": "5.0"}
     )
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Year-boundary separators on the time-series charts
+# ---------------------------------------------------------------------------
+
+
+def _series(*dates: datetime.date) -> list[tuple[datetime.date, Decimal]]:
+    return [(d, Decimal("100")) for d in dates]
+
+
+async def test_performance_chart_draws_year_boundary(client: AsyncClient) -> None:
+    """A series spanning into a new year gets a Jan-1 separator + year label."""
+    history = _series(
+        datetime.date(2025, 6, 1),
+        datetime.date(2026, 1, 1),
+        datetime.date(2026, 5, 1),
+    )
+    with patch.object(
+        PortfolioService, "get_performance_history", new=AsyncMock(return_value=history)
+    ):
+        response = await client.get("/api/v1/holdings/chart/performance")
+
+    fig = response.json()
+    vlines = _vline_shapes(fig)
+    assert [s["x0"] for s in vlines] == ["2026-01-01"]
+    assert {a["text"] for a in fig["layout"].get("annotations", [])} == {"2026"}
+
+
+async def test_performance_chart_no_boundary_within_single_year(
+    client: AsyncClient,
+) -> None:
+    """A series wholly inside one calendar year has no separators."""
+    history = _series(datetime.date(2025, 2, 1), datetime.date(2025, 11, 1))
+    with patch.object(
+        PortfolioService, "get_performance_history", new=AsyncMock(return_value=history)
+    ):
+        response = await client.get("/api/v1/holdings/chart/performance")
+
+    assert _vline_shapes(response.json()) == []
+
+
+async def test_gain_loss_chart_draws_boundaries_per_year(client: AsyncClient) -> None:
+    """The P/L chart marks each Jan-1 in the span and keeps its y=0 baseline."""
+    history = _series(
+        datetime.date(2024, 3, 1),
+        datetime.date(2025, 1, 1),
+        datetime.date(2026, 1, 1),
+        datetime.date(2026, 4, 1),
+    )
+    with patch.object(
+        PortfolioService, "get_gain_loss_history", new=AsyncMock(return_value=history)
+    ):
+        response = await client.get("/api/v1/holdings/chart/gain-loss")
+
+    fig = response.json()
+    assert [s["x0"] for s in _vline_shapes(fig)] == ["2025-01-01", "2026-01-01"]
+    # The break-even baseline is a horizontal shape (y0 == y1) and must survive.
+    shapes = fig["layout"]["shapes"]
+    assert any(s.get("y0") == s.get("y1") == 0 for s in shapes)

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -275,3 +275,194 @@ async def test_history_returns_empty_when_no_position_events() -> None:
     history = await PortfolioService().get_performance_history(db)
 
     assert history == []
+
+
+# ---------------------------------------------------------------------------
+# get_gain_loss_history — Total P/L since the first transaction (issue #122)
+# ---------------------------------------------------------------------------
+
+
+def _gain_loss_db(
+    earliest: datetime.date | None,
+    events: list[tuple[int, datetime.datetime, str, str]],
+    stocks: dict[int, tuple[str, str]],
+    prices: dict[datetime.date, dict[str, str]],
+    flows: list[tuple[datetime.datetime, str, str, str, str, str]],
+) -> AsyncMock:
+    """Mock session for get_gain_loss_history, in the order it queries:
+
+    1. earliest transaction date:  scalar_one_or_none() -> datetime|None
+    2. transaction events:         (stock_id, datetime, type, shares)
+    3. stock info:                 (id, ticker, currency)
+    4. price cache rows:           (ticker, date, close_price)
+    5. cash-flow rows:             (datetime, type, amount, fee, tax, currency)
+    """
+    earliest_result = MagicMock()
+    earliest_result.scalar_one_or_none.return_value = earliest
+
+    event_rows = [(sid, dt, t, Decimal(sh)) for sid, dt, t, sh in events]
+    event_result = MagicMock()
+    event_result.__iter__ = lambda self: iter(event_rows)
+
+    stock_rows = [(sid, t, c) for sid, (t, c) in stocks.items()]
+    stock_result = MagicMock()
+    stock_result.__iter__ = lambda self: iter(stock_rows)
+
+    price_rows = [
+        (ticker, d, Decimal(p))
+        for d, by_ticker in prices.items()
+        for ticker, p in by_ticker.items()
+    ]
+    price_result = MagicMock()
+    price_result.__iter__ = lambda self: iter(price_rows)
+
+    flow_rows = [
+        (dt, t, Decimal(a), Decimal(f), Decimal(tx), cur)
+        for dt, t, a, f, tx, cur in flows
+    ]
+    flow_result = MagicMock()
+    flow_result.__iter__ = lambda self: iter(flow_rows)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            earliest_result,
+            event_result,
+            stock_result,
+            price_result,
+            flow_result,
+        ]
+    )
+    return db
+
+
+@pytest.mark.asyncio
+async def test_gain_loss_positive_when_up_negative_when_down() -> None:
+    """P/L tracks market value vs. net invested: 0 at cost, +above, −below."""
+    base = datetime.date(2025, 1, 1)
+    day = lambda n: base + datetime.timedelta(days=n - 1)  # noqa: E731
+
+    db = _gain_loss_db(
+        earliest=day(1),
+        events=[(1, datetime.datetime(2025, 1, 1), "BUY", "10")],
+        stocks={1: ("AAPL", "EUR")},
+        prices={
+            day(1): {"AAPL": "100.00"},
+            day(2): {"AAPL": "120.00"},
+            day(3): {"AAPL": "90.00"},
+        },
+        flows=[(datetime.datetime(2025, 1, 1), "BUY", "1000", "0", "0", "EUR")],
+    )
+
+    history = await PortfolioService().get_gain_loss_history(db)
+
+    by_date = dict(history)
+    assert by_date[day(1)] == Decimal("0")  # at cost
+    assert by_date[day(2)] == Decimal("200")  # 1200 value − 1000 invested
+    assert by_date[day(3)] == Decimal("-100")  # 900 value − 1000 invested
+
+
+@pytest.mark.asyncio
+async def test_gain_loss_realized_profit_persists_after_full_sell() -> None:
+    """A fully-sold position keeps its profit: value→0, net invested goes
+    negative, so P/L stays at the realized gain."""
+    base = datetime.date(2025, 1, 1)
+    day = lambda n: base + datetime.timedelta(days=n - 1)  # noqa: E731
+
+    db = _gain_loss_db(
+        earliest=day(1),
+        events=[
+            (1, datetime.datetime(2025, 1, 1), "BUY", "10"),
+            (1, datetime.datetime(2025, 1, 3), "SELL", "10"),
+        ],
+        stocks={1: ("AAPL", "EUR")},
+        prices={
+            day(1): {"AAPL": "100.00"},
+            day(2): {"AAPL": "100.00"},
+            day(3): {"AAPL": "150.00"},
+            day(4): {"AAPL": "150.00"},
+        },
+        flows=[
+            (datetime.datetime(2025, 1, 1), "BUY", "1000", "0", "0", "EUR"),
+            (datetime.datetime(2025, 1, 3), "SELL", "1500", "0", "0", "EUR"),
+        ],
+    )
+
+    history = await PortfolioService().get_gain_loss_history(db)
+
+    by_date = dict(history)
+    assert by_date[day(1)] == Decimal("0")
+    assert by_date[day(2)] == Decimal("0")
+    # Sold for 1500 having paid 1000 → +500 realized, held even after value→0.
+    assert by_date[day(3)] == Decimal("500")
+    assert by_date[day(4)] == Decimal("500")
+
+
+@pytest.mark.asyncio
+async def test_gain_loss_dividend_increases_pl() -> None:
+    """A DIVIDEND is cash received → lowers net invested → raises P/L."""
+    base = datetime.date(2025, 1, 1)
+    day = lambda n: base + datetime.timedelta(days=n - 1)  # noqa: E731
+
+    db = _gain_loss_db(
+        earliest=day(1),
+        events=[(1, datetime.datetime(2025, 1, 1), "BUY", "10")],
+        stocks={1: ("AAPL", "EUR")},
+        prices={
+            day(1): {"AAPL": "100.00"},
+            day(2): {"AAPL": "100.00"},
+        },
+        flows=[
+            (datetime.datetime(2025, 1, 1), "BUY", "1000", "0", "0", "EUR"),
+            (datetime.datetime(2025, 1, 2), "DIVIDEND", "50", "0", "0", "EUR"),
+        ],
+    )
+
+    history = await PortfolioService().get_gain_loss_history(db)
+
+    by_date = dict(history)
+    assert by_date[day(1)] == Decimal("0")
+    assert by_date[day(2)] == Decimal("50")  # value flat, but 50 cash received
+
+
+@pytest.mark.asyncio
+async def test_gain_loss_forward_fills_missing_price() -> None:
+    """A ticker missing a close on one date keeps its value — no P/L dip."""
+    base = datetime.date(2025, 1, 1)
+    day = lambda n: base + datetime.timedelta(days=n - 1)  # noqa: E731
+
+    db = _gain_loss_db(
+        earliest=day(1),
+        events=[
+            (1, datetime.datetime(2025, 1, 1), "BUY", "10"),
+            (2, datetime.datetime(2025, 1, 1), "BUY", "1"),
+        ],
+        stocks={1: ("AAPL", "EUR"), 2: ("BTC-EUR", "EUR")},
+        prices={
+            day(1): {"AAPL": "100.00", "BTC-EUR": "50000.00"},
+            day(2): {"AAPL": "100.00"},  # BTC-EUR missing
+            day(3): {"AAPL": "100.00", "BTC-EUR": "50000.00"},
+        },
+        flows=[
+            (datetime.datetime(2025, 1, 1), "BUY", "1000", "0", "0", "EUR"),
+            (datetime.datetime(2025, 1, 1), "BUY", "50000", "0", "0", "EUR"),
+        ],
+    )
+
+    history = await PortfolioService().get_gain_loss_history(db)
+
+    by_date = dict(history)
+    # Bought at cost (51000) and flat → P/L is 0 throughout; the point is that
+    # day 2 doesn't drop BTC-EUR (which would read −50000).
+    assert by_date[day(1)] == Decimal("0")
+    assert by_date[day(2)] == Decimal("0")
+    assert by_date[day(3)] == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_gain_loss_returns_empty_without_transactions() -> None:
+    db = _gain_loss_db(earliest=None, events=[], stocks={}, prices={}, flows=[])
+
+    history = await PortfolioService().get_gain_loss_history(db)
+
+    assert history == []

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -20,6 +20,9 @@ def _make_existing_db(cached_tickers: list[str]) -> AsyncMock:
     """Mock AsyncSession whose ticker-existence query returns *cached_tickers*."""
     existing = MagicMock()
     existing.scalars.return_value.all.return_value = cached_tickers
+    # The earliest-transaction-date query reads scalar_one_or_none; None means
+    # "no transactions yet", so backfill falls back to the trailing year.
+    existing.scalar_one_or_none.return_value = None
     db = AsyncMock(spec=AsyncSession)
     db.execute = AsyncMock(return_value=existing)
     db.flush = AsyncMock()
@@ -99,7 +102,8 @@ async def test_refresh_price_cache_upserts_rows() -> None:
     ):
         await refresh_price_cache(["AAPL"], db)
 
-    db.execute.assert_awaited_once()
+    # One execute for the earliest-transaction-date lookup + one for the upsert.
+    assert db.execute.await_count == 2
     db.commit.assert_awaited_once()
 
 
@@ -115,7 +119,8 @@ async def test_refresh_price_cache_skips_empty_history() -> None:
     ):
         await refresh_price_cache(["AAPL"], db)
 
-    db.execute.assert_not_awaited()
+    # Only the earliest-date lookup ran; empty history means no upsert.
+    assert db.execute.await_count == 1
     db.commit.assert_awaited_once()
 
 
@@ -132,7 +137,8 @@ async def test_refresh_price_cache_handles_fetch_error() -> None:
         # Should not raise — errors are logged and skipped.
         await refresh_price_cache(["AAPL"], db)
 
-    db.execute.assert_not_awaited()
+    # Only the earliest-date lookup ran; the fetch error skips the upsert.
+    assert db.execute.await_count == 1
     db.commit.assert_awaited_once()
 
 
@@ -148,7 +154,8 @@ async def test_refresh_price_cache_multiple_tickers() -> None:
     ):
         await refresh_price_cache(["AAPL", "MSFT"], db)
 
-    assert db.execute.await_count == 2
+    # One earliest-date lookup + one upsert per ticker.
+    assert db.execute.await_count == 3
     db.commit.assert_awaited_once()
 
 
@@ -184,12 +191,12 @@ async def test_ensure_prices_cached_fetches_missing() -> None:
     ) as fetch:
         fetched = await ensure_prices_cached(["NEW"], db)
 
-    fetch.assert_awaited_once_with("NEW")
+    fetch.assert_awaited_once_with("NEW", None)
     assert fetched == ["NEW"]
     db.flush.assert_awaited_once()
     db.commit.assert_not_awaited()
-    # one execute for the existence check + one for the upsert insert
-    assert db.execute.await_count == 2
+    # existence check + earliest-date lookup + the upsert insert
+    assert db.execute.await_count == 3
 
 
 @pytest.mark.asyncio
@@ -215,5 +222,5 @@ async def test_ensure_prices_cached_skips_ticker_with_empty_history() -> None:
 
     assert fetched == []
     db.flush.assert_not_awaited()
-    # only the existence check ran; no upsert
-    assert db.execute.await_count == 1
+    # existence check + earliest-date lookup ran; empty history means no upsert
+    assert db.execute.await_count == 2


### PR DESCRIPTION
## Summary

Implements the **Gain/Loss chart since the first transaction** feature set (closes #121, #122, #123, #124).

The dashboard now shows a Total P/L line spanning the full holding period, where:

```
P/L(t) = market_value(t) − net_invested(t)
net_invested(t) = cumulative outflows (BUY cost, standalone FEE/TAX)
                − cumulative inflows  (SELL proceeds, DIVIDEND)
```

All amounts FX-converted to EUR. Realized gains are handled correctly: a fully-sold position has zero market value but keeps its profit as a negative net-invested balance, so the line stays up.

## What changed

- **#121 — deeper price cache** (`app/services/price_service.py`): new `earliest_transaction_date()` and an optional `start` on `_fetch_history(_sync)`. `refresh_price_cache` and `ensure_prices_cached` now backfill from the first transaction forward (falling back to the trailing year when there are no transactions). Upsert path unchanged.
- **#122 — P/L series + endpoint** (`app/services/portfolio_service.py`, `app/routers/holdings.py`): `get_gain_loss_history` reuses the forward-filled market-value walk (now with an optional `since`) plus a cumulative cash-flow walk. New `GET /api/v1/holdings/chart/gain-loss` returns Plotly JSON with a zero baseline; empty → `{}`.
- **#123 — dashboard card** (`app/templates/portfolio.html`): a dark-themed Gain/Loss card beside Performance and Allocation, green/red line based on the latest point.
- **#124 — tests** (`tests/test_portfolio_service.py`): mocked-DB unit tests covering up/down, realized gain after a full sell, dividend, forward-fill, and the empty case.

## Verification

- `pytest`: 216 passed
- `ruff` clean, `mypy` clean
- `pio.to_json` smoke-tested with the zero baseline shape

## Notes

- `TRANSFER_IN/OUT` are out of scope (none in this data set), per #122.
- `earliest_transaction_date` is intentionally duplicated (module-level in `price_service`, private method in `portfolio_service`) to avoid a cross-service import.
- Issue #114 was found already implemented and tested on `master` (PR #115) — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update — year-boundary separators

Both time-series charts (Performance and Gain/Loss) now draw a faint dotted vertical line at each `Jan-1` that falls within the plotted span, labelled with the year at the top of the plot, so the series read clearly across year boundaries.

- **`app/routers/holdings.py`**: shared `_add_year_boundaries(fig, dates)` helper using Plotly `add_vline`/`add_annotation`, called from both chart endpoints. The annotation is added separately (not via `add_vline(annotation_text=...)`, which can't average date-string x-coords).
- The shapes/annotations survive the dashboard's dark-theme layout merge, which only overrides `xaxis`/`yaxis` — the same path the Gain/Loss break-even baseline already relies on.
- **`tests/test_holdings.py`**: endpoint tests assert the vertical separators + year labels appear (and aren't drawn within a single calendar year), and that the Gain/Loss break-even baseline still survives.

`pytest`: 219 passed; `ruff` and `mypy` clean.