### PR TITLE
feat(charts): span Performance chart since first transaction

### DIFF
--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -62,8 +62,10 @@ async def _get_or_404(holding_id: int, db: AsyncSession) -> Holding:
 async def get_performance_chart(
     db: AsyncSession = _DB,
 ) -> Response:
-    """Return a Plotly line chart of total portfolio value over the past year."""
-    performance = await PortfolioService().get_performance_history(db)
+    """Return a Plotly line chart of total portfolio value since the first transaction."""
+    service = PortfolioService()
+    since = await service.earliest_transaction_date(db)
+    performance = await service.get_performance_history(db, since=since)
 
     if not performance:
         return JSONResponse(content={})

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -255,7 +255,7 @@ class PortfolioService:
         forward-filled market-value walk used by the Performance chart, but
         spans from the earliest transaction rather than the trailing year.
         """
-        since = await self._earliest_transaction_date(db)
+        since = await self.earliest_transaction_date(db)
         market_values = await self.get_performance_history(db, since=since)
         if not market_values:
             return []
@@ -293,7 +293,7 @@ class PortfolioService:
 
         return gain_loss
 
-    async def _earliest_transaction_date(
+    async def earliest_transaction_date(
         self, db: AsyncSession
     ) -> datetime.date | None:
         """Return the date of the earliest stock transaction, or None."""

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -76,6 +76,10 @@ async def test_performance_chart_draws_year_boundary(client: AsyncClient) -> Non
         datetime.date(2026, 5, 1),
     )
     with patch.object(
+        PortfolioService,
+        "earliest_transaction_date",
+        new=AsyncMock(return_value=datetime.date(2025, 6, 1)),
+    ), patch.object(
         PortfolioService, "get_performance_history", new=AsyncMock(return_value=history)
     ):
         response = await client.get("/api/v1/holdings/chart/performance")
@@ -92,6 +96,10 @@ async def test_performance_chart_no_boundary_within_single_year(
     """A series wholly inside one calendar year has no separators."""
     history = _series(datetime.date(2025, 2, 1), datetime.date(2025, 11, 1))
     with patch.object(
+        PortfolioService,
+        "earliest_transaction_date",
+        new=AsyncMock(return_value=datetime.date(2025, 2, 1)),
+    ), patch.object(
         PortfolioService, "get_performance_history", new=AsyncMock(return_value=history)
     ):
         response = await client.get("/api/v1/holdings/chart/performance")


### PR DESCRIPTION
## Summary
The Performance and Gain/Loss charts share one computation engine (`PortfolioService.get_performance_history`) but started on different dates: Gain/Loss spans **since the first transaction** while Performance fell back to a **trailing-365-day** window.

This change makes the Performance chart pass the same `since` value the Gain/Loss path already uses (`earliest_transaction_date`), so both charts cover an identical x-axis range. Because Gain/Loss is built directly on top of `get_performance_history`, identical `since` → identical range.

## Changes
- `app/routers/holdings.py`: `get_performance_chart` computes `since = earliest_transaction_date(db)` and passes it to `get_performance_history`.
- `app/services/portfolio_service.py`: promote `_earliest_transaction_date` → public `earliest_transaction_date` (now two call sites); update its internal caller in `get_gain_loss_history`.
- `tests/test_holdings.py`: the two performance-chart tests also patch `earliest_transaction_date` so the route no longer leans on the bare mock session.

The trailing-year default in `get_performance_history` is left intact as a fallback for any future caller. Year-boundary separators already handle multi-year spans (existing tests cover this), so no chart-rendering changes were needed.

## Testing
- `.venv/bin/python -m pytest tests/test_portfolio_service.py tests/test_holdings.py` — 22 passed
- `.venv/bin/ruff check app tests` — clean
- `.venv/bin/python -m mypy app` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)