### PR TITLE
fix(import): use div for file list container so filenames render

### DIFF
--- a/app/templates/import_pdf.html
+++ b/app/templates/import_pdf.html
@@ -42,7 +42,7 @@
         <p class="drop-zone-text">Drag &amp; drop one or more PDFs here or <strong>click to browse</strong></p>
         <span class="file-badge">.PDF</span>
         <input type="file" id="file-input" name="files" accept=".pdf" multiple required>
-        <p class="selected-file" id="selected-file"></p>
+        <div class="selected-file" id="selected-file"></div>
       </div>
       <button type="submit" class="btn-primary">Upload &amp; Preview</button>
     </form>


### PR DESCRIPTION
## Summary

- `<p>` elements cannot contain block-level children like `<ul>` — browsers silently close the `<p>` before the list, so the injected filenames were never displayed
- Changed the container from `<p>` to `<div>` so the filename list renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)