### PR TITLE
feat: Meridian frontend redesign — warm dark palette, sidebar nav & editorial typography

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,25 +3,30 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}Terminal Ledger{% endblock %}</title>
+  <title>{% block title %}Meridian{% endblock %}</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script>
   <style>
     /* ── Design tokens ──────────────────────────────────────── */
     :root {
-      --bg:        #0d1117;
-      --surface:   #161b22;
-      --border:    #30363d;
-      --accent:    #22d3a0;
-      --danger:    #ff4d6d;
-      --text:      #e6edf3;
-      --muted:     #8b949e;
-      --font-ui:   "Syne", system-ui, sans-serif;
-      --font-mono: "JetBrains Mono", "Fira Code", monospace;
-      --radius:    6px;
-      --radius-sm: 4px;
+      --bg:           #0A0908;
+      --surface:      #141210;
+      --surface-2:    #1C1916;
+      --border:       #2C2825;
+      --accent:       #D4924A;
+      --positive:     #5AB87E;
+      --negative:     #C96B6B;
+      --danger:       #C96B6B;   /* alias for backward compat */
+      --text:         #F2EDE4;
+      --muted:        #8A8178;
+      --font-display: "Cormorant Garamond", Georgia, serif;
+      --font-ui:      "DM Sans", system-ui, sans-serif;
+      --font-mono:    "JetBrains Mono", "Fira Code", monospace;
+      --radius:       8px;
+      --radius-sm:    5px;
+      --sidebar-w:    220px;
     }
 
     /* ── Reset & base ───────────────────────────────────────── */
@@ -30,8 +35,8 @@
     body {
       background-color: var(--bg);
       background-image:
-        radial-gradient(ellipse at 20% 0%,   rgba(34, 211, 160, 0.04) 0%, transparent 50%),
-        radial-gradient(ellipse at 80% 100%, rgba(34, 211, 160, 0.03) 0%, transparent 50%);
+        radial-gradient(ellipse at 75% 0%,   rgba(212, 146, 74, 0.04) 0%, transparent 55%),
+        radial-gradient(ellipse at 15% 100%, rgba(212, 146, 74, 0.025) 0%, transparent 50%);
       color: var(--text);
       font-family: var(--font-ui);
       font-size: 15px;
@@ -40,115 +45,189 @@
     }
 
     h1, h2, h3, h4 { font-family: var(--font-ui); font-weight: 700; line-height: 1.2; }
-    h1 { font-size: 1.6rem; font-weight: 800; margin-bottom: 1rem; }
-    h2 { font-size: 1.1rem; }
+    h1 { font-size: 1.6rem; font-weight: 700; margin-bottom: 1rem; }
+    h2 { font-size: 1.05rem; font-weight: 600; }
 
     a { color: var(--accent); text-decoration: none; }
     a:hover { opacity: 0.8; text-decoration: underline; }
-
     p { color: var(--muted); }
 
     input, select, textarea {
-      background: var(--bg);
+      background: var(--surface-2);
       color: var(--text);
       border: 1px solid var(--border);
       border-radius: var(--radius-sm);
       font-family: var(--font-ui);
       font-size: 0.9rem;
-      padding: 0.35rem 0.6rem;
+      padding: 0.4rem 0.7rem;
       transition: border-color 150ms ease, box-shadow 150ms ease;
     }
     input:focus, select:focus, textarea:focus {
       outline: none;
       border-color: var(--accent);
-      box-shadow: 0 0 0 2px rgba(34, 211, 160, 0.15);
+      box-shadow: 0 0 0 2px rgba(212, 146, 74, 0.15);
     }
 
-    /* ── Navigation ─────────────────────────────────────────── */
-    .nav {
-      border-bottom: 1px solid var(--border);
+    /* ── App shell & sidebar ────────────────────────────────── */
+    .app-shell {
+      display: flex;
+      min-height: 100vh;
+    }
+
+    .sidebar {
+      width: var(--sidebar-w);
+      min-height: 100vh;
       background: var(--surface);
-      padding: 0 1.5rem;
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      position: fixed;
+      top: 0;
+      left: 0;
+      z-index: 100;
+    }
+
+    .sidebar-logo {
       display: flex;
       align-items: center;
-      gap: 1rem;
-      height: 52px;
+      gap: 0.55rem;
+      padding: 1.4rem 1.25rem 1.1rem;
+      font-family: var(--font-display);
+      font-size: 1.2rem;
+      font-weight: 600;
+      font-style: italic;
+      color: var(--text);
+      letter-spacing: 0.01em;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 0.75rem;
+      text-decoration: none;
     }
-    .nav-logo {
-      font-family: var(--font-ui);
-      font-weight: 800;
-      font-size: 1rem;
-      color: var(--accent);
-      letter-spacing: 0.02em;
+    .sidebar-logo:hover { opacity: 1; text-decoration: none; color: var(--accent); }
+    .sidebar-logo-icon { color: var(--accent); flex-shrink: 0; }
+
+    .sidebar-nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.1rem;
+      padding: 0 0.65rem;
+      flex: 1;
     }
-    .nav-logo:hover { opacity: 0.8; text-decoration: none; }
-    .nav-sep { color: var(--border); user-select: none; }
-    .nav-link {
+
+    .sidebar-section-label {
+      font-size: 0.62rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--muted);
+      padding: 0.85rem 0.65rem 0.2rem;
+      font-family: var(--font-mono);
+      opacity: 0.6;
+    }
+
+    .sidebar-link {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.45rem 0.65rem;
+      border-radius: var(--radius-sm);
       color: var(--muted);
       font-size: 0.875rem;
+      font-weight: 500;
+      font-family: var(--font-ui);
+      text-decoration: none;
+      transition: color 120ms ease, background 120ms ease;
+    }
+    .sidebar-link:hover {
+      color: var(--text);
+      background: rgba(242, 237, 228, 0.045);
+      text-decoration: none;
+      opacity: 1;
+    }
+    .sidebar-link.active {
+      color: var(--accent);
+      background: rgba(212, 146, 74, 0.1);
       font-weight: 600;
     }
-    .nav-link:hover { color: var(--text); text-decoration: none; opacity: 1; }
-
-    /* ── Main wrapper ────────────────────────────────────────── */
-    .page {
-      max-width: 960px;
-      margin: 0 auto;
-      padding: 2rem 1.5rem;
+    .sidebar-icon {
+      width: 15px;
+      height: 15px;
+      flex-shrink: 0;
+      color: currentColor;
+      opacity: 0.9;
     }
-    .page--wide {
-      max-width: min(1400px, calc(100vw - 3rem));
+
+    .sidebar-footer {
+      padding: 1rem 1.25rem;
+      border-top: 1px solid var(--border);
+    }
+    .sidebar-version {
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
+      color: var(--muted);
+      opacity: 0.5;
+      letter-spacing: 0.04em;
+    }
+
+    /* ── Main content area ──────────────────────────────────── */
+    .main-content {
+      margin-left: var(--sidebar-w);
+      flex: 1;
+      min-width: 0;
+      padding: 2.5rem 2.75rem;
+      max-width: calc(960px + var(--sidebar-w));
+    }
+    .main-content--wide {
+      max-width: min(1440px, calc(100vw - var(--sidebar-w)));
     }
 
     /* ── Tables ──────────────────────────────────────────────── */
     table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }
-    th, td { padding: 0.6rem 1rem; text-align: left; border-bottom: 1px solid var(--border); }
+    th, td { padding: 0.65rem 1rem; text-align: left; border-bottom: 1px solid var(--border); }
     th {
       background: var(--surface);
-      font-weight: 600;
-      font-size: 0.75rem;
+      font-weight: 500;
+      font-size: 0.7rem;
       text-transform: uppercase;
-      letter-spacing: 0.06em;
+      letter-spacing: 0.08em;
       color: var(--muted);
+      font-family: var(--font-mono);
     }
-    tbody tr:hover:not(.editing) { background: rgba(255, 255, 255, 0.02); }
+    tbody tr:hover:not(.editing) { background: rgba(242, 237, 228, 0.02); }
     th.number, td.number { text-align: right; font-family: var(--font-mono); }
     th.actions, td.actions { text-align: right; width: 130px; }
-    .total-row { font-weight: bold; border-top: 2px solid var(--border); }
+    .total-row { font-weight: 700; border-top: 2px solid var(--border); }
 
     /* ── Buttons ─────────────────────────────────────────────── */
     button {
       cursor: pointer;
       border: none;
       border-radius: var(--radius-sm);
-      padding: 0.3rem 0.7rem;
+      padding: 0.3rem 0.75rem;
       font-size: 0.85rem;
       font-family: var(--font-ui);
-      font-weight: 600;
+      font-weight: 500;
+      transition: opacity 120ms ease, background 120ms ease;
     }
-    button:disabled { opacity: 0.4; cursor: not-allowed; }
+    button:disabled { opacity: 0.35; cursor: not-allowed; }
 
-    /* Utility classes */
-    .btn-primary { background: var(--accent); color: #0d1117; padding: 0.4rem 1rem; font-size: 0.9rem; }
-    .btn-primary:hover { opacity: 0.85; }
-    .btn-danger  { background: var(--danger); color: #fff; }
+    .btn-primary { background: var(--accent); color: var(--bg); padding: 0.45rem 1.1rem; font-size: 0.9rem; font-weight: 600; }
+    .btn-primary:hover { opacity: 0.88; }
+    .btn-danger  { background: var(--negative); color: #fff; }
     .btn-danger:hover  { opacity: 0.85; }
     .btn-ghost   { background: transparent; color: var(--muted); border: 1px solid var(--border); }
     .btn-ghost:hover   { color: var(--text); border-color: var(--muted); }
 
-    /* Legacy button names used by existing templates and partials */
-    .btn-add    { background: var(--accent); color: #0d1117; padding: 0.4rem 1rem; font-size: 0.9rem; margin-bottom: 1rem; }
-    .btn-add:hover    { opacity: 0.85; }
-    .btn-edit   { background: rgba(34, 211, 160, 0.1); color: var(--accent); }
-    .btn-edit:hover   { background: rgba(34, 211, 160, 0.2); }
-    .btn-save   { background: var(--accent); color: #0d1117; }
-    .btn-save:hover   { opacity: 0.85; }
+    .btn-add    { background: var(--accent); color: var(--bg); padding: 0.45rem 1.1rem; font-size: 0.9rem; font-weight: 600; margin-bottom: 1rem; }
+    .btn-add:hover    { opacity: 0.88; }
+    .btn-edit   { background: rgba(212, 146, 74, 0.1); color: var(--accent); }
+    .btn-edit:hover   { background: rgba(212, 146, 74, 0.18); }
+    .btn-save   { background: var(--accent); color: var(--bg); }
+    .btn-save:hover   { opacity: 0.88; }
     .btn-cancel { background: transparent; color: var(--muted); border: 1px solid var(--border); }
     .btn-cancel:hover { color: var(--text); border-color: var(--muted); }
-    .btn-delete { background: rgba(255, 77, 109, 0.12); color: var(--danger); margin-left: 0.3rem; }
-    .btn-delete:hover { background: rgba(255, 77, 109, 0.22); }
-    .btn-confirm   { background: var(--accent); color: #0d1117; }
-    .btn-confirm:hover { opacity: 0.85; }
+    .btn-delete { background: rgba(201, 107, 107, 0.1); color: var(--negative); margin-left: 0.3rem; }
+    .btn-delete:hover { background: rgba(201, 107, 107, 0.2); }
+    .btn-confirm   { background: var(--accent); color: var(--bg); }
+    .btn-confirm:hover { opacity: 0.88; }
     .btn-secondary { background: transparent; color: var(--muted); border: 1px solid var(--border); margin-left: 0.5rem; }
     .btn-secondary:hover { color: var(--text); border-color: var(--muted); }
 
@@ -170,9 +249,9 @@
       margin-bottom: 1.5rem;
       background: var(--surface);
     }
-    .add-form-container h2 { margin: 0 0 1rem; font-size: 1.1rem; }
+    .add-form-container h2 { margin: 0 0 1rem; font-size: 1rem; }
     .form-row { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem; }
-    .form-row label { min-width: 70px; font-weight: 600; font-size: 0.9rem; color: var(--muted); }
+    .form-row label { min-width: 70px; font-weight: 500; font-size: 0.875rem; color: var(--muted); }
     .form-row input { width: 160px; }
     .form-or-divider {
       display: flex;
@@ -187,24 +266,24 @@
       height: 1px;
       background: var(--border);
     }
-    .or-label { font-size: 0.8rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; }
+    .or-label { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; }
     .input-group { display: flex; align-items: center; gap: 0.5rem; }
     .form-actions { margin-top: 0.75rem; display: flex; gap: 0.5rem; }
-    .form-error { color: var(--danger); font-size: 0.85rem; margin-bottom: 0.5rem; }
+    .form-error { color: var(--negative); font-size: 0.85rem; margin-bottom: 0.5rem; }
 
     .error {
-      color: var(--danger);
-      background: rgba(255, 77, 109, 0.1);
-      border: 1px solid rgba(255, 77, 109, 0.3);
+      color: var(--negative);
+      background: rgba(201, 107, 107, 0.08);
+      border: 1px solid rgba(201, 107, 107, 0.25);
       border-radius: var(--radius-sm);
       padding: 0.7rem 1rem;
       margin-bottom: 1rem;
       font-size: 0.9rem;
     }
     .success {
-      color: var(--accent);
-      background: rgba(34, 211, 160, 0.08);
-      border: 1px solid rgba(34, 211, 160, 0.3);
+      color: var(--positive);
+      background: rgba(90, 184, 126, 0.08);
+      border: 1px solid rgba(90, 184, 126, 0.25);
       border-radius: var(--radius-sm);
       padding: 0.7rem 1rem;
       margin-bottom: 1rem;
@@ -227,12 +306,12 @@
       border-radius: 50%;
       flex-shrink: 0;
     }
-    .ticker-hint.positive .ticker-hint-dot { background: var(--accent); }
-    .ticker-hint.negative .ticker-hint-dot { background: var(--danger); }
-    .ticker-hint.positive { color: var(--accent); }
-    .ticker-hint.negative { color: var(--danger); }
-    .ticker-valid   { color: var(--accent); font-size: 0.85rem; }
-    .ticker-invalid { color: var(--danger);  font-size: 0.85rem; }
+    .ticker-hint.positive .ticker-hint-dot { background: var(--positive); }
+    .ticker-hint.negative .ticker-hint-dot { background: var(--negative); }
+    .ticker-hint.positive { color: var(--positive); }
+    .ticker-hint.negative { color: var(--negative); }
+    .ticker-valid   { color: var(--positive); font-size: 0.85rem; }
+    .ticker-invalid { color: var(--negative); font-size: 0.85rem; }
 
     /* ── Charts ──────────────────────────────────────────────── */
     .chart-section { margin-bottom: 2rem; }
@@ -242,24 +321,24 @@
     /* ── Inline edit (portfolio table) ───────────────────────── */
     .inline-form { display: flex; align-items: center; gap: 0.5rem; justify-content: flex-end; }
     .qty-input { width: 100px; font-family: var(--font-mono); }
-    .editing td { background: #1c2128; }
+    .editing td { background: var(--surface-2); }
     .input-mono { font-family: var(--font-mono); }
-    .input-glow:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(34, 211, 160, 0.15); }
+    .input-glow:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(212, 146, 74, 0.15); }
 
-    /* ── Stock detail ────────────────────────────────────────── */
+    /* ── Summary card (used in stock detail + import XML) ────── */
     .subtitle { color: var(--muted); margin-bottom: 2rem; font-family: var(--font-mono); font-size: 0.95rem; }
     .summary-card { border: 1px solid var(--border); border-radius: var(--radius); padding: 1.2rem 1.5rem; margin-bottom: 2rem; background: var(--surface); }
-    .summary-card h2 { margin: 0 0 1rem; font-size: 1rem; font-weight: 600; }
+    .summary-card h2 { margin: 0 0 1rem; font-size: 0.875rem; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
     .summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; }
     .summary-item { display: flex; flex-direction: column; }
-    .summary-label { font-size: 0.8rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 0.25rem; }
-    .summary-value { font-size: 1.1rem; font-weight: 600; font-family: var(--font-mono); }
+    .summary-label { font-size: 0.7rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 0.25rem; font-family: var(--font-mono); }
+    .summary-value { font-size: 1rem; font-weight: 600; font-family: var(--font-mono); color: var(--text); }
 
     /* ── Import page ─────────────────────────────────────────── */
     div.actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
     .note { color: var(--muted); font-size: 0.85rem; margin-bottom: 1rem; }
 
-    /* ── Filter bar (preview/list tables) ────────────────────── */
+    /* ── Filter bar ──────────────────────────────────────────── */
     .filter-bar {
       display: flex;
       flex-wrap: wrap;
@@ -282,26 +361,20 @@
       display: flex;
       align-items: center;
       gap: 0;
-      margin-bottom: 2rem;
-      font-family: var(--font-mono);
+      margin-bottom: 2.5rem;
       font-size: 0.82rem;
-      letter-spacing: 0.03em;
     }
     .step-item {
       display: flex;
       align-items: center;
       gap: 0.45rem;
       color: var(--muted);
-      opacity: 0.5;
+      opacity: 0.45;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
     }
-    .step-item.active {
-      color: var(--accent);
-      opacity: 1;
-    }
-    .step-item.completed {
-      color: var(--accent);
-      opacity: 0.7;
-    }
+    .step-item.active { color: var(--accent); opacity: 1; }
+    .step-item.completed { color: var(--positive); opacity: 0.75; }
     .step-num {
       display: inline-flex;
       align-items: center;
@@ -318,6 +391,11 @@
       color: var(--bg);
       border-color: var(--accent);
     }
+    .step-item.completed .step-num {
+      background: var(--positive);
+      color: var(--bg);
+      border-color: var(--positive);
+    }
     .step-arrow {
       color: var(--border);
       margin: 0 0.7rem;
@@ -327,42 +405,42 @@
 
     /* ── Drop zone ───────────────────────────────────────────── */
     .drop-zone {
-      border: 2px dashed var(--accent);
+      border: 2px dashed var(--border);
       border-radius: var(--radius);
-      padding: 2.5rem 1.5rem;
+      padding: 2.75rem 1.5rem;
       text-align: center;
       margin-bottom: 1.25rem;
-      transition: background 0.15s;
+      transition: background 150ms ease, border-color 150ms ease;
       cursor: pointer;
       position: relative;
     }
     .drop-zone:hover,
     .drop-zone.dragover {
-      background: rgba(34, 211, 160, 0.06);
+      background: rgba(212, 146, 74, 0.04);
+      border-color: var(--accent);
     }
     .drop-zone-icon {
       display: block;
       margin: 0 auto 0.75rem;
       color: var(--accent);
+      opacity: 0.7;
     }
     .drop-zone-text {
       color: var(--muted);
       font-size: 0.9rem;
       margin-bottom: 0.5rem;
     }
-    .drop-zone-text strong {
-      color: var(--accent);
-    }
+    .drop-zone-text strong { color: var(--text); }
     .file-badge {
       display: inline-block;
-      background: rgba(34, 211, 160, 0.1);
+      background: rgba(212, 146, 74, 0.1);
       color: var(--accent);
       font-family: var(--font-mono);
-      font-size: 0.75rem;
+      font-size: 0.7rem;
       font-weight: 600;
-      padding: 0.2rem 0.6rem;
+      padding: 0.2rem 0.55rem;
       border-radius: var(--radius-sm);
-      letter-spacing: 0.04em;
+      letter-spacing: 0.06em;
     }
     .drop-zone input[type="file"] {
       position: absolute;
@@ -377,7 +455,7 @@
       margin-top: 0.75rem;
     }
 
-    /* ── Striped table rows (preview/done) ───────────────────── */
+    /* ── Striped table rows ──────────────────────────────────── */
     .table-striped tbody tr:nth-child(even) {
       background: rgba(255, 255, 255, 0.015);
     }
@@ -393,10 +471,32 @@
       margin: 0 auto 1.25rem;
     }
 
+    /* ── Back nav (shared across detail pages) ───────────────── */
+    .back-nav {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      color: var(--muted);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 0.25rem 0.65rem;
+      margin-bottom: 2rem;
+      text-decoration: none;
+      transition: color 120ms ease, border-color 120ms ease;
+    }
+    .back-nav:hover {
+      color: var(--text);
+      border-color: var(--muted);
+      text-decoration: none;
+      opacity: 1;
+    }
+
     /* ── Utility classes ─────────────────────────────────────── */
     .text-mono { font-family: var(--font-mono); }
-    .positive  { color: var(--accent); }
-    .negative  { color: var(--danger); }
+    .positive  { color: var(--positive); }
+    .negative  { color: var(--negative); }
     .na        { color: var(--muted); font-weight: normal; }
 
     /* ── Keyframes ───────────────────────────────────────────── */
@@ -413,7 +513,7 @@
       to   { opacity: 1; }
     }
     @keyframes flash-highlight {
-      0%   { background: rgba(34, 211, 160, 0.18); }
+      0%   { background: rgba(212, 146, 74, 0.16); }
       100% { background: transparent; }
     }
     @keyframes row-collapse {
@@ -426,22 +526,14 @@
     }
 
     /* ── Shared animation classes ────────────────────────────── */
-    .anim-fade-slide-down {
-      animation: fade-slide-down 350ms ease-out both;
-    }
-    .anim-fade-slide-up {
-      animation: fade-slide-up 400ms ease-out both;
-    }
-    .anim-fade-in {
-      animation: fade-in 500ms ease both;
-    }
+    .anim-fade-slide-down { animation: fade-slide-down 350ms ease-out both; }
+    .anim-fade-slide-up   { animation: fade-slide-up 400ms ease-out both; }
+    .anim-fade-in         { animation: fade-in 500ms ease both; }
     .anim-stagger {
       animation: fade-in 350ms ease both;
       animation-delay: calc(var(--row-index, 0) * 40ms);
     }
-    .anim-flash {
-      animation: flash-highlight 800ms ease-out;
-    }
+    .anim-flash { animation: flash-highlight 800ms ease-out; }
 
     /* ── Button interactions ─────────────────────────────────── */
     .btn-primary:active, .btn-save:active, .btn-confirm:active, .btn-add:active {
@@ -460,20 +552,64 @@
   {% block extra_head %}{% endblock %}
 </head>
 <body>
-  <nav class="nav">
-    <a href="/" class="nav-logo">Terminal Ledger</a>
-    <span class="nav-sep">/</span>
-    <a href="/" class="nav-link">Portfolio</a>
-    <span class="nav-sep">/</span>
-    <a href="/import/pdf" class="nav-link">Import PDF</a>
-    <span class="nav-sep">/</span>
-    <a href="/import/xml" class="nav-link">Import XML</a>
-    <span class="nav-sep">/</span>
-    <a href="/reports" class="nav-link">Reports</a>
-  </nav>
-  <main class="{% block page_class %}page{% endblock %}">
-    {% block content %}{% endblock %}
-  </main>
+  {# Hidden block — child templates override to set active sidebar item #}
+  <template id="active-page-marker">{% block active_page %}portfolio{% endblock %}</template>
+
+  <div class="app-shell">
+    <aside class="sidebar">
+      <a href="/" class="sidebar-logo">
+        <svg class="sidebar-logo-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+        </svg>
+        Meridian
+      </a>
+      <nav class="sidebar-nav">
+        <a href="/" class="sidebar-link {% if self.active_page().strip() == 'portfolio' %}active{% endif %}">
+          <svg class="sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2"/>
+            <line x1="8" y1="21" x2="16" y2="21"/>
+            <line x1="12" y1="17" x2="12" y2="21"/>
+          </svg>
+          Portfolio
+        </a>
+        <a href="/reports" class="sidebar-link {% if self.active_page().strip() == 'reports' %}active{% endif %}">
+          <svg class="sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+            <polyline points="14 2 14 8 20 8"/>
+            <line x1="16" y1="13" x2="8" y2="13"/>
+            <line x1="16" y1="17" x2="8" y2="17"/>
+            <polyline points="10 9 9 9 8 9"/>
+          </svg>
+          Reports
+        </a>
+        <span class="sidebar-section-label">Import</span>
+        <a href="/import/pdf" class="sidebar-link {% if self.active_page().strip() == 'import-pdf' %}active{% endif %}">
+          <svg class="sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+            <polyline points="14 2 14 8 20 8"/>
+            <line x1="12" y1="18" x2="12" y2="12"/>
+            <polyline points="9 15 12 12 15 15"/>
+          </svg>
+          Import PDF
+        </a>
+        <a href="/import/xml" class="sidebar-link {% if self.active_page().strip() == 'import-xml' %}active{% endif %}">
+          <svg class="sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="16 18 22 12 16 6"/>
+            <polyline points="8 6 2 12 8 18"/>
+          </svg>
+          Import XML
+        </a>
+      </nav>
+      <div class="sidebar-footer">
+        <span class="sidebar-version">MERIDIAN · v1.0</span>
+      </div>
+    </aside>
+
+    <main class="{% block page_class %}main-content{% endblock %}">
+      {% block content %}{% endblock %}
+    </main>
+  </div>
+
   {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/app/templates/import_pdf.html
+++ b/app/templates/import_pdf.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Import Broker PDF{% endblock %}
+{% block title %}Import Broker PDF — Meridian{% endblock %}
+{% block active_page %}import-pdf{% endblock %}
 
 {% block content %}
-  <p style="margin-bottom: 0.75rem;"><a href="/">&larr; Back to portfolio</a></p>
+  <a href="/" class="back-nav">&larr; Portfolio</a>
   <h1>Import Broker PDF</h1>
 
   <!-- Step indicator -->
@@ -148,7 +149,7 @@
     <h2>Import complete</h2>
     {% if processed %}
     <div class="done-icon">
-      <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--positive)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="10"/>
         <polyline points="9 12 11.5 14.5 16 10"/>
       </svg>
@@ -172,7 +173,7 @@
     </table>
     {% else %}
     <div class="done-icon">
-      <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--negative)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="10"/>
         <line x1="15" y1="9" x2="9" y2="15"/>
         <line x1="9" y1="9" x2="15" y2="15"/>

--- a/app/templates/import_xml.html
+++ b/app/templates/import_xml.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}Import Portfolio Performance XML{% endblock %}
+{% block title %}Import XML — Meridian{% endblock %}
 
-{% block page_class %}page{% if step == "preview" %} page--wide{% endif %}{% endblock %}
+{% block page_class %}main-content{% if step == "preview" %} main-content--wide{% endif %}{% endblock %}
+{% block active_page %}import-xml{% endblock %}
 
 {% block content %}
-  <p style="margin-bottom: 0.75rem;"><a href="/">&larr; Back to portfolio</a></p>
+  <a href="/" class="back-nav">&larr; Portfolio</a>
   <h1>Import Portfolio Performance XML</h1>
 
   <div class="step-indicator">

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
-{% block title %}Portfolio Overview{% endblock %}
+{% block title %}Portfolio — Meridian{% endblock %}
+{% block active_page %}portfolio{% endblock %}
 
 {% block extra_head %}
 <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
@@ -10,53 +11,72 @@
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 1.5rem 2rem;
+    padding: 1.75rem 2.25rem;
     margin-bottom: 2rem;
     display: flex;
     align-items: center;
     gap: 3rem;
     flex-wrap: wrap;
+    position: relative;
+    overflow: hidden;
+  }
+  .hero-bar::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 1px;
+    background: linear-gradient(to right, var(--accent), transparent 60%);
+    opacity: 0.6;
   }
   .hero-primary {
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
+    gap: 0.25rem;
   }
   .hero-label {
     font-family: var(--font-mono);
-    font-size: 0.7rem;
+    font-size: 0.65rem;
     color: var(--muted);
     text-transform: uppercase;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.12em;
   }
   .hero-value {
-    font-family: var(--font-ui);
-    font-size: 2.6rem;
-    font-weight: 800;
+    font-family: var(--font-display);
+    font-size: 3.5rem;
+    font-weight: 600;
     color: var(--text);
     line-height: 1;
+    letter-spacing: -0.01em;
   }
   .hero-value .hero-currency {
-    font-size: 1.1rem;
+    font-family: var(--font-ui);
+    font-size: 1rem;
     font-weight: 400;
     color: var(--muted);
-    margin-left: 0.25rem;
+    margin-left: 0.35rem;
+  }
+  .hero-divider {
+    width: 1px;
+    height: 44px;
+    background: var(--border);
+    align-self: center;
+    flex-shrink: 0;
   }
   .hero-kpi {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: 0.2rem;
   }
   .hero-kpi-label {
     font-family: var(--font-mono);
-    font-size: 0.7rem;
+    font-size: 0.65rem;
     color: var(--muted);
     text-transform: uppercase;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.12em;
   }
   .hero-kpi-value {
     font-family: var(--font-mono);
-    font-size: 1.1rem;
+    font-size: 1.05rem;
     font-weight: 600;
     color: var(--text);
   }
@@ -67,9 +87,9 @@
     justify-content: flex-end;
     gap: 0.75rem;
     margin-bottom: 1.25rem;
+    flex-wrap: wrap;
   }
 
-  /* Refresh button loading state swap */
   .htmx-indicator-show { display: none; }
   .htmx-request .htmx-indicator-hide { display: none; }
   .htmx-request .htmx-indicator-show { display: inline; }
@@ -86,6 +106,32 @@
     margin-bottom: 1.5rem;
   }
 
+  /* ── Chart layout ────────────────────────────────────────────── */
+  .chart-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+  .chart-card h2 {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    margin-bottom: 1rem;
+  }
+  .chart-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+  .chart-row .chart-card { margin-bottom: 0; }
+  @media (max-width: 900px) { .chart-row { grid-template-columns: 1fr; } }
+
   /* ── Holdings table ─────────────────────────────────────────── */
   .holdings-table {
     width: 100%;
@@ -93,18 +139,17 @@
     border-spacing: 0;
     margin-bottom: 1.5rem;
   }
-  .holdings-table thead tr {
-    background: var(--surface);
-  }
+  .holdings-table thead tr { background: var(--surface); }
   .holdings-table th {
     padding: 0.6rem 1rem;
-    font-size: 0.75rem;
+    font-size: 0.68rem;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
     color: var(--muted);
-    font-weight: 600;
+    font-weight: 500;
     border-bottom: 1px solid var(--border);
     text-align: left;
+    font-family: var(--font-mono);
   }
   .holdings-table th.number,
   .holdings-table td.number {
@@ -118,28 +163,17 @@
     min-width: 160px;
     white-space: nowrap;
   }
-  .holdings-table td.actions {
-    display: table-cell;
-  }
-  .holdings-table td.actions button {
-    display: inline-block;
-  }
-  .holdings-table tbody tr {
-    transition: background 150ms ease;
-    position: relative;
-  }
+  .holdings-table td.actions { display: table-cell; }
+  .holdings-table td.actions button { display: inline-block; }
+  .holdings-table tbody tr { transition: background 150ms ease; }
   .holdings-table tbody tr td:first-child {
     border-left: 2px solid transparent;
     transition: border-left-color 150ms ease;
   }
-  .holdings-table tbody tr:not(.editing):hover td:first-child {
-    border-left-color: var(--accent);
-  }
-  .holdings-table tbody tr:not(.editing):hover td {
-    background: rgba(34, 211, 160, 0.03);
-  }
+  .holdings-table tbody tr:not(.editing):hover td:first-child { border-left-color: var(--accent); }
+  .holdings-table tbody tr:not(.editing):hover td { background: rgba(212, 146, 74, 0.025); }
   .holdings-table td {
-    padding: 0.65rem 1rem;
+    padding: 0.7rem 1rem;
     border-bottom: 1px solid var(--border);
     vertical-align: middle;
   }
@@ -152,7 +186,7 @@
   .holding-name {
     display: block;
     font-family: var(--font-mono);
-    font-size: 0.75rem;
+    font-size: 0.72rem;
     color: var(--muted);
     font-weight: 400;
     margin-top: 0.1rem;
@@ -160,7 +194,7 @@
   .asset-badge {
     display: inline-block;
     font-family: var(--font-mono);
-    font-size: 0.6rem;
+    font-size: 0.58rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -171,8 +205,8 @@
   }
   .asset-badge-crypto {
     background: rgba(247, 147, 26, 0.12);
-    color: #f7931a;
-    border: 1px solid rgba(247, 147, 26, 0.35);
+    color: #f0922e;
+    border: 1px solid rgba(247, 147, 26, 0.3);
   }
   .holdings-table tfoot .total-row td {
     border-top: 2px solid var(--border);
@@ -182,47 +216,31 @@
     padding-top: 0.8rem;
   }
 
-  /* ── Chart containers ───────────────────────────────────────── */
-  .chart-card {
-    background: #161b22;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-  .chart-card h2 {
-    font-family: var(--font-ui);
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.7rem;
-    color: var(--muted);
-    margin-bottom: 1rem;
-  }
-
   /* ── Empty state ────────────────────────────────────────────── */
   .empty-state {
     text-align: center;
     padding: 4rem 2rem;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius);
+    margin-bottom: 1.5rem;
   }
   .empty-state-glyph {
-    font-family: var(--font-mono);
+    font-family: var(--font-display);
     font-size: 3rem;
+    font-style: italic;
     color: var(--border);
     margin-bottom: 1rem;
     line-height: 1;
+    opacity: 0.6;
   }
   .empty-state-title {
     font-family: var(--font-ui);
     font-size: 1.1rem;
-    font-weight: 700;
+    font-weight: 600;
     color: var(--text);
     margin-bottom: 0.4rem;
   }
-  .empty-state p {
-    color: var(--muted);
-    margin-bottom: 1.5rem;
-  }
+  .empty-state p { color: var(--muted); margin-bottom: 1.5rem; }
 </style>
 {% endblock %}
 
@@ -236,15 +254,17 @@
         {% if total_value is not none %}
           {{ "%.2f"|format(total_value) }}<span class="hero-currency">EUR</span>
         {% else %}
-          <span style="color: var(--muted);">—</span>
+          <span style="color: var(--muted); font-family: var(--font-mono);">—</span>
         {% endif %}
       </span>
     </div>
+    <div class="hero-divider"></div>
     <div class="hero-kpi">
-      <span class="hero-kpi-label">Holdings</span>
+      <span class="hero-kpi-label">Positions</span>
       <span class="hero-kpi-value">{{ holdings_count }}</span>
     </div>
     {% if last_refresh %}
+    <div class="hero-divider"></div>
     <div class="hero-kpi">
       <span class="hero-kpi-label">Last Refresh</span>
       <span class="hero-kpi-value">{{ last_refresh }}</span>
@@ -287,19 +307,20 @@
 
   <!-- Charts (only when there is data) -->
   {% if total_value is not none %}
-  <div class="chart-card anim-fade-in" style="animation-delay: 350ms">
+  <div class="chart-card anim-fade-in" style="animation-delay: 300ms">
     <h2>Performance</h2>
-    <div id="performance-chart" style="height: 300px;"></div>
+    <div id="performance-chart" style="height: 310px;"></div>
   </div>
 
-  <div class="chart-card anim-fade-in" style="animation-delay: 425ms">
-    <h2>Gain / Loss</h2>
-    <div id="gain-loss-chart" style="height: 300px;"></div>
-  </div>
-
-  <div class="chart-card anim-fade-in" style="animation-delay: 500ms">
-    <h2>Allocation</h2>
-    <div id="allocation-chart" style="height: 350px;"></div>
+  <div class="chart-row">
+    <div class="chart-card anim-fade-in" style="animation-delay: 400ms">
+      <h2>Gain / Loss</h2>
+      <div id="gain-loss-chart" style="height: 250px;"></div>
+    </div>
+    <div class="chart-card anim-fade-in" style="animation-delay: 480ms">
+      <h2>Allocation</h2>
+      <div id="allocation-chart" style="height: 250px;"></div>
+    </div>
   </div>
   {% endif %}
 
@@ -379,7 +400,7 @@
     <tbody id="holdings-tbody"></tbody>
   </table>
   <div class="empty-state">
-    <div class="empty-state-glyph">[ ]</div>
+    <div class="empty-state-glyph">∅</div>
     <div class="empty-state-title">No holdings yet</div>
     <p>Your portfolio is empty. Add your first holding to get started.</p>
     <button
@@ -399,12 +420,13 @@
 {% if total_value is not none %}
 <script>
   const DARK_LAYOUT = {
-    paper_bgcolor: '#0d1117',
-    plot_bgcolor: '#161b22',
-    font: { color: '#e6edf3', family: "'JetBrains Mono', monospace" },
-    xaxis: { gridcolor: '#30363d', zerolinecolor: '#30363d' },
-    yaxis: { gridcolor: '#30363d', zerolinecolor: '#30363d' },
-    legend: { bgcolor: 'transparent', font: { color: '#8b949e' } },
+    paper_bgcolor: '#0A0908',
+    plot_bgcolor:  '#141210',
+    font: { color: '#F2EDE4', family: "'JetBrains Mono', monospace" },
+    xaxis: { gridcolor: '#2C2825', zerolinecolor: '#2C2825' },
+    yaxis: { gridcolor: '#2C2825', zerolinecolor: '#2C2825' },
+    legend: { bgcolor: 'transparent', font: { color: '#8A8178' } },
+    margin: { t: 16, b: 40, l: 56, r: 16 },
   };
 
   (async () => {
@@ -416,12 +438,10 @@
         yaxis: Object.assign({}, (fig.layout || {}).yaxis, DARK_LAYOUT.yaxis),
       });
       if (fig.data[0]) {
-        fig.data[0].line = Object.assign({}, fig.data[0].line, { color: '#22d3a0' });
+        fig.data[0].line = Object.assign({}, fig.data[0].line, { color: '#D4924A', width: 2 });
+        fig.data[0].fillcolor = 'rgba(212, 146, 74, 0.07)';
       }
-      Plotly.newPlot('performance-chart', fig.data, layout, {
-        responsive: true,
-        displayModeBar: false,
-      });
+      Plotly.newPlot('performance-chart', fig.data, layout, { responsive: true, displayModeBar: false });
     }
   })();
 
@@ -434,16 +454,13 @@
         yaxis: Object.assign({}, (fig.layout || {}).yaxis, DARK_LAYOUT.yaxis),
       });
       if (fig.data[0]) {
-        // Green when in profit, red when underwater (based on the latest point).
         const y = fig.data[0].y || [];
         const last = y.length ? y[y.length - 1] : 0;
-        const color = last >= 0 ? '#22d3a0' : '#f85149';
+        const color = last >= 0 ? '#5AB87E' : '#C96B6B';
         fig.data[0].line = Object.assign({}, fig.data[0].line, { color });
+        fig.data[0].fillcolor = last >= 0 ? 'rgba(90, 184, 126, 0.07)' : 'rgba(201, 107, 107, 0.07)';
       }
-      Plotly.newPlot('gain-loss-chart', fig.data, layout, {
-        responsive: true,
-        displayModeBar: false,
-      });
+      Plotly.newPlot('gain-loss-chart', fig.data, layout, { responsive: true, displayModeBar: false });
     }
   })();
 
@@ -454,24 +471,34 @@
       const layout = Object.assign({}, fig.layout, DARK_LAYOUT, {
         xaxis: Object.assign({}, (fig.layout || {}).xaxis, DARK_LAYOUT.xaxis),
         yaxis: Object.assign({}, (fig.layout || {}).yaxis, DARK_LAYOUT.yaxis),
+        showlegend: true,
+        legend: {
+          bgcolor: 'transparent',
+          font: { color: '#8A8178', size: 11, family: "'JetBrains Mono', monospace" },
+          orientation: 'v',
+          x: 1, y: 0.5,
+          xanchor: 'left',
+        },
+        margin: { t: 16, b: 16, l: 16, r: 100 },
       });
-      Plotly.newPlot('allocation-chart', fig.data, layout, {
-        responsive: true,
-        displayModeBar: false,
-      });
+      if (fig.data[0]) {
+        fig.data[0].marker = {
+          colors: ['#D4924A', '#5AB87E', '#7BAFD4', '#C9A96B', '#8A7B6B', '#C96B6B', '#A49478', '#6B8A7B'],
+          line: { color: '#0A0908', width: 2 },
+        };
+      }
+      Plotly.newPlot('allocation-chart', fig.data, layout, { responsive: true, displayModeBar: false });
     }
   })();
 </script>
 {% endif %}
 <script>
-  // Open add-form-slot after HTMX loads the add holding form
   document.body.addEventListener('htmx:afterSwap', function(evt) {
     if (evt.detail.target && evt.detail.target.id === 'add-form-slot') {
       evt.detail.target.classList.add('open');
     }
   });
 
-  // Delete row collapse animation
   document.body.addEventListener('htmx:beforeSwap', function(evt) {
     var target = evt.detail.target;
     if (target && target.id && target.id.startsWith('holding-row-') && evt.detail.serverResponse === '') {

--- a/app/templates/report_detail.html
+++ b/app/templates/report_detail.html
@@ -1,31 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}{{ month_label }} Report — Terminal Ledger{% endblock %}
+{% block title %}{{ month_label }} Report — Meridian{% endblock %}
+{% block active_page %}reports{% endblock %}
 
 {% block extra_head %}
 <style>
-  /* ── Back nav ────────────────────────────────────────────────── */
-  .back-nav {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--muted);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 0.25rem 0.65rem;
-    margin-bottom: 2rem;
-    text-decoration: none;
-    transition: color 120ms ease, border-color 120ms ease;
-  }
-  .back-nav:hover {
-    color: var(--text);
-    border-color: var(--muted);
-    text-decoration: none;
-    opacity: 1;
-  }
-
   /* ── Stats strip ─────────────────────────────────────────────── */
   .stats-strip {
     display: grid;
@@ -47,7 +26,7 @@
   }
   .stat-label {
     font-family: var(--font-mono);
-    font-size: 0.7rem;
+    font-size: 0.65rem;
     color: var(--muted);
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -56,25 +35,27 @@
     font-family: var(--font-mono);
     font-size: 1.35rem;
     font-weight: 600;
-    color: var(--accent);
+    color: var(--text);
     line-height: 1.1;
   }
-  .stat-value.na {
-    color: var(--muted);
-    font-weight: 400;
-    font-size: 1.1rem;
-  }
-  .stat-value.positive { color: var(--accent); }
-  .stat-value.negative { color: var(--danger); }
+  .stat-value.na { color: var(--muted); font-weight: 400; font-size: 1.1rem; }
+  .stat-value.positive { color: var(--positive); }
+  .stat-value.negative { color: var(--negative); }
   .stat-value.neutral  { color: var(--text); }
 
   /* ── Report header ───────────────────────────────────────────── */
-  .report-header {
-    margin-bottom: 2rem;
+  .report-header { margin-bottom: 2rem; }
+  .report-header h1 {
+    font-family: var(--font-display);
+    font-size: 2.8rem;
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: -0.01em;
+    margin-bottom: 0.4rem;
   }
   .report-period {
     font-family: var(--font-mono);
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: var(--muted);
     margin-top: 0.25rem;
   }
@@ -86,19 +67,19 @@
 
 {% if report is none %}
 <div style="text-align: center; padding: 3rem 1.5rem; border: 1px dashed var(--border); border-radius: var(--radius);">
-  <p style="font-family: var(--font-mono); font-size: 2rem; color: var(--border); margin-bottom: 1rem;">[ ]</p>
+  <p style="font-family: var(--font-display); font-style: italic; font-size: 2.5rem; color: var(--border); margin-bottom: 1rem;">∅</p>
   <p style="font-weight: 600; color: var(--text); margin-bottom: 0.5rem;">No data for {{ month_label }}</p>
   <p style="font-size: 0.9rem;">No holdings were found. Add stocks to your portfolio to generate reports.</p>
 </div>
 {% else %}
 
-<div class="report-header">
+<div class="report-header anim-fade-slide-down">
   <h1>{{ report.month_label }}</h1>
   <p class="report-period">{{ report.period_start.strftime("%d %b %Y") }} – {{ report.period_end.strftime("%d %b %Y") }}</p>
 </div>
 
 <div class="stats-strip">
-  <div class="stat-card">
+  <div class="stat-card anim-fade-slide-up" style="animation-delay:0ms">
     <span class="stat-label">Value on {{ report.period_start.strftime("%-d %b") }}</span>
     {% if report.total_value_1st is not none %}
       <span class="stat-value neutral">€{{ "%.2f"|format(report.total_value_1st) }}</span>
@@ -106,8 +87,7 @@
       <span class="stat-value na">—</span>
     {% endif %}
   </div>
-
-  <div class="stat-card">
+  <div class="stat-card anim-fade-slide-up" style="animation-delay:60ms">
     <span class="stat-label">Value on {{ report.period_end.strftime("%-d %b") }}</span>
     {% if report.total_value_last is not none %}
       <span class="stat-value neutral">€{{ "%.2f"|format(report.total_value_last) }}</span>
@@ -115,8 +95,7 @@
       <span class="stat-value na">—</span>
     {% endif %}
   </div>
-
-  <div class="stat-card">
+  <div class="stat-card anim-fade-slide-up" style="animation-delay:120ms">
     <span class="stat-label">Delta (€)</span>
     {% if report.total_delta_eur is not none %}
       {% set sign = "+" if report.total_delta_eur >= 0 else "" %}
@@ -126,8 +105,7 @@
       <span class="stat-value na">—</span>
     {% endif %}
   </div>
-
-  <div class="stat-card">
+  <div class="stat-card anim-fade-slide-up" style="animation-delay:180ms">
     <span class="stat-label">Delta (%)</span>
     {% if report.total_delta_pct is not none %}
       {% set sign = "+" if report.total_delta_pct >= 0 else "" %}
@@ -139,7 +117,7 @@
   </div>
 </div>
 
-<div class="card">
+<div class="card anim-fade-in" style="animation-delay: 250ms">
   <h2>Per-Stock Breakdown</h2>
   <table>
     <thead>
@@ -156,42 +134,32 @@
       {% for line in report.lines %}
       <tr>
         <td>
-          <span style="font-family: var(--font-mono); font-weight: 600;">{{ line.ticker }}</span>
+          <span style="font-family: var(--font-mono); font-weight: 600; color: var(--accent);">{{ line.ticker }}</span>
           <br>
-          <span style="font-size: 0.8rem; color: var(--muted);">{{ line.name }}</span>
+          <span style="font-size: 0.78rem; color: var(--muted); font-family: var(--font-mono);">{{ line.name }}</span>
         </td>
         <td class="number">{{ line.quantity }}</td>
         <td class="number">
-          {% if line.price_1st is not none %}
-            €{{ "%.2f"|format(line.price_1st) }}
-          {% else %}
-            <span class="na">—</span>
-          {% endif %}
+          {% if line.price_1st is not none %}€{{ "%.2f"|format(line.price_1st) }}
+          {% else %}<span class="na">—</span>{% endif %}
         </td>
         <td class="number">
-          {% if line.price_last is not none %}
-            €{{ "%.2f"|format(line.price_last) }}
-          {% else %}
-            <span class="na">—</span>
-          {% endif %}
+          {% if line.price_last is not none %}€{{ "%.2f"|format(line.price_last) }}
+          {% else %}<span class="na">—</span>{% endif %}
         </td>
         <td class="number">
           {% if line.delta_eur is not none %}
             {% set sign = "+" if line.delta_eur >= 0 else "" %}
             {% set css  = "positive" if line.delta_eur >= 0 else "negative" %}
             <span class="{{ css }}">{{ sign }}€{{ "%.2f"|format(line.delta_eur) }}</span>
-          {% else %}
-            <span class="na">—</span>
-          {% endif %}
+          {% else %}<span class="na">—</span>{% endif %}
         </td>
         <td class="number">
           {% if line.delta_pct is not none %}
             {% set sign = "+" if line.delta_pct >= 0 else "" %}
             {% set css  = "positive" if line.delta_pct >= 0 else "negative" %}
             <span class="{{ css }}">{{ sign }}{{ line.delta_pct }}%</span>
-          {% else %}
-            <span class="na">—</span>
-          {% endif %}
+          {% else %}<span class="na">—</span>{% endif %}
         </td>
       </tr>
       {% endfor %}
@@ -201,36 +169,26 @@
         <td><strong>Total</strong></td>
         <td class="number"></td>
         <td class="number">
-          {% if report.total_value_1st is not none %}
-            €{{ "%.2f"|format(report.total_value_1st) }}
-          {% else %}
-            <span class="na">—</span>
-          {% endif %}
+          {% if report.total_value_1st is not none %}€{{ "%.2f"|format(report.total_value_1st) }}
+          {% else %}<span class="na">—</span>{% endif %}
         </td>
         <td class="number">
-          {% if report.total_value_last is not none %}
-            €{{ "%.2f"|format(report.total_value_last) }}
-          {% else %}
-            <span class="na">—</span>
-          {% endif %}
+          {% if report.total_value_last is not none %}€{{ "%.2f"|format(report.total_value_last) }}
+          {% else %}<span class="na">—</span>{% endif %}
         </td>
         <td class="number">
           {% if report.total_delta_eur is not none %}
             {% set sign = "+" if report.total_delta_eur >= 0 else "" %}
             {% set css  = "positive" if report.total_delta_eur >= 0 else "negative" %}
             <span class="{{ css }}"><strong>{{ sign }}€{{ "%.2f"|format(report.total_delta_eur) }}</strong></span>
-          {% else %}
-            <span class="na">—</span>
-          {% endif %}
+          {% else %}<span class="na">—</span>{% endif %}
         </td>
         <td class="number">
           {% if report.total_delta_pct is not none %}
             {% set sign = "+" if report.total_delta_pct >= 0 else "" %}
             {% set css  = "positive" if report.total_delta_pct >= 0 else "negative" %}
             <span class="{{ css }}"><strong>{{ sign }}{{ report.total_delta_pct }}%</strong></span>
-          {% else %}
-            <span class="na">—</span>
-          {% endif %}
+          {% else %}<span class="na">—</span>{% endif %}
         </td>
       </tr>
     </tfoot>

--- a/app/templates/reports.html
+++ b/app/templates/reports.html
@@ -1,42 +1,123 @@
 {% extends "base.html" %}
 
-{% block title %}Monthly Reports — Terminal Ledger{% endblock %}
+{% block title %}Reports — Meridian{% endblock %}
+{% block active_page %}reports{% endblock %}
+
+{% block extra_head %}
+<style>
+  .reports-header { margin-bottom: 2.5rem; }
+  .reports-title {
+    font-family: var(--font-display);
+    font-size: 2.8rem;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.01em;
+  }
+  .reports-subtitle { color: var(--muted); font-size: 0.9rem; }
+
+  .reports-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  .report-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    text-decoration: none;
+    transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+  }
+  .report-card:hover {
+    border-color: var(--accent);
+    background: rgba(212, 146, 74, 0.04);
+    transform: translateY(-2px);
+    text-decoration: none;
+    opacity: 1;
+  }
+  .report-card-year {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--muted);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0.1rem;
+  }
+  .report-card-month {
+    font-family: var(--font-display);
+    font-size: 1.9rem;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1;
+    margin-bottom: 0.35rem;
+  }
+  .report-card-range {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--muted);
+  }
+  .report-card-link {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--accent);
+    margin-top: auto;
+    padding-top: 1rem;
+    font-family: var(--font-mono);
+    letter-spacing: 0.02em;
+  }
+
+  .reports-empty {
+    text-align: center;
+    padding: 4rem 2rem;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius);
+  }
+  .reports-empty-glyph {
+    font-family: var(--font-display);
+    font-size: 3rem;
+    font-style: italic;
+    color: var(--border);
+    margin-bottom: 1rem;
+    opacity: 0.6;
+  }
+  .reports-empty-title {
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 0.5rem;
+  }
+</style>
+{% endblock %}
 
 {% block content %}
-<h1>Monthly Reports</h1>
-<p>Historical portfolio performance, one month at a time.</p>
+<div class="reports-header anim-fade-slide-down">
+  <div class="reports-title">Reports</div>
+  <p class="reports-subtitle">Historical portfolio performance, one month at a time.</p>
+</div>
 
 {% if months %}
-<table style="margin-top: 1.5rem;">
-  <thead>
-    <tr>
-      <th>Period</th>
-      <th>Date Range</th>
-      <th class="actions"></th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for m in months %}
-    <tr>
-      <td><span class="text-mono" style="font-weight: 600;">{{ m.label }}</span></td>
-      <td style="color: var(--muted); font-family: var(--font-mono); font-size: 0.85rem;">
-        {{ m.period_start.strftime("%d %b %Y") }} – {{ m.period_end.strftime("%d %b %Y") }}
-      </td>
-      <td class="actions">
-        <a href="/reports/{{ m.year }}/{{ '%02d'|format(m.month) }}"
-           style="font-family: var(--font-mono); font-size: 0.85rem; font-weight: 600;">
-          View &rarr;
-        </a>
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+<div class="reports-grid">
+  {% for m in months %}
+  <a href="/reports/{{ m.year }}/{{ '%02d'|format(m.month) }}" class="report-card anim-fade-in" style="animation-delay: {{ loop.index0 * 45 }}ms">
+    <div class="report-card-year">{{ m.year }}</div>
+    <div class="report-card-month">{{ m.label.split(' ')[0] }}</div>
+    <div class="report-card-range">
+      {{ m.period_start.strftime("%d %b") }} – {{ m.period_end.strftime("%d %b") }}
+    </div>
+    <div class="report-card-link">View &rarr;</div>
+  </a>
+  {% endfor %}
+</div>
 {% else %}
-<div style="margin-top: 2rem; text-align: center; padding: 3rem 1.5rem; border: 1px dashed var(--border); border-radius: var(--radius);">
-  <p style="font-family: var(--font-mono); font-size: 2rem; color: var(--border); margin-bottom: 1rem;">[ ]</p>
-  <p style="font-weight: 600; color: var(--text); margin-bottom: 0.5rem;">No reports yet</p>
-  <p style="font-size: 0.9rem;">Reports will appear here once a full calendar month of price data has been recorded.</p>
+<div class="reports-empty">
+  <div class="reports-empty-glyph">∅</div>
+  <p class="reports-empty-title">No reports yet</p>
+  <p>Reports appear once a full calendar month of price data has been recorded.</p>
 </div>
 {% endif %}
 {% endblock %}

--- a/app/templates/stock_detail.html
+++ b/app/templates/stock_detail.html
@@ -1,42 +1,19 @@
 {% extends "base.html" %}
 
-{% block title %}{{ stock.ticker }} — Terminal Ledger{% endblock %}
+{% block title %}{{ stock.ticker }} — Meridian{% endblock %}
+{% block active_page %}portfolio{% endblock %}
 
 {% block extra_head %}
 <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
 <style>
-  /* ── Back nav ────────────────────────────────────────────────── */
-  .back-nav {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--muted);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 0.25rem 0.65rem;
-    margin-bottom: 2rem;
-    text-decoration: none;
-    transition: color 120ms ease, border-color 120ms ease;
-  }
-  .back-nav:hover {
-    color: var(--text);
-    border-color: var(--muted);
-    text-decoration: none;
-    opacity: 1;
-  }
-
   /* ── Instrument header ───────────────────────────────────────── */
-  .instrument-header {
-    margin-bottom: 2rem;
-  }
+  .instrument-header { margin-bottom: 2rem; }
   .instrument-ticker {
-    font-family: var(--font-mono);
-    font-size: 2.8rem;
+    font-family: var(--font-display);
+    font-size: 3.5rem;
     font-weight: 600;
     color: var(--text);
-    letter-spacing: 0.04em;
+    letter-spacing: 0.01em;
     line-height: 1;
     margin-bottom: 0.3rem;
   }
@@ -52,7 +29,7 @@
     background: linear-gradient(to right, var(--accent), transparent);
     border: none;
     margin: 0;
-    opacity: 0.5;
+    opacity: 0.45;
   }
 
   /* ── Stats strip ─────────────────────────────────────────────── */
@@ -73,7 +50,7 @@
   }
   .stat-label {
     font-family: var(--font-mono);
-    font-size: 0.7rem;
+    font-size: 0.65rem;
     color: var(--muted);
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -82,7 +59,7 @@
     font-family: var(--font-mono);
     font-size: 1.35rem;
     font-weight: 600;
-    color: var(--accent);
+    color: var(--text);
     line-height: 1.1;
   }
   .stat-value.na {
@@ -99,11 +76,11 @@
     margin-bottom: 1.5rem;
   }
   .chart-card-title {
-    font-family: var(--font-ui);
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.7rem;
+    letter-spacing: 0.08em;
     color: var(--muted);
     margin-bottom: 1rem;
   }
@@ -118,9 +95,7 @@
     padding: 3rem 2rem;
     color: var(--muted);
   }
-  .no-data-icon {
-    opacity: 0.3;
-  }
+  .no-data-icon { opacity: 0.25; }
   .no-data-text {
     font-family: var(--font-mono);
     font-size: 0.85rem;
@@ -130,58 +105,46 @@
 
   @media (max-width: 600px) {
     .stats-strip { grid-template-columns: 1fr; }
-    .instrument-ticker { font-size: 2rem; }
+    .instrument-ticker { font-size: 2.5rem; }
   }
 </style>
 {% endblock %}
 
 {% block content %}
 
-  <!-- Back navigation -->
   <a href="/" class="back-nav">&larr; Portfolio</a>
 
-  <!-- Instrument header -->
   <div class="instrument-header">
     <div class="instrument-ticker">{{ stock.ticker }}</div>
     <div class="instrument-name">{{ stock.name }}</div>
     <hr class="instrument-sep">
   </div>
 
-  <!-- Stats strip -->
   <div class="stats-strip">
     <div class="stat-card anim-fade-slide-up" style="animation-delay: 0ms">
       <span class="stat-label">Quantity</span>
       <span class="stat-value{% if stock.quantity is none %} na{% endif %}">
-        {% if stock.quantity is not none %}
-          {{ stock.quantity }}
-        {% else %}
-          —
-        {% endif %}
+        {% if stock.quantity is not none %}{{ stock.quantity }}{% else %}—{% endif %}
       </span>
     </div>
     <div class="stat-card anim-fade-slide-up" style="animation-delay: 80ms">
       <span class="stat-label">Current Price</span>
       <span class="stat-value{% if stock.current_price is none %} na{% endif %}">
         {% if stock.current_price is not none %}
-          {{ "%.2f"|format(stock.current_price) }} <small style="font-size:0.75em;color:var(--muted);">EUR</small>
-        {% else %}
-          —
-        {% endif %}
+          {{ "%.2f"|format(stock.current_price) }} <small style="font-size:0.7em;color:var(--muted);">EUR</small>
+        {% else %}—{% endif %}
       </span>
     </div>
     <div class="stat-card anim-fade-slide-up" style="animation-delay: 160ms">
       <span class="stat-label">Current Value</span>
       <span class="stat-value{% if stock.current_value is none %} na{% endif %}">
         {% if stock.current_value is not none %}
-          {{ "%.2f"|format(stock.current_value) }} <small style="font-size:0.75em;color:var(--muted);">EUR</small>
-        {% else %}
-          —
-        {% endif %}
+          {{ "%.2f"|format(stock.current_value) }} <small style="font-size:0.7em;color:var(--muted);">EUR</small>
+        {% else %}—{% endif %}
       </span>
     </div>
   </div>
 
-  <!-- Price history chart -->
   <div class="chart-card anim-fade-in" style="animation-delay: 200ms">
     <div class="chart-card-title">Price History &middot; 1Y</div>
     <div id="price-history-chart" style="height: 300px;"></div>
@@ -194,58 +157,51 @@
   (async () => {
     const resp = await fetch('/api/v1/stocks/{{ stock.ticker }}/chart/price-history');
     const fig = await resp.json();
-
     const container = document.getElementById('price-history-chart');
 
     if (fig && fig.data && fig.data.length) {
-      // Apply dark theme and green line with fill
       const trace = Object.assign({}, fig.data[0], {
-        line: { color: '#22d3a0', width: 2 },
+        line: { color: '#D4924A', width: 2 },
         fill: 'tozeroy',
-        fillcolor: 'rgba(34, 211, 160, 0.07)',
+        fillcolor: 'rgba(212, 146, 74, 0.07)',
         mode: 'lines',
       });
-
       const layout = {
-        paper_bgcolor: '#161b22',
-        plot_bgcolor: '#161b22',
+        paper_bgcolor: '#141210',
+        plot_bgcolor:  '#141210',
         margin: { t: 10, b: 40, l: 60, r: 10 },
-        font: { color: '#8b949e', family: "'JetBrains Mono', monospace", size: 11 },
+        font: { color: '#8A8178', family: "'JetBrains Mono', monospace", size: 11 },
         xaxis: {
           showgrid: false,
           zeroline: false,
-          tickcolor: '#30363d',
-          linecolor: '#30363d',
-          tickfont: { color: '#8b949e' },
+          tickcolor: '#2C2825',
+          linecolor: '#2C2825',
+          tickfont: { color: '#8A8178' },
         },
         yaxis: {
           showgrid: true,
-          gridcolor: '#30363d',
+          gridcolor: '#2C2825',
           zeroline: false,
           tickformat: ',.2f',
-          tickfont: { color: '#8b949e' },
+          tickfont: { color: '#8A8178' },
         },
         hovermode: 'x unified',
         hoverlabel: {
-          bgcolor: '#0d1117',
-          bordercolor: '#30363d',
-          font: { color: '#e6edf3', family: "'JetBrains Mono', monospace" },
+          bgcolor: '#0A0908',
+          bordercolor: '#2C2825',
+          font: { color: '#F2EDE4', family: "'JetBrains Mono', monospace" },
         },
       };
-
-      Plotly.newPlot(container, [trace], layout, {
-        responsive: true,
-        displayModeBar: false,
-      });
+      Plotly.newPlot(container, [trace], layout, { responsive: true, displayModeBar: false });
     } else {
       container.innerHTML = `
         <div class="no-data-state">
-          <svg class="no-data-icon" width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="4" y="32" width="8" height="12" rx="1" fill="#8b949e"/>
-            <rect x="16" y="22" width="8" height="22" rx="1" fill="#8b949e"/>
-            <rect x="28" y="14" width="8" height="30" rx="1" fill="#8b949e"/>
-            <rect x="40" y="8" width="4" height="36" rx="1" fill="#8b949e"/>
-            <line x1="4" y1="36" x2="44" y2="36" stroke="#30363d" stroke-width="1"/>
+          <svg class="no-data-icon" width="48" height="48" viewBox="0 0 48 48" fill="none">
+            <rect x="4" y="32" width="8" height="12" rx="1" fill="#8A8178"/>
+            <rect x="16" y="22" width="8" height="22" rx="1" fill="#8A8178"/>
+            <rect x="28" y="14" width="8" height="30" rx="1" fill="#8A8178"/>
+            <rect x="40" y="8" width="4" height="36" rx="1" fill="#8A8178"/>
+            <line x1="4" y1="36" x2="44" y2="36" stroke="#2C2825" stroke-width="1"/>
           </svg>
           <span class="no-data-text">// no price history available &mdash; data is refreshed daily</span>
         </div>`;


### PR DESCRIPTION
## Summary

Comprehensive frontend redesign replacing the "Terminal Ledger" blue-dark + teal aesthetic with **"Meridian"** — a warm, refined design inspired by premium financial journalism (FT, Bloomberg editorial) and Swiss precision instruments.

### What changed

- **Design system**: Warm near-black (`#0A0908`) + amber/gold accent (`#D4924A`), replacing blue-dark + teal. Green (`#5AB87E`) and red (`#C96B6B`) for gains/losses respectively.
- **Typography**: Cormorant Garamond (serif display font for hero numbers and page headings) + DM Sans (clean UI text) + JetBrains Mono (tickers and financial data)
- **Layout**: Fixed 220px sidebar navigation replacing the horizontal top nav bar, with per-page active state highlighting
- **Portfolio page**: Hero portfolio value in large Cormorant Garamond serif; Gain/Loss and Allocation charts side-by-side in a 2-column grid below the full-width Performance chart
- **Reports page**: Month card grid replacing the bare table — each card shows month in large serif with amber hover lift effect
- **Stock detail**: Ticker symbol rendered in Cormorant Garamond at 3.5rem
- **Import pages**: Unified back-nav component, all pages updated to new color tokens
- **All Plotly charts**: Amber line for performance, green/red for gain/loss, warm custom palette for allocation donut

### Architecture unchanged

All Jinja2 templates, HTMX attributes, URL routes, and Python backend are untouched. The redesign is purely CSS + HTML template structure.

## Test plan

- [ ] Portfolio page renders with sidebar, amber hero value in serif font, 2-col chart grid
- [ ] All sidebar nav items highlight the correct active page
- [ ] HTMX flows work: add holding, edit quantity, delete holding, validate ticker
- [ ] Plotly charts render with amber/green/red palette
- [ ] Reports page shows card grid (not a table)
- [ ] Stock detail ticker renders in Cormorant Garamond
- [ ] XML import preview step uses wide layout (`main-content--wide`)
- [ ] Import step indicators and drop zones style correctly

Closes #127, #128, #129, #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)