### PR TITLE
fix(report): apply FX conversion and use historical quantities

### DIFF
--- a/app/services/holdings_service.py
+++ b/app/services/holdings_service.py
@@ -7,10 +7,11 @@ recompute whenever transactions are added or changed.
 
 from __future__ import annotations
 
+import datetime
 from collections.abc import Iterable
 from decimal import Decimal
 
-from sqlalchemy import case, func, select
+from sqlalchemy import Date, case, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.holding import Holding
@@ -109,4 +110,33 @@ async def net_shares_by_stock(
     return await _net_positions(db, stock_ids)
 
 
-__all__ = ["recompute_holdings", "net_shares_by_stock"]
+async def net_shares_as_of_date(
+    db: AsyncSession,
+    as_of: datetime.date,
+    stock_ids: Iterable[int] | None = None,
+) -> dict[int, Decimal]:
+    """Return ``{stock_id: net_shares}`` considering only transactions with date <= as_of."""
+    signed = case(
+        (Transaction.type.in_(_POSITIVE), Transaction.shares),
+        (Transaction.type.in_(_NEGATIVE), -Transaction.shares),
+        else_=Decimal("0"),
+    )
+    stmt = (
+        select(Transaction.stock_id, func.coalesce(func.sum(signed), 0))
+        .where(
+            Transaction.stock_id.is_not(None),
+            cast(Transaction.date, Date) <= as_of,
+        )
+        .group_by(Transaction.stock_id)
+    )
+    id_list = list(stock_ids) if stock_ids is not None else None
+    if id_list is not None:
+        if not id_list:
+            return {}
+        stmt = stmt.where(Transaction.stock_id.in_(id_list))
+
+    result = await db.execute(stmt)
+    return {sid: Decimal(net or 0) for sid, net in result.all() if sid is not None}
+
+
+__all__ = ["recompute_holdings", "net_shares_by_stock", "net_shares_as_of_date"]

--- a/app/services/report_service.py
+++ b/app/services/report_service.py
@@ -11,10 +11,11 @@ from decimal import Decimal
 from jinja2 import Environment, PackageLoader, select_autoescape
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
-from app.models.holding import Holding
 from app.models.price_cache import PriceCache
+from app.models.stock import Stock
+from app.services.fx_service import to_eur
+from app.services.holdings_service import net_shares_as_of_date
 
 logger = logging.getLogger(__name__)
 
@@ -109,13 +110,24 @@ class ReportService:
         period_end: datetime.date,
     ) -> MonthlyReportData | None:
         """Core report-building logic shared by all public methods."""
-        rows = await db.execute(select(Holding).options(selectinload(Holding.stock)))
-        holdings = rows.scalars().all()
+        start_of_period = period_start - datetime.timedelta(days=1)
 
-        if not holdings:
+        # Historical quantities: what did the portfolio look like at the period
+        # boundaries?  Using current holdings would misrepresent months where
+        # shares were bought or sold mid-period.
+        start_positions = await net_shares_as_of_date(db, start_of_period)
+        end_positions = await net_shares_as_of_date(db, period_end)
+
+        all_stock_ids = set(start_positions) | set(end_positions)
+        if not all_stock_ids:
             return None
 
-        tickers = [h.stock.ticker for h in holdings]
+        stocks_result = await db.execute(
+            select(Stock).where(Stock.id.in_(list(all_stock_ids)))
+        )
+        stocks: dict[int, Stock] = {s.id: s for s in stocks_result.scalars().all()}
+
+        tickers = [s.ticker for s in stocks.values()]
 
         price_rows = await db.execute(
             select(PriceCache.ticker, PriceCache.date, PriceCache.close_price)
@@ -134,19 +146,27 @@ class ReportService:
         total_value_1st: Decimal | None = None
         total_value_last: Decimal | None = None
 
-        for h in holdings:
-            ticker = h.stock.ticker
+        for sid in sorted(all_stock_ids):
+            stock = stocks.get(sid)
+            if stock is None:
+                continue
+
+            ticker = stock.ticker
+            currency = stock.currency
+            qty_start = start_positions.get(sid, Decimal("0"))
+            qty_end = end_positions.get(sid, Decimal("0"))
+
             ticker_prices = prices.get(ticker, {})
 
             price_1st: Decimal | None = None
             price_last: Decimal | None = None
 
             if ticker_prices:
-                price_1st = ticker_prices[min(ticker_prices)]
-                price_last = ticker_prices[max(ticker_prices)]
+                price_1st = to_eur(ticker_prices[min(ticker_prices)], currency)
+                price_last = to_eur(ticker_prices[max(ticker_prices)], currency)
 
-            value_1st = h.quantity * price_1st if price_1st is not None else None
-            value_last = h.quantity * price_last if price_last is not None else None
+            value_1st = qty_start * price_1st if price_1st is not None else None
+            value_last = qty_end * price_last if price_last is not None else None
 
             delta_eur: Decimal | None = None
             delta_pct: Decimal | None = None
@@ -165,8 +185,8 @@ class ReportService:
             lines.append(
                 StockReportLine(
                     ticker=ticker,
-                    name=h.stock.name,
-                    quantity=h.quantity,
+                    name=stock.name,
+                    quantity=qty_end,
                     price_1st=price_1st,
                     price_last=price_last,
                     value_1st=value_1st,

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -14,34 +14,53 @@ from app.services.report_service import MonthlyReportData, ReportService, StockR
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_holding(
+def _make_stock(
+    sid: int,
     ticker: str,
     name: str,
-    quantity: str,
+    currency: str = "EUR",
 ) -> MagicMock:
     stock = MagicMock()
+    stock.id = sid
     stock.ticker = ticker
     stock.name = name
-
-    holding = MagicMock()
-    holding.quantity = Decimal(quantity)
-    holding.stock = stock
-    return holding
+    stock.currency = currency
+    return stock
 
 
-def _make_db(holdings: list[MagicMock], price_rows: list[tuple]) -> AsyncMock:  # type: ignore[type-arg]
-    """Return an AsyncMock db whose execute() returns holdings on the first call
+def _make_db(stocks: list[MagicMock], price_rows: list[tuple]) -> AsyncMock:  # type: ignore[type-arg]
+    """Return an AsyncMock db whose execute() returns stocks on the first call
     and price rows on the second call."""
     db = AsyncMock()
 
-    holdings_result = MagicMock()
-    holdings_result.scalars.return_value.all.return_value = holdings
+    stocks_result = MagicMock()
+    stocks_result.scalars.return_value.all.return_value = stocks
 
     prices_result = MagicMock()
     prices_result.__iter__ = MagicMock(return_value=iter(price_rows))
 
-    db.execute = AsyncMock(side_effect=[holdings_result, prices_result])
+    db.execute = AsyncMock(side_effect=[stocks_result, prices_result])
     return db
+
+
+def _patch_positions(
+    start: dict[int, str],
+    end: dict[int, str],
+) -> MagicMock:
+    """Return a patch context for net_shares_as_of_date.
+
+    *start* and *end* map stock_id → quantity string for the two calls made
+    by _build_report (start-of-period and end-of-period).
+    """
+    return patch(
+        "app.services.report_service.net_shares_as_of_date",
+        new=AsyncMock(
+            side_effect=[
+                {k: Decimal(v) for k, v in start.items()},
+                {k: Decimal(v) for k, v in end.items()},
+            ]
+        ),
+    )
 
 
 # Reference date: 10 Apr 2026 → previous month is March 2026
@@ -57,25 +76,26 @@ _MAR_31 = datetime.date(2026, 3, 31)
 @pytest.mark.asyncio
 async def test_no_holdings_returns_none() -> None:
     db = AsyncMock()
-    result = MagicMock()
-    result.scalars.return_value.all.return_value = []
-    db.execute = AsyncMock(return_value=result)
-
-    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+    with patch(
+        "app.services.report_service.net_shares_as_of_date",
+        new=AsyncMock(return_value={}),
+    ):
+        report = await ReportService().generate_monthly_report(db, reference_date=_REF)
 
     assert report is None
 
 
 @pytest.mark.asyncio
 async def test_single_holding_full_data() -> None:
-    holdings = [_make_holding("AAPL", "Apple Inc.", "10")]
+    stocks = [_make_stock(1, "AAPL", "Apple Inc.")]
     price_rows = [
         ("AAPL", _MAR_1, Decimal("150.0000")),
         ("AAPL", _MAR_31, Decimal("160.0000")),
     ]
-    db = _make_db(holdings, price_rows)
+    db = _make_db(stocks, price_rows)
 
-    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+    with _patch_positions(start={1: "10"}, end={1: "10"}):
+        report = await ReportService().generate_monthly_report(db, reference_date=_REF)
 
     assert report is not None
     assert report.month_label == "March 2026"
@@ -85,6 +105,7 @@ async def test_single_holding_full_data() -> None:
     assert len(report.lines) == 1
     line = report.lines[0]
     assert line.ticker == "AAPL"
+    assert line.quantity == Decimal("10")
     assert line.price_1st == Decimal("150.0000")
     assert line.price_last == Decimal("160.0000")
     assert line.value_1st == Decimal("1500.0000")
@@ -100,14 +121,15 @@ async def test_single_holding_full_data() -> None:
 
 @pytest.mark.asyncio
 async def test_negative_delta() -> None:
-    holdings = [_make_holding("TSLA", "Tesla Inc.", "5")]
+    stocks = [_make_stock(1, "TSLA", "Tesla Inc.")]
     price_rows = [
         ("TSLA", _MAR_1, Decimal("200.0000")),
         ("TSLA", _MAR_31, Decimal("180.0000")),
     ]
-    db = _make_db(holdings, price_rows)
+    db = _make_db(stocks, price_rows)
 
-    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+    with _patch_positions(start={1: "5"}, end={1: "5"}):
+        report = await ReportService().generate_monthly_report(db, reference_date=_REF)
 
     assert report is not None
     line = report.lines[0]
@@ -118,10 +140,11 @@ async def test_negative_delta() -> None:
 
 @pytest.mark.asyncio
 async def test_holding_without_cached_prices() -> None:
-    holdings = [_make_holding("UNKN", "Unknown Corp.", "3")]
-    db = _make_db(holdings, [])  # no price rows
+    stocks = [_make_stock(1, "UNKN", "Unknown Corp.")]
+    db = _make_db(stocks, [])  # no price rows
 
-    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+    with _patch_positions(start={1: "3"}, end={1: "3"}):
+        report = await ReportService().generate_monthly_report(db, reference_date=_REF)
 
     assert report is not None
     line = report.lines[0]
@@ -139,17 +162,18 @@ async def test_holding_without_cached_prices() -> None:
 @pytest.mark.asyncio
 async def test_multiple_holdings_mixed_prices() -> None:
     """Holdings with and without cached prices; total excludes missing prices."""
-    holdings = [
-        _make_holding("AAPL", "Apple Inc.", "10"),
-        _make_holding("UNKN", "Unknown Corp.", "5"),
+    stocks = [
+        _make_stock(1, "AAPL", "Apple Inc."),
+        _make_stock(2, "UNKN", "Unknown Corp."),
     ]
     price_rows = [
         ("AAPL", _MAR_1, Decimal("100.0000")),
         ("AAPL", _MAR_31, Decimal("110.0000")),
     ]
-    db = _make_db(holdings, price_rows)
+    db = _make_db(stocks, price_rows)
 
-    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+    with _patch_positions(start={1: "10", 2: "5"}, end={1: "10", 2: "5"}):
+        report = await ReportService().generate_monthly_report(db, reference_date=_REF)
 
     assert report is not None
     assert len(report.lines) == 2
@@ -169,21 +193,72 @@ async def test_multiple_holdings_mixed_prices() -> None:
 @pytest.mark.asyncio
 async def test_uses_first_and_last_available_trading_day() -> None:
     """When prices don't start on the 1st, use the earliest/latest available."""
-    holdings = [_make_holding("MSFT", "Microsoft Corp.", "2")]
+    stocks = [_make_stock(1, "MSFT", "Microsoft Corp.")]
     mar_3 = datetime.date(2026, 3, 3)
     mar_28 = datetime.date(2026, 3, 28)
     price_rows = [
         ("MSFT", mar_3, Decimal("400.0000")),
         ("MSFT", mar_28, Decimal("420.0000")),
     ]
-    db = _make_db(holdings, price_rows)
+    db = _make_db(stocks, price_rows)
 
-    report = await ReportService().generate_monthly_report(db, reference_date=_REF)
+    with _patch_positions(start={1: "2"}, end={1: "2"}):
+        report = await ReportService().generate_monthly_report(db, reference_date=_REF)
 
     assert report is not None
     line = report.lines[0]
     assert line.price_1st == Decimal("400.0000")
     assert line.price_last == Decimal("420.0000")
+
+
+@pytest.mark.asyncio
+async def test_mid_month_purchase_uses_historical_quantities() -> None:
+    """Shares bought mid-month: value_1st uses start quantity, value_last uses end quantity."""
+    stocks = [_make_stock(1, "AAPL", "Apple Inc.")]
+    price_rows = [
+        ("AAPL", _MAR_1, Decimal("100.0000")),
+        ("AAPL", _MAR_31, Decimal("110.0000")),
+    ]
+    db = _make_db(stocks, price_rows)
+
+    with _patch_positions(start={1: "5"}, end={1: "15"}):
+        report = await ReportService()._build_report(db, _MAR_1, _MAR_31)
+
+    assert report is not None
+    line = report.lines[0]
+    assert line.quantity == Decimal("15")
+    assert line.value_1st == Decimal("500.0000")    # 5 × 100
+    assert line.value_last == Decimal("1650.0000")  # 15 × 110
+    assert line.delta_eur == Decimal("1150.0000")
+    assert line.delta_pct == Decimal("230.00")      # 1150/500 × 100
+
+
+@pytest.mark.asyncio
+async def test_usd_stock_fx_conversion() -> None:
+    """USD stock prices are converted to EUR before computing values."""
+    stocks = [_make_stock(1, "AAPL", "Apple Inc.", currency="USD")]
+    price_rows = [
+        ("AAPL", _MAR_1, Decimal("110.0000")),
+        ("AAPL", _MAR_31, Decimal("110.0000")),
+    ]
+    db = _make_db(stocks, price_rows)
+
+    # 1 EUR = 1.10 USD → $110 = €100
+    def fake_to_eur(amount: Decimal, currency: str) -> Decimal:
+        return amount / Decimal("1.1") if currency == "USD" else amount
+
+    with _patch_positions(start={1: "10"}, end={1: "10"}), patch(
+        "app.services.report_service.to_eur", side_effect=fake_to_eur
+    ):
+        report = await ReportService()._build_report(db, _MAR_1, _MAR_31)
+
+    assert report is not None
+    line = report.lines[0]
+    expected_price = Decimal("110.0000") / Decimal("1.1")  # = 100
+    assert line.price_1st == expected_price
+    assert line.price_last == expected_price
+    assert line.value_1st == Decimal("10") * expected_price
+    assert line.delta_eur == Decimal("0")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **FX conversion bug**: `PriceCache` stores prices in native currency (USD for US stocks), but `_build_report` multiplied `quantity × price` with no conversion before displaying values under a `€` symbol. All prices now pass through `to_eur()` so per-stock values and portfolio totals are accurate EUR figures.

- **Static quantity bug**: `_build_report` previously used the current `Holding.quantity` for both `value_1st` and `value_last`. In months where shares were bought or sold mid-period, this overstated the opening value. The report now calls a new `net_shares_as_of_date()` helper to derive the actual position at each period boundary from transaction history.

- **Broader scope**: Because position data is now read from transactions rather than `Holding`, stocks that were fully sold during the reporting period (no current holding) will also appear correctly in historical reports.

## Changes

| File | What changed |
|------|-------------|
| `app/services/holdings_service.py` | Added `net_shares_as_of_date(db, as_of, stock_ids=None)` — date-scoped variant of `_net_positions` using `cast(Transaction.date, Date) <= as_of` |
| `app/services/report_service.py` | `_build_report` rewritten: loads start/end positions from transactions, converts prices via `to_eur()`, queries `Stock` directly instead of through `Holding` |
| `tests/test_report_service.py` | Mocks updated for new DB call pattern; added `test_mid_month_purchase_uses_historical_quantities` and `test_usd_stock_fx_conversion` |

## Test plan

- [x] `pytest tests/test_report_service.py` — 11 tests pass (2 new)
- [x] Full suite (`pytest --ignore=tests/test_portfolio_page.py`) — 219 passed, 0 failures (pre-existing `test_portfolio_page_contains_expected_elements` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)