### PR TITLE
fix(import): show all selected filenames in PDF upload zone

### DIFF
--- a/app/templates/import_pdf.html
+++ b/app/templates/import_pdf.html
@@ -344,11 +344,16 @@
 
     function updateLabel(files) {
       if (!files || !files.length) {
-        label.textContent = "";
+        label.innerHTML = "";
       } else if (files.length === 1) {
-        label.textContent = files[0].name;
+        label.innerHTML = files[0].name;
       } else {
-        label.textContent = files.length + " files selected";
+        var html = "<ul style=\"list-style:none;padding:0;margin:0;\">";
+        for (var i = 0; i < files.length; i++) {
+          html += "<li>" + files[i].name + "</li>";
+        }
+        html += "</ul>";
+        label.innerHTML = html;
       }
     }
 


### PR DESCRIPTION
## Summary

- When multiple PDFs are selected, each filename is now listed individually instead of showing "N files selected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)