### PR TITLE
perf(charts): in-memory TTL cache for chart endpoints

### DIFF
--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -91,7 +91,11 @@ async def get_performance_chart(
         plot_bgcolor="#fff",
         paper_bgcolor="#fff",
     )
-    return Response(content=pio.to_json(fig), media_type="application/json")
+    return Response(
+        content=pio.to_json(fig),
+        media_type="application/json",
+        headers={"Cache-Control": "max-age=300, private"},
+    )
 
 
 @router.get("/chart/gain-loss")
@@ -127,7 +131,11 @@ async def get_gain_loss_chart(
         plot_bgcolor="#fff",
         paper_bgcolor="#fff",
     )
-    return Response(content=pio.to_json(fig), media_type="application/json")
+    return Response(
+        content=pio.to_json(fig),
+        media_type="application/json",
+        headers={"Cache-Control": "max-age=300, private"},
+    )
 
 
 @router.get("/chart/allocation")
@@ -158,7 +166,10 @@ async def get_allocation_chart(
         margin={"t": 20, "b": 20, "l": 20, "r": 20},
         showlegend=True,
     )
-    return JSONResponse(content=fig.to_dict())
+    return JSONResponse(
+        content=fig.to_dict(),
+        headers={"Cache-Control": "max-age=300, private"},
+    )
 
 
 @router.get("/summary", response_model=PortfolioSummary)

--- a/app/routers/import_xml.py
+++ b/app/routers/import_xml.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_async_session
 from app.models.stock import ASSET_TYPE_CRYPTO, ASSET_TYPE_STOCK, Stock
-from app.services import import_cache
+from app.services import chart_cache, import_cache
 from app.services.holdings_service import recompute_holdings
 from app.services.portfolio_performance_importer import (
     ParseResult,
@@ -151,6 +151,7 @@ async def import_xml_confirm(
         await ensure_prices_cached(list(ticker_rows.scalars().all()), db)
 
     import_cache.delete(token)
+    chart_cache.invalidate()
 
     return _render(
         request,

--- a/app/services/chart_cache.py
+++ b/app/services/chart_cache.py
@@ -1,0 +1,34 @@
+"""Lightweight in-memory TTL cache for chart computation results.
+
+Chart data (performance, gain/loss, allocation) is expensive to compute but
+changes only when new transactions are imported or the daily price refresh
+runs.  This module caches those results for up to _TTL seconds and exposes
+an invalidate() function so the import flow can bust the cache immediately
+after committing new transactions.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+_TTL = 300  # seconds — matches the Cache-Control max-age on chart endpoints
+_store: dict[str, tuple[float, Any]] = {}
+
+
+def get(key: str) -> Any | None:
+    """Return the cached value for *key* if it is still within TTL, else None."""
+    entry = _store.get(key)
+    if entry is not None and (time.monotonic() - entry[0]) < _TTL:
+        return entry[1]
+    return None
+
+
+def set(key: str, value: Any) -> None:  # noqa: A001
+    """Store *value* under *key* with the current timestamp."""
+    _store[key] = (time.monotonic(), value)
+
+
+def invalidate() -> None:
+    """Clear all cached chart results (call after importing new transactions)."""
+    _store.clear()

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -21,6 +21,7 @@ from app.models.transaction import (
     Transaction,
 )
 from app.schemas.holdings import HoldingSummaryItem, PortfolioSummary
+from app.services import chart_cache
 from app.services.fx_service import to_eur
 
 _POSITION_TYPES = ("BUY", "SELL", "TRANSFER_IN", "TRANSFER_OUT")
@@ -69,6 +70,10 @@ class PortfolioService:
         price contribute ``None`` for their value and are excluded from
         the ``total_value`` sum.
         """
+        cached = chart_cache.get("summary")
+        if cached is not None:
+            return cached
+
         rows = await db.execute(select(Holding).options(selectinload(Holding.stock)))
         holdings = rows.scalars().all()
 
@@ -99,7 +104,9 @@ class PortfolioService:
                 )
             )
 
-        return PortfolioSummary(holdings=items, total_value=total_value)
+        result = PortfolioSummary(holdings=items, total_value=total_value)
+        chart_cache.set("summary", result)
+        return result
 
     async def get_performance_history(
         self, db: AsyncSession, since: datetime.date | None = None
@@ -124,6 +131,11 @@ class PortfolioService:
         3. Multiply the running positions by the cached close price on
            date *d*, convert to EUR via the FX cache, and sum.
         """
+        cache_key = f"performance:{since}"
+        cached = chart_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
         event_rows = await db.execute(
             select(
                 Transaction.stock_id,
@@ -213,6 +225,7 @@ class PortfolioService:
 
             performance.append((date, total))
 
+        chart_cache.set(cache_key, performance)
         return performance
 
     @staticmethod
@@ -255,6 +268,10 @@ class PortfolioService:
         forward-filled market-value walk used by the Performance chart, but
         spans from the earliest transaction rather than the trailing year.
         """
+        cached = chart_cache.get("gain_loss")
+        if cached is not None:
+            return cached
+
         since = await self.earliest_transaction_date(db)
         market_values = await self.get_performance_history(db, since=since)
         if not market_values:
@@ -291,6 +308,7 @@ class PortfolioService:
                 ptr += 1
             gain_loss.append((date, market_value - net_invested))
 
+        chart_cache.set("gain_loss", gain_loss)
         return gain_loss
 
     async def earliest_transaction_date(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,13 @@ from httpx import ASGITransport, AsyncClient
 from app.config import Settings
 from app.database import get_async_session
 from app.main import create_app
+from app.services import chart_cache
+
+
+@pytest.fixture(autouse=True)
+def clear_chart_cache() -> None:
+    """Reset the chart cache before every test to prevent cross-test pollution."""
+    chart_cache.invalidate()
 
 
 def _make_test_settings() -> Settings:

--- a/tests/test_chart_cache.py
+++ b/tests/test_chart_cache.py
@@ -1,0 +1,58 @@
+"""Tests for the in-memory chart result cache."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.services import chart_cache
+
+
+def setup_function() -> None:
+    chart_cache.invalidate()
+
+
+def test_miss_returns_none() -> None:
+    assert chart_cache.get("nonexistent") is None
+
+
+def test_set_and_hit() -> None:
+    chart_cache.set("k", [1, 2, 3])
+    assert chart_cache.get("k") == [1, 2, 3]
+
+
+def test_ttl_expiry_returns_none() -> None:
+    with patch("app.services.chart_cache.time") as mock_time:
+        mock_time.monotonic.return_value = 0.0
+        chart_cache.set("k", "data")
+
+        # Still within TTL
+        mock_time.monotonic.return_value = 299.0
+        assert chart_cache.get("k") == "data"
+
+        # Exactly at TTL boundary — expired
+        mock_time.monotonic.return_value = 300.0
+        assert chart_cache.get("k") is None
+
+
+def test_invalidate_clears_all() -> None:
+    chart_cache.set("a", 1)
+    chart_cache.set("b", 2)
+    chart_cache.invalidate()
+    assert chart_cache.get("a") is None
+    assert chart_cache.get("b") is None
+
+
+def test_overwrite_updates_timestamp() -> None:
+    with patch("app.services.chart_cache.time") as mock_time:
+        mock_time.monotonic.return_value = 0.0
+        chart_cache.set("k", "old")
+
+        mock_time.monotonic.return_value = 290.0
+        chart_cache.set("k", "new")
+
+        # 290 + 290 = 580 > 300 from original write, but < 300 from re-write
+        mock_time.monotonic.return_value = 580.0
+        assert chart_cache.get("k") == "new"
+
+        mock_time.monotonic.return_value = 591.0
+        assert chart_cache.get("k") is None


### PR DESCRIPTION
## Summary

- Charts (Performance, Gain/Loss, Allocation) were recomputing from scratch on every page load — 3–4 DB queries + an O(days × stocks) walk each time
- Data only changes on import or the daily 07:00 price refresh, so repeat computation was pure waste
- Added `app/services/chart_cache.py`: a module-level dict cache with 5-minute TTL (no new dependencies, same pattern as `_fx_cache` in `fx_service.py`)
- Wrapped `get_performance_history`, `get_gain_loss_history`, and `get_summary` with cache check/store
- Cache is explicitly invalidated in `import_xml_confirm` so charts reflect new imports immediately, not after 5 min
- Added `Cache-Control: max-age=300, private` headers to all three chart endpoints so browsers skip the request on repeat loads

## Test plan

- [ ] `tests/test_chart_cache.py` — 5 new unit tests covering miss, hit, TTL expiry, invalidation, and timestamp refresh
- [ ] `tests/conftest.py` — `autouse` fixture clears cache before each test to prevent cross-test pollution
- [ ] Full suite: 225 passed (1 pre-existing failure in `test_portfolio_page` from Meridian redesign, unrelated)
- [ ] Check chart endpoints return `Cache-Control` header; observe second request < 5ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)