### PR TITLE
feat(import): multi-PDF batch import with duplicate overview

### DIFF
--- a/app/routers/import_pdf.py
+++ b/app/routers/import_pdf.py
@@ -17,6 +17,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_async_session
 from app.models.transaction import TX_TYPE_BUY
+from app.services.batch_pdf_cache import BatchPdfItem
+from app.services import batch_pdf_cache
 from app.services.comdirect_parser import ComdirectParser, ParsedTrade
 from app.services.generic_parser import GenericTableParser
 from app.services.import_service import ImportService
@@ -66,16 +68,35 @@ async def import_pdf_page(request: Request) -> HTMLResponse:
 @router.post("/pdf", response_class=HTMLResponse)
 async def import_pdf_preview(
     request: Request,
-    file: UploadFile,
+    files: list[UploadFile],
+    db: AsyncSession = _DB,
 ) -> HTMLResponse:
-    """Accept a broker PDF, extract holdings, and show a preview."""
-    if not file.filename or not file.filename.lower().endswith(".pdf"):
+    """Accept one or more broker PDFs, extract trades/holdings, and show a preview."""
+    if not files or all(not f.filename for f in files):
         return _render(
             request,
             "import_pdf.html",
-            {"step": "upload", "error": "Please upload a valid PDF file."},
+            {"step": "upload", "error": "Please upload at least one PDF file."},
         )
 
+    invalid = [f.filename for f in files if f.filename and not f.filename.lower().endswith(".pdf")]
+    if invalid:
+        return _render(
+            request,
+            "import_pdf.html",
+            {"step": "upload", "error": f"Please upload valid PDF files only. Not accepted: {', '.join(invalid)}"},
+        )
+
+    # Single-file path — existing flow, untouched.
+    if len(files) == 1:
+        return await _handle_single_file(request, files[0])
+
+    # Multi-file batch path.
+    return await _handle_batch(request, files, db)
+
+
+async def _handle_single_file(request: Request, file: UploadFile) -> HTMLResponse:
+    """Original single-file flow: comdirect trade or generic holdings preview."""
     contents = await file.read()
 
     with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
@@ -120,6 +141,75 @@ async def import_pdf_preview(
         request,
         "import_pdf.html",
         {"step": "preview", "pairs": pairs},
+    )
+
+
+async def _handle_batch(
+    request: Request,
+    files: list[UploadFile],
+    db: AsyncSession,
+) -> HTMLResponse:
+    """Parse multiple PDFs, check duplicates, cache results, and show batch overview."""
+    key = getattr(getattr(request.app.state, "settings", None), "openfigi_api_key", "")
+    items: list[BatchPdfItem] = []
+
+    for file in files:
+        filename = file.filename or "unknown.pdf"
+        contents = await file.read()
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(contents)
+            tmp_path = Path(tmp.name)
+
+        trade: ParsedTrade | None = None
+        pairs: list[tuple[str, Decimal]] | None = None
+        parse_error: str | None = None
+
+        try:
+            trade = _comdirect.extract_trade(tmp_path)
+            if trade is None:
+                pairs = _parser.extract(tmp_path) or None
+                if pairs is None:
+                    parse_error = "No holdings found in this PDF."
+        except Exception as exc:
+            parse_error = f"Could not parse: {exc}"
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        ticker: str | None = None
+        is_duplicate: bool | None = None
+
+        if trade is not None:
+            t0 = time.perf_counter()
+            if trade.wkn:
+                ticker = await resolve_wkn(trade.wkn, key)
+            if ticker is None and trade.isin:
+                ticker = await resolve_isin(trade.isin, key)
+            logger.info(
+                "PDF batch import: ticker resolution for %s took %.2fs -> %s",
+                filename,
+                time.perf_counter() - t0,
+                ticker,
+            )
+            if ticker is not None:
+                is_duplicate = await _service.check_is_duplicate(trade, ticker, db)
+
+        items.append(
+            BatchPdfItem(
+                filename=filename,
+                trade=trade,
+                ticker=ticker,
+                is_duplicate=is_duplicate,
+                pairs=pairs,
+                parse_error=parse_error,
+            )
+        )
+
+    token = batch_pdf_cache.store(items)
+    return _render(
+        request,
+        "import_pdf.html",
+        {"step": "preview_batch", "items": items, "token": token, "enumerate": enumerate},
     )
 
 
@@ -259,4 +349,60 @@ async def import_pdf_confirm_trade(
         request,
         "import_pdf.html",
         {"step": "done", "processed": processed, "message": messages.get(status)},
+    )
+
+
+@router.post("/pdf/confirm-batch", response_class=HTMLResponse)
+async def import_pdf_confirm_batch(
+    request: Request,
+    token: Annotated[str, Form()],
+    selected: Annotated[list[int], Form()] = [],
+    db: AsyncSession = _DB,
+) -> HTMLResponse:
+    """Import the user-selected trades from the batch preview."""
+    preview = batch_pdf_cache.get(token)
+    if preview is None:
+        return _render(
+            request,
+            "import_pdf.html",
+            {"step": "upload", "error": "Preview session expired. Please re-upload your PDFs."},
+        )
+
+    created = 0
+    duplicates = 0
+    errors = 0
+
+    for idx in selected:
+        if idx < 0 or idx >= len(preview.items):
+            continue
+        item = preview.items[idx]
+
+        if item.parse_error:
+            errors += 1
+            continue
+
+        if item.trade is not None:
+            ticker = item.ticker or ""
+            if not ticker:
+                errors += 1
+                continue
+            status = await _service.import_trade(item.trade, ticker, db)
+            if status == "created":
+                created += 1
+            elif status == "duplicate":
+                duplicates += 1
+            else:
+                errors += 1
+        elif item.pairs is not None:
+            processed = await _service.import_from_holdings(item.pairs, db, source_file=item.filename)
+            created += len(processed)
+        else:
+            errors += 1
+
+    batch_pdf_cache.delete(token)
+
+    return _render(
+        request,
+        "import_pdf.html",
+        {"step": "done_batch", "created": created, "duplicates": duplicates, "errors": errors},
     )

--- a/app/services/batch_pdf_cache.py
+++ b/app/services/batch_pdf_cache.py
@@ -1,0 +1,59 @@
+"""In-memory store that bridges the multi-PDF batch preview and confirm steps."""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from app.services.comdirect_parser import ParsedTrade
+
+_TTL_SECONDS = 30 * 60
+
+
+@dataclass(slots=True)
+class BatchPdfItem:
+    filename: str
+    trade: ParsedTrade | None  # comdirect trade, or None
+    ticker: str | None  # resolved ticker, or None
+    is_duplicate: bool | None  # True/False, or None when ticker unknown
+    pairs: list[tuple[str, Decimal]] | None  # generic holdings, or None
+    parse_error: str | None  # error message if the file could not be parsed
+
+
+@dataclass(slots=True)
+class BatchPdfPreview:
+    items: list[BatchPdfItem]
+    created_at: float = field(default_factory=time.monotonic)
+
+
+_store: dict[str, BatchPdfPreview] = {}
+_lock = threading.Lock()
+
+
+def store(items: list[BatchPdfItem]) -> str:
+    token = uuid.uuid4().hex
+    with _lock:
+        _evict_expired_locked()
+        _store[token] = BatchPdfPreview(items=items)
+    return token
+
+
+def get(token: str) -> BatchPdfPreview | None:
+    with _lock:
+        _evict_expired_locked()
+        return _store.get(token)
+
+
+def delete(token: str) -> None:
+    with _lock:
+        _store.pop(token, None)
+
+
+def _evict_expired_locked() -> None:
+    now = time.monotonic()
+    expired = [k for k, e in _store.items() if now - e.created_at > _TTL_SECONDS]
+    for k in expired:
+        _store.pop(k, None)

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -98,6 +98,32 @@ class ImportService:
             await ensure_prices_cached(affected_tickers, db)
         return processed
 
+    async def check_is_duplicate(
+        self,
+        trade: ParsedTrade,
+        ticker: str,
+        db: AsyncSession,
+    ) -> bool | None:
+        """Check whether *trade* would be a duplicate without inserting anything.
+
+        Returns ``True`` (duplicate), ``False`` (new), or ``None`` (unknown
+        ticker).  Uses the same exact-UUID / fuzzy-same-day logic as
+        :meth:`import_trade`.
+        """
+        stock = await self._get_stock(db, ticker)
+        if stock is None:
+            return None
+
+        if trade.order_ref:
+            external_uuid = build_comdirect_external_uuid(trade.order_ref)
+            existing = await db.execute(
+                select(Transaction.id).where(
+                    Transaction.external_uuid == external_uuid
+                )
+            )
+            return existing.scalar_one_or_none() is not None
+        return await self._find_duplicate_trade(db, stock.id, trade)
+
     async def import_trade(
         self,
         trade: ParsedTrade,

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -455,6 +455,29 @@
       margin-top: 0.75rem;
     }
 
+    /* ── Batch PDF import status badges ─────────────────────── */
+    .status-badge {
+      display: inline-block;
+      font-size: 0.72rem;
+      font-weight: 600;
+      padding: 0.15rem 0.5rem;
+      border-radius: var(--radius-sm);
+      letter-spacing: 0.04em;
+      white-space: nowrap;
+    }
+    .status-new {
+      background: rgba(90, 184, 126, 0.12);
+      color: var(--positive);
+    }
+    .status-duplicate {
+      background: rgba(212, 146, 74, 0.12);
+      color: var(--accent);
+    }
+    .status-error {
+      background: rgba(201, 107, 107, 0.12);
+      color: var(--negative);
+    }
+
     /* ── Striped table rows ──────────────────────────────────── */
     .table-striped tbody tr:nth-child(even) {
       background: rgba(255, 255, 255, 0.015);

--- a/app/templates/import_pdf.html
+++ b/app/templates/import_pdf.html
@@ -13,11 +13,11 @@
       <span class="step-num">1</span> Upload
     </span>
     <span class="step-arrow">&rarr;</span>
-    <span class="step-item {{ 'active' if step == 'preview' else ('completed' if step == 'done' else '') }}">
+    <span class="step-item {{ 'active' if step in ('preview', 'preview_trade', 'preview_batch') else ('completed' if step in ('done', 'done_batch') else '') }}">
       <span class="step-num">2</span> Preview
     </span>
     <span class="step-arrow">&rarr;</span>
-    <span class="step-item {{ 'active' if step == 'done' else '' }}">
+    <span class="step-item {{ 'active' if step in ('done', 'done_batch') else '' }}">
       <span class="step-num">3</span> Done
     </span>
   </div>
@@ -39,9 +39,9 @@
           <line x1="12" y1="18" x2="12" y2="12"/>
           <polyline points="9 15 12 12 15 15"/>
         </svg>
-        <p class="drop-zone-text">Drag &amp; drop your PDF here or <strong>click to browse</strong></p>
+        <p class="drop-zone-text">Drag &amp; drop one or more PDFs here or <strong>click to browse</strong></p>
         <span class="file-badge">.PDF</span>
-        <input type="file" id="file" name="file" accept=".pdf" required>
+        <input type="file" id="file-input" name="files" accept=".pdf" multiple required>
         <p class="selected-file" id="selected-file"></p>
       </div>
       <button type="submit" class="btn-primary">Upload &amp; Preview</button>
@@ -141,9 +141,113 @@
     </form>
   </div>
 
+  {% elif step == "preview_batch" %}
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Batch overview: duplicate check across all uploaded PDFs            -->
+  <!-- ------------------------------------------------------------------ -->
+  {% set ns = namespace(new_count=0, dup_count=0, err_count=0) %}
+  {% for item in items %}
+    {% if item.parse_error %}
+      {% set ns.err_count = ns.err_count + 1 %}
+    {% elif item.is_duplicate == true %}
+      {% set ns.dup_count = ns.dup_count + 1 %}
+    {% else %}
+      {% set ns.new_count = ns.new_count + 1 %}
+    {% endif %}
+  {% endfor %}
+
+  <div class="card">
+    <h2>Batch overview — {{ items | length }} file(s)</h2>
+    <p class="note">
+      Review the trades extracted from your PDFs. Pre-checked entries will be imported;
+      duplicates and unresolved trades are unchecked by default.
+    </p>
+
+    <div style="display: flex; gap: 1rem; margin-bottom: 1.25rem; flex-wrap: wrap;">
+      {% if ns.new_count %}
+      <span style="color: var(--positive); font-weight: 600;">{{ ns.new_count }} new</span>
+      {% endif %}
+      {% if ns.dup_count %}
+      <span style="color: var(--accent); font-weight: 600;">{{ ns.dup_count }} duplicate{{ 's' if ns.dup_count != 1 }}</span>
+      {% endif %}
+      {% if ns.err_count %}
+      <span style="color: var(--negative); font-weight: 600;">{{ ns.err_count }} error{{ 's' if ns.err_count != 1 }}</span>
+      {% endif %}
+    </div>
+
+    <form method="post" action="/import/pdf/confirm-batch">
+      <input type="hidden" name="token" value="{{ token }}">
+      <div style="overflow-x: auto;">
+        <table class="table-striped">
+          <thead>
+            <tr>
+              <th style="width: 2rem;"></th>
+              <th>File</th>
+              <th>Type</th>
+              <th>Ticker</th>
+              <th class="number">Shares</th>
+              <th class="number">Amount</th>
+              <th>Date</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in items %}
+            {% set idx = loop.index0 %}
+            <tr>
+              {% if item.parse_error %}
+              <td><input type="checkbox" name="selected" value="{{ idx }}" disabled></td>
+              <td style="color: var(--text-muted); font-size: 0.875rem;">{{ item.filename }}</td>
+              <td colspan="5" style="color: var(--negative); font-size: 0.875rem;">{{ item.parse_error }}</td>
+              <td><span class="status-badge status-error">Error</span></td>
+              {% elif item.trade is not none %}
+              <td><input type="checkbox" name="selected" value="{{ idx }}"{% if item.is_duplicate != true and item.ticker %} checked{% endif %}{% if not item.ticker %} disabled{% endif %}></td>
+              <td style="font-size: 0.875rem; color: var(--text-muted);">{{ item.filename }}</td>
+              <td>{{ item.trade.trade_type }}</td>
+              <td>
+                {% if item.ticker %}
+                  <strong>{{ item.ticker }}</strong>
+                {% else %}
+                  <span style="color: var(--negative);">—</span>
+                {% endif %}
+              </td>
+              <td class="number">{{ item.trade.shares }}</td>
+              <td class="number">{{ item.trade.currency }} {{ item.trade.amount }}</td>
+              <td>{{ item.trade.date.date() }}</td>
+              <td>
+                {% if not item.ticker %}
+                  <span class="status-badge status-error">Unresolved</span>
+                {% elif item.is_duplicate == true %}
+                  <span class="status-badge status-duplicate">Duplicate</span>
+                {% else %}
+                  <span class="status-badge status-new">New</span>
+                {% endif %}
+              </td>
+              {% else %}
+              <td><input type="checkbox" name="selected" value="{{ idx }}" checked></td>
+              <td style="font-size: 0.875rem; color: var(--text-muted);">{{ item.filename }}</td>
+              <td>—</td>
+              <td>—</td>
+              <td class="number">{{ item.pairs | length }} holdings</td>
+              <td>—</td>
+              <td>—</td>
+              <td><span class="status-badge status-new">New</span></td>
+              {% endif %}
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div class="actions" style="margin-top: 1.25rem;">
+        <button type="submit" class="btn-primary">Import Selected</button>
+        <a href="/import/pdf"><button type="button" class="btn-ghost">Cancel</button></a>
+      </div>
+    </form>
+  </div>
+
   {% elif step == "done" %}
   <!-- ------------------------------------------------------------------ -->
-  <!-- Success / error summary                                              -->
+  <!-- Success / error summary (single-file)                               -->
   <!-- ------------------------------------------------------------------ -->
   <div class="card" style="text-align: center;">
     <h2>Import complete</h2>
@@ -186,6 +290,47 @@
       <a href="/import/pdf"><button type="button" class="btn-ghost">Import another PDF</button></a>
     </div>
   </div>
+
+  {% elif step == "done_batch" %}
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Batch import summary                                                 -->
+  <!-- ------------------------------------------------------------------ -->
+  <div class="card" style="text-align: center;">
+    <h2>Import complete</h2>
+    {% if created > 0 %}
+    <div class="done-icon">
+      <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--positive)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/>
+        <polyline points="9 12 11.5 14.5 16 10"/>
+      </svg>
+    </div>
+    {% else %}
+    <div class="done-icon">
+      <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/>
+        <line x1="12" y1="8" x2="12" y2="12"/>
+        <line x1="12" y1="16" x2="12.01" y2="16"/>
+      </svg>
+    </div>
+    {% endif %}
+    <ul style="list-style: none; padding: 0; margin: 1rem 0; font-size: 1rem;">
+      <li style="margin-bottom: 0.4rem;">
+        <strong style="color: var(--positive);">{{ created }}</strong> transaction{{ 's' if created != 1 }} imported
+      </li>
+      <li style="margin-bottom: 0.4rem;">
+        <strong style="color: var(--accent);">{{ duplicates }}</strong> duplicate{{ 's' if duplicates != 1 }} skipped
+      </li>
+      {% if errors %}
+      <li>
+        <strong style="color: var(--negative);">{{ errors }}</strong> error{{ 's' if errors != 1 }}
+      </li>
+      {% endif %}
+    </ul>
+    <div class="actions" style="justify-content: center; margin-top: 1rem;">
+      <a href="/"><button type="button" class="btn-primary">Back to portfolio</button></a>
+      <a href="/import/pdf"><button type="button" class="btn-ghost">Import more PDFs</button></a>
+    </div>
+  </div>
   {% endif %}
 {% endblock %}
 
@@ -197,6 +342,16 @@
     var input = zone.querySelector('input[type="file"]');
     var label = document.getElementById("selected-file");
 
+    function updateLabel(files) {
+      if (!files || !files.length) {
+        label.textContent = "";
+      } else if (files.length === 1) {
+        label.textContent = files[0].name;
+      } else {
+        label.textContent = files.length + " files selected";
+      }
+    }
+
     zone.addEventListener("dragover", function (e) { e.preventDefault(); zone.classList.add("dragover"); });
     zone.addEventListener("dragleave", function () { zone.classList.remove("dragover"); });
     zone.addEventListener("drop", function (e) {
@@ -204,11 +359,11 @@
       zone.classList.remove("dragover");
       if (e.dataTransfer.files.length) {
         input.files = e.dataTransfer.files;
-        label.textContent = e.dataTransfer.files[0].name;
+        updateLabel(e.dataTransfer.files);
       }
     });
     input.addEventListener("change", function () {
-      label.textContent = input.files.length ? input.files[0].name : "";
+      updateLabel(input.files);
     });
   })();
 </script>

--- a/tests/test_import_pdf.py
+++ b/tests/test_import_pdf.py
@@ -34,7 +34,7 @@ async def test_import_pdf_get_renders_upload_form(client: AsyncClient) -> None:
 async def test_import_pdf_post_non_pdf_returns_error(client: AsyncClient) -> None:
     response = await client.post(
         "/import/pdf",
-        files={"file": ("report.txt", b"not a pdf", "text/plain")},
+        files=[("files", ("report.txt", b"not a pdf", "text/plain"))],
     )
     assert response.status_code == 200
     assert "valid PDF" in response.text
@@ -44,7 +44,7 @@ async def test_import_pdf_post_non_pdf_returns_error(client: AsyncClient) -> Non
 async def test_import_pdf_post_unreadable_pdf_returns_error(client: AsyncClient) -> None:
     response = await client.post(
         "/import/pdf",
-        files={"file": ("bad.pdf", b"garbage data", "application/pdf")},
+        files=[("files", ("bad.pdf", b"garbage data", "application/pdf"))],
     )
     assert response.status_code == 200
     assert "Unrecognized PDF" in response.text or "No holdings" in response.text
@@ -55,7 +55,7 @@ async def test_import_pdf_post_valid_pdf_shows_preview(client: AsyncClient) -> N
     pdf_bytes = FIXTURE_PDF.read_bytes()
     response = await client.post(
         "/import/pdf",
-        files={"file": ("holdings.pdf", pdf_bytes, "application/pdf")},
+        files=[("files", ("holdings.pdf", pdf_bytes, "application/pdf"))],
     )
     assert response.status_code == 200
     assert "Preview extracted holdings" in response.text
@@ -68,7 +68,7 @@ async def test_import_pdf_post_valid_pdf_shows_all_tickers(client: AsyncClient) 
     pdf_bytes = FIXTURE_PDF.read_bytes()
     response = await client.post(
         "/import/pdf",
-        files={"file": ("holdings.pdf", pdf_bytes, "application/pdf")},
+        files=[("files", ("holdings.pdf", pdf_bytes, "application/pdf"))],
     )
     assert "AAPL" in response.text
     assert "MSFT" in response.text


### PR DESCRIPTION
## Summary

- File input now accepts multiple PDFs at once (`multiple` attribute)
- Single-file upload path is completely unchanged (no regression)
- When 2+ files are uploaded: parses all PDFs, resolves tickers via OpenFIGI, checks each trade against the DB for duplicates, and shows a batch overview table
- Overview shows **New** (green) / **Duplicate** (amber) / **Unresolved** (red) / **Error** (red) badges per row with pre-checked checkboxes (duplicates unchecked by default)
- New `POST /import/pdf/confirm-batch` endpoint imports only the selected rows
- New `BatchPdfItem` cache (30-min TTL) bridges preview and confirm steps, mirroring `import_cache.py`
- Extracted `check_is_duplicate()` on `ImportService` so the duplicate check is a read-only DB probe at preview time

## Test plan

- [x] All existing tests pass (`pytest tests/test_import_pdf.py tests/test_comdirect_parser.py`)
- [ ] Upload 1 PDF → existing single-file `preview_trade` flow works unchanged
- [ ] Upload 2+ comdirect PDFs (including one already imported) → batch overview shows correct badges
- [ ] Uncheck a row and confirm → only checked rows imported
- [ ] Re-upload same PDFs → all show Duplicate, nothing inserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)