### PR TITLE
feat(charts): add year picker to performance and gain/loss charts

### DIFF
--- a/app/routers/holdings.py
+++ b/app/routers/holdings.py
@@ -6,7 +6,7 @@ import datetime
 
 import plotly.graph_objects as go
 import plotly.io as pio
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -61,11 +61,18 @@ async def _get_or_404(holding_id: int, db: AsyncSession) -> Holding:
 @router.get("/chart/performance")
 async def get_performance_chart(
     db: AsyncSession = _DB,
+    year: int | None = Query(None),
 ) -> Response:
     """Return a Plotly line chart of total portfolio value since the first transaction."""
     service = PortfolioService()
-    since = await service.earliest_transaction_date(db)
+    if year is not None:
+        since: datetime.date | None = datetime.date(year, 1, 1)
+        until = min(datetime.date(year, 12, 31), datetime.date.today())
+    else:
+        since = await service.earliest_transaction_date(db)
+        until = datetime.date.today()
     performance = await service.get_performance_history(db, since=since)
+    performance = [(d, v) for d, v in performance if d <= until]
 
     if not performance:
         return JSONResponse(content={})
@@ -101,9 +108,14 @@ async def get_performance_chart(
 @router.get("/chart/gain-loss")
 async def get_gain_loss_chart(
     db: AsyncSession = _DB,
+    year: int | None = Query(None),
 ) -> Response:
     """Return a Plotly line chart of Total P/L since the first transaction."""
     history = await PortfolioService().get_gain_loss_history(db)
+    if year is not None:
+        since_d = datetime.date(year, 1, 1)
+        until_d = min(datetime.date(year, 12, 31), datetime.date.today())
+        history = [(d, v) for d, v in history if since_d <= d <= until_d]
 
     if not history:
         return JSONResponse(content={})

--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -29,10 +29,16 @@ async def portfolio_overview(
     db: AsyncSession = _DB,
 ) -> HTMLResponse:
     """Render the portfolio overview page."""
-    summary = await PortfolioService().get_summary(db)
+    service = PortfolioService()
+    summary = await service.get_summary(db)
 
     last_refresh_result = await db.execute(select(func.max(PriceCache.date)))
     last_refresh: datetime.date | None = last_refresh_result.scalar()
+
+    current_year = datetime.date.today().year
+    earliest = await service.earliest_transaction_date(db)
+    earliest_year = earliest.year if earliest else current_year
+    chart_years = list(range(current_year, earliest_year - 1, -1))
 
     return templates.TemplateResponse(
         request=request,
@@ -42,5 +48,7 @@ async def portfolio_overview(
             "total_value": summary.total_value,
             "holdings_count": len(summary.holdings),
             "last_refresh": last_refresh,
+            "chart_years": chart_years,
+            "current_year": current_year,
         },
     )

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -121,8 +121,27 @@
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--muted);
+    margin-bottom: 0;
+  }
+  .chart-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     margin-bottom: 1rem;
   }
+  .year-picker {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    padding: 0.2rem 0.5rem;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+  }
+  .year-picker:focus { outline: 1px solid var(--accent); }
   .chart-row {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -308,13 +327,27 @@
   <!-- Charts (only when there is data) -->
   {% if total_value is not none %}
   <div class="chart-card anim-fade-in" style="animation-delay: 300ms">
-    <h2>Performance</h2>
+    <div class="chart-header">
+      <h2>Performance</h2>
+      <select id="perf-year-picker" class="year-picker">
+        {% for y in chart_years %}
+        <option value="{{ y }}"{% if y == current_year %} selected{% endif %}>{{ y }}</option>
+        {% endfor %}
+      </select>
+    </div>
     <div id="performance-chart" style="height: 310px;"></div>
   </div>
 
   <div class="chart-row">
     <div class="chart-card anim-fade-in" style="animation-delay: 400ms">
-      <h2>Gain / Loss</h2>
+      <div class="chart-header">
+        <h2>Gain / Loss</h2>
+        <select id="gain-loss-year-picker" class="year-picker">
+          {% for y in chart_years %}
+          <option value="{{ y }}"{% if y == current_year %} selected{% endif %}>{{ y }}</option>
+          {% endfor %}
+        </select>
+      </div>
       <div id="gain-loss-chart" style="height: 250px;"></div>
     </div>
     <div class="chart-card anim-fade-in" style="animation-delay: 480ms">
@@ -429,8 +462,9 @@
     margin: { t: 16, b: 40, l: 56, r: 16 },
   };
 
-  (async () => {
-    const resp = await fetch('/api/v1/holdings/chart/performance');
+  let perfChartInitialized = false;
+  async function loadPerformanceChart(year) {
+    const resp = await fetch(`/api/v1/holdings/chart/performance?year=${year}`);
     const fig = await resp.json();
     if (fig && fig.data) {
       const layout = Object.assign({}, fig.layout, DARK_LAYOUT, {
@@ -441,12 +475,18 @@
         fig.data[0].line = Object.assign({}, fig.data[0].line, { color: '#D4924A', width: 2 });
         fig.data[0].fillcolor = 'rgba(212, 146, 74, 0.07)';
       }
-      Plotly.newPlot('performance-chart', fig.data, layout, { responsive: true, displayModeBar: false });
+      if (perfChartInitialized) {
+        Plotly.react('performance-chart', fig.data, layout);
+      } else {
+        Plotly.newPlot('performance-chart', fig.data, layout, { responsive: true, displayModeBar: false });
+        perfChartInitialized = true;
+      }
     }
-  })();
+  }
 
-  (async () => {
-    const resp = await fetch('/api/v1/holdings/chart/gain-loss');
+  let gainLossChartInitialized = false;
+  async function loadGainLossChart(year) {
+    const resp = await fetch(`/api/v1/holdings/chart/gain-loss?year=${year}`);
     const fig = await resp.json();
     if (fig && fig.data) {
       const layout = Object.assign({}, fig.layout, DARK_LAYOUT, {
@@ -460,9 +500,21 @@
         fig.data[0].line = Object.assign({}, fig.data[0].line, { color });
         fig.data[0].fillcolor = last >= 0 ? 'rgba(90, 184, 126, 0.07)' : 'rgba(201, 107, 107, 0.07)';
       }
-      Plotly.newPlot('gain-loss-chart', fig.data, layout, { responsive: true, displayModeBar: false });
+      if (gainLossChartInitialized) {
+        Plotly.react('gain-loss-chart', fig.data, layout);
+      } else {
+        Plotly.newPlot('gain-loss-chart', fig.data, layout, { responsive: true, displayModeBar: false });
+        gainLossChartInitialized = true;
+      }
     }
-  })();
+  }
+
+  const _currentYear = {{ current_year }};
+  loadPerformanceChart(_currentYear);
+  loadGainLossChart(_currentYear);
+
+  document.getElementById('perf-year-picker').addEventListener('change', e => loadPerformanceChart(e.target.value));
+  document.getElementById('gain-loss-year-picker').addEventListener('change', e => loadGainLossChart(e.target.value));
 
   (async () => {
     const resp = await fetch('/api/v1/holdings/chart/allocation');


### PR DESCRIPTION
## Summary
- Adds a `<select>` year picker above the Performance and Gain/Loss chart cards
- Defaults to the current year; available years are data-driven (earliest transaction year → today)
- Selecting a year re-fetches chart data with `?year=YYYY` and updates the chart in place
- Both charts are independent — different years can be shown simultaneously
- Allocation chart is unaffected

## Test plan
- [ ] Portfolio page loads with year picker showing current year selected
- [ ] Switching year on Performance chart re-renders with only that year's dates
- [ ] Switching year on Gain/Loss chart re-renders with only that year's dates
- [ ] Charts are independent (can show different years)
- [ ] `?year=` with no data returns empty chart (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)