### PR TITLE
feat(stocks): show transactions list on stock detail page

### DIFF
--- a/app/routers/stocks.py
+++ b/app/routers/stocks.py
@@ -19,6 +19,7 @@ from app.database import get_async_session
 from app.models.holding import Holding
 from app.models.price_cache import PriceCache
 from app.models.stock import Stock
+from app.models.transaction import Transaction
 from app.services.fx_service import to_eur
 from app.services.price_service import get_latest_close
 
@@ -28,6 +29,18 @@ _TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
 templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 
 _DB = Depends(get_async_session)
+
+
+@dataclass
+class TransactionRow:
+    date: datetime.datetime
+    type: str
+    shares: Decimal
+    amount: Decimal
+    currency: str
+    fee: Decimal
+    tax: Decimal
+    note: str | None
 
 
 @dataclass
@@ -81,10 +94,29 @@ async def stock_detail(
         current_value=current_value,
     )
 
+    tx_result = await db.execute(
+        select(Transaction)
+        .where(Transaction.stock_id == stock.id)
+        .order_by(Transaction.date.desc())
+    )
+    transactions = [
+        TransactionRow(
+            date=tx.date,
+            type=tx.type,
+            shares=tx.shares,
+            amount=tx.amount,
+            currency=tx.currency,
+            fee=tx.fee,
+            tax=tx.tax,
+            note=tx.note,
+        )
+        for tx in tx_result.scalars().all()
+    ]
+
     return templates.TemplateResponse(
         request=request,
         name="stock_detail.html",
-        context={"stock": detail},
+        context={"stock": detail, "transactions": transactions},
     )
 
 

--- a/app/templates/stock_detail.html
+++ b/app/templates/stock_detail.html
@@ -85,6 +85,67 @@
     margin-bottom: 1rem;
   }
 
+  /* ── Transactions list ───────────────────────────────────────── */
+  .tx-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .tx-row {
+    display: grid;
+    grid-template-columns: 6.5rem 7.5rem 1fr auto;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 0.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .tx-row:last-child { border-bottom: none; }
+  .tx-date {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .tx-type {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    color: var(--muted);
+    justify-self: start;
+    white-space: nowrap;
+  }
+  .tx-type.buy        { color: #6FB07F; border-color: rgba(111, 176, 127, 0.4); }
+  .tx-type.sell       { color: #C77B6B; border-color: rgba(199, 123, 107, 0.4); }
+  .tx-type.dividend   { color: var(--accent); border-color: rgba(212, 146, 74, 0.4); }
+  .tx-meta {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .tx-amount {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text);
+    text-align: right;
+    white-space: nowrap;
+  }
+  .tx-amount small { font-size: 0.7em; color: var(--muted); font-weight: 400; }
+
+  @media (max-width: 600px) {
+    .tx-row { grid-template-columns: 1fr auto; row-gap: 0.4rem; }
+    .tx-meta { grid-column: 1 / -1; }
+  }
+
   /* ── No-data state ───────────────────────────────────────────── */
   .no-data-state {
     display: flex;
@@ -148,6 +209,33 @@
   <div class="chart-card anim-fade-in" style="animation-delay: 200ms">
     <div class="chart-card-title">Price History &middot; 1Y</div>
     <div id="price-history-chart" style="height: 300px;"></div>
+  </div>
+
+  <div class="chart-card anim-fade-in" style="animation-delay: 280ms">
+    <div class="chart-card-title">Transactions</div>
+    {% if transactions %}
+      <ul class="tx-list">
+        {% for tx in transactions %}
+          <li class="tx-row">
+            <span class="tx-date">{{ tx.date.strftime("%Y-%m-%d") }}</span>
+            <span class="tx-type {{ tx.type|lower }}">{{ tx.type }}</span>
+            <span class="tx-meta">
+              {% if tx.shares %}{{ "%g"|format(tx.shares) }} sh{% endif %}
+              {%- if tx.fee %} &middot; fee {{ "%.2f"|format(tx.fee) }}{% endif %}
+              {%- if tx.tax %} &middot; tax {{ "%.2f"|format(tx.tax) }}{% endif %}
+              {%- if tx.note %} &middot; {{ tx.note }}{% endif %}
+            </span>
+            <span class="tx-amount">
+              {{ "%.2f"|format(tx.amount) }} <small>{{ tx.currency }}</small>
+            </span>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <div class="no-data-state">
+        <span class="no-data-text">// no transactions recorded for this instrument</span>
+      </div>
+    {% endif %}
   </div>
 
 {% endblock %}

--- a/tests/test_stock_detail_page.py
+++ b/tests/test_stock_detail_page.py
@@ -1,0 +1,77 @@
+"""Tests for the stock detail HTML page, including the transactions list."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from httpx import AsyncClient
+
+from app.models.stock import Stock
+from app.models.transaction import Transaction
+
+
+def _stock() -> Stock:
+    stock = Stock(id=1, ticker="AAPL", name="Apple Inc.", currency="USD")
+    return stock
+
+
+def _result(scalar_one: object = None, scalars_all: list | None = None) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar_one
+    result.scalars.return_value.all.return_value = scalars_all or []
+    return result
+
+
+def _configure(mock_session: MagicMock, transactions: list[Transaction]) -> None:
+    """Wire the four db.execute() calls the stock_detail route makes in order.
+
+    1. Stock lookup, 2. Holding lookup, 3. latest close price, 4. transactions.
+    """
+    mock_session.execute.side_effect = [
+        _result(scalar_one=_stock()),  # stock
+        _result(scalar_one=None),  # holding
+        _result(scalar_one=None),  # latest close
+        _result(scalars_all=transactions),  # transactions
+    ]
+
+
+async def test_stock_detail_lists_transactions(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    tx = Transaction(
+        stock_id=1,
+        date=datetime.datetime(2026, 1, 15, tzinfo=datetime.UTC),
+        type="BUY",
+        shares=Decimal("10"),
+        amount=Decimal("1500.00"),
+        currency="USD",
+        fee=Decimal("1.50"),
+        tax=Decimal("0"),
+        note="initial position",
+        source="MANUAL",
+    )
+    _configure(mock_session, [tx])
+
+    response = await client.get("/stocks/AAPL")
+    html = response.text
+
+    assert response.status_code == 200
+    assert "Transactions" in html
+    assert "2026-01-15" in html
+    assert "BUY" in html
+    assert "1500.00" in html
+    assert "initial position" in html
+
+
+async def test_stock_detail_empty_transactions(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    _configure(mock_session, [])
+
+    response = await client.get("/stocks/AAPL")
+    html = response.text
+
+    assert response.status_code == 200
+    assert "no transactions recorded" in html


### PR DESCRIPTION
## Summary
Extends the stock overview page (`/stocks/<ticker>`) with the transactions made for that stock, displayed as a list placed under the price history chart.

## Changes
- **Router** (`app/routers/stocks.py`): query the `transaction` table for the stock (newest first) and pass a `TransactionRow` list to the template.
- **Template** (`app/templates/stock_detail.html`): new "Transactions" card under the price history, rendering each transaction as a list row (date, color-coded type badge, shares/fee/tax/note meta, amount + currency). Shows an empty state when there are no transactions.
- **Tests** (`tests/test_stock_detail_page.py`): DB-mocked tests covering the populated and empty transaction cases.

## Testing
- `ruff check` clean on changed files
- `pytest tests/test_stock_detail_page.py` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)