### PR TITLE
feat(charts): add "All" full-range option to chart year pickers

### DIFF
--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -49,6 +49,5 @@ async def portfolio_overview(
             "holdings_count": len(summary.holdings),
             "last_refresh": last_refresh,
             "chart_years": chart_years,
-            "current_year": current_year,
         },
     )

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -330,8 +330,9 @@
     <div class="chart-header">
       <h2>Performance</h2>
       <select id="perf-year-picker" class="year-picker">
+        <option value="" selected>All</option>
         {% for y in chart_years %}
-        <option value="{{ y }}"{% if y == current_year %} selected{% endif %}>{{ y }}</option>
+        <option value="{{ y }}">{{ y }}</option>
         {% endfor %}
       </select>
     </div>
@@ -343,8 +344,9 @@
       <div class="chart-header">
         <h2>Gain / Loss</h2>
         <select id="gain-loss-year-picker" class="year-picker">
+          <option value="" selected>All</option>
           {% for y in chart_years %}
-          <option value="{{ y }}"{% if y == current_year %} selected{% endif %}>{{ y }}</option>
+          <option value="{{ y }}">{{ y }}</option>
           {% endfor %}
         </select>
       </div>
@@ -464,7 +466,8 @@
 
   let perfChartInitialized = false;
   async function loadPerformanceChart(year) {
-    const resp = await fetch(`/api/v1/holdings/chart/performance?year=${year}`);
+    const url = year ? `/api/v1/holdings/chart/performance?year=${year}` : '/api/v1/holdings/chart/performance';
+    const resp = await fetch(url);
     const fig = await resp.json();
     if (fig && fig.data) {
       const layout = Object.assign({}, fig.layout, DARK_LAYOUT, {
@@ -486,7 +489,8 @@
 
   let gainLossChartInitialized = false;
   async function loadGainLossChart(year) {
-    const resp = await fetch(`/api/v1/holdings/chart/gain-loss?year=${year}`);
+    const url = year ? `/api/v1/holdings/chart/gain-loss?year=${year}` : '/api/v1/holdings/chart/gain-loss';
+    const resp = await fetch(url);
     const fig = await resp.json();
     if (fig && fig.data) {
       const layout = Object.assign({}, fig.layout, DARK_LAYOUT, {
@@ -509,9 +513,8 @@
     }
   }
 
-  const _currentYear = {{ current_year }};
-  loadPerformanceChart(_currentYear);
-  loadGainLossChart(_currentYear);
+  loadPerformanceChart('');
+  loadGainLossChart('');
 
   document.getElementById('perf-year-picker').addEventListener('change', e => loadPerformanceChart(e.target.value));
   document.getElementById('gain-loss-year-picker').addEventListener('change', e => loadGainLossChart(e.target.value));


### PR DESCRIPTION
## Summary
- Prepend a default-selected `All` entry to the Performance and Gain/Loss year-picker dropdowns
- Make the JS omit the `year` query parameter when `All` is selected so the backend's existing `year is None` branch returns the full history
- Drop the now-unused `current_year` template context variable

## Test plan
- [ ] Open the portfolio page → both pickers show `All` selected; Performance and Gain/Loss charts render the full history
- [ ] Pick a specific year on each picker → chart re-renders restricted to that year
- [ ] Switch back to `All` → chart re-renders with the full series
- [ ] Network: `All` fires `/api/v1/holdings/chart/{performance,gain-loss}` (no `?year=`); a year selection fires `?year=YYYY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)