### PR TITLE
fix(import): invalidate chart cache after PDF imports

### DIFF
--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.stock import Stock
 from app.models.transaction import TX_SOURCE_PDF, TX_TYPE_BUY, Transaction
+from app.services import chart_cache
 from app.services.comdirect_parser import ParsedTrade
 from app.services.comdirect_ref import build_comdirect_external_uuid
 from app.services.holdings_service import recompute_holdings
@@ -96,6 +97,9 @@ class ImportService:
         if affected_stock_ids:
             await recompute_holdings(db, affected_stock_ids)
             await ensure_prices_cached(affected_tickers, db)
+            # Holdings changed — bust the cached portfolio summary/charts so the
+            # main page reflects the new quantities instead of stale cache.
+            chart_cache.invalidate()
         return processed
 
     async def check_is_duplicate(
@@ -193,6 +197,9 @@ class ImportService:
         await db.flush()
         await recompute_holdings(db, {stock.id})
         await ensure_prices_cached([stock.ticker], db)
+        # Holdings changed — bust the cached portfolio summary/charts so the
+        # main page reflects the new quantities instead of stale cache.
+        chart_cache.invalidate()
         return "created"
 
     async def _find_duplicate_trade(

--- a/tests/test_import_pdf.py
+++ b/tests/test_import_pdf.py
@@ -290,6 +290,31 @@ async def test_import_from_holdings_caches_prices_for_imported_tickers() -> None
 
 
 @pytest.mark.asyncio
+async def test_import_from_holdings_invalidates_chart_cache() -> None:
+    """Importing holdings must bust the cached portfolio summary so the main
+    page shows the updated quantities instead of the stale cache."""
+    from app.services.import_service import ImportService
+
+    db = _stub_pdf_db(known_tickers={"AAPL": 1})
+
+    service = ImportService()
+    with (
+        patch(
+            "app.services.import_service.ensure_prices_cached",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "app.services.import_service.chart_cache.invalidate"
+        ) as mock_invalidate,
+    ):
+        await service.import_from_holdings(
+            [("AAPL", Decimal("5"))], db, source_file="report.pdf"
+        )
+
+    mock_invalidate.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_import_from_pdf_delegates_to_import_from_holdings() -> None:
     """import_from_pdf should extract pairs and call import_from_holdings."""
     from app.services.import_service import ImportService


### PR DESCRIPTION
## Problem

A stock's quantity on the **main page** differed from the quantity on the **stock detail page** after a PDF import.

## Root cause

Both pages ultimately read `Holding.quantity`, but the main page's `PortfolioService.get_summary` serves a cached `"summary"` from `chart_cache` (300s TTL). The XML import path explicitly calls `chart_cache.invalidate()`, but the **PDF import paths never did**. So after a PDF import:

- `recompute_holdings` updated the DB → the detail page (fresh DB read) showed the new quantity ✅
- the main page kept serving the stale cached summary until the TTL expired → old quantity ❌

## Fix

Invalidate the chart cache after PDF imports mutate holdings, centralized in `ImportService` right after `recompute_holdings`. This covers all three PDF endpoints: `confirm`, `confirm-trade`, and `confirm-batch`. Mirrors the existing XML import behavior.

## Tests

- Added `test_import_from_holdings_invalidates_chart_cache`.
- Existing import/cache tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)