### PR TITLE
feat(import): support ING-DiBa Wertpapierabrechnung PDFs

### DIFF
--- a/app/routers/import_pdf.py
+++ b/app/routers/import_pdf.py
@@ -17,11 +17,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_async_session
 from app.models.transaction import TX_TYPE_BUY
-from app.services.batch_pdf_cache import BatchPdfItem
 from app.services import batch_pdf_cache
+from app.services.batch_pdf_cache import BatchPdfItem
 from app.services.comdirect_parser import ComdirectParser, ParsedTrade
 from app.services.generic_parser import GenericTableParser
 from app.services.import_service import ImportService
+from app.services.ing_parser import IngParser
 from app.services.openfigi_lookup import resolve_isin, resolve_wkn
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 _DB = Depends(get_async_session)
 _parser = GenericTableParser()
 _comdirect = ComdirectParser()
+_ing = IngParser()
 _service = ImportService()
 
 
@@ -105,9 +107,9 @@ async def _handle_single_file(request: Request, file: UploadFile) -> HTMLRespons
 
     try:
         t0 = time.perf_counter()
-        trade = _comdirect.extract_trade(tmp_path)
+        trade = _comdirect.extract_trade(tmp_path) or _ing.extract_trade(tmp_path)
         logger.info(
-            "PDF import: comdirect parse took %.2fs (%d bytes, matched=%s)",
+            "PDF import: broker trade parse took %.2fs (%d bytes, matched=%s)",
             time.perf_counter() - t0,
             len(contents),
             trade is not None,
@@ -166,7 +168,7 @@ async def _handle_batch(
         parse_error: str | None = None
 
         try:
-            trade = _comdirect.extract_trade(tmp_path)
+            trade = _comdirect.extract_trade(tmp_path) or _ing.extract_trade(tmp_path)
             if trade is None:
                 pairs = _parser.extract(tmp_path) or None
                 if pairs is None:
@@ -299,6 +301,7 @@ async def import_pdf_confirm_trade(
     wkn: Annotated[str, Form()] = "",
     isin: Annotated[str, Form()] = "",
     order_ref: Annotated[str, Form()] = "",
+    broker: Annotated[str, Form()] = "comdirect",
     db: AsyncSession = _DB,
 ) -> HTMLResponse:
     """Commit a previewed comdirect trade as a full transaction."""
@@ -329,6 +332,7 @@ async def import_pdf_confirm_trade(
         currency=currency.strip().upper() or "EUR",
         date=trade_date,
         order_ref=order_ref or None,
+        broker=broker.strip() or "comdirect",
     )
 
     status = await _service.import_trade(trade, ticker, db)

--- a/app/services/comdirect_parser.py
+++ b/app/services/comdirect_parser.py
@@ -65,6 +65,7 @@ class ParsedTrade:
     currency: str
     date: datetime.datetime
     order_ref: str | None
+    broker: str = "comdirect"  # namespaces the dedupe key: pdf:{broker}:{ref}
 
     @property
     def display(self) -> str:

--- a/app/services/comdirect_ref.py
+++ b/app/services/comdirect_ref.py
@@ -44,6 +44,20 @@ def parse_comdirect_order_ref(note: str | None) -> str | None:
     return m.group(1)
 
 
+def build_pdf_external_uuid(broker: str, ref: str) -> str:
+    """Return the ``external_uuid`` key for a PDF-imported *broker* trade *ref*.
+
+    The ``pdf:{broker}:{ref}`` shape namespaces dedupe keys per broker so that
+    e.g. an ING order number can never collide with a comdirect one.
+    """
+    return f"pdf:{broker}:{ref}"
+
+
 def build_comdirect_external_uuid(ref: str) -> str:
-    """Return the shared ``external_uuid`` key for a comdirect order *ref*."""
-    return f"pdf:comdirect:{ref}"
+    """Return the shared ``external_uuid`` key for a comdirect order *ref*.
+
+    Kept as the single source of truth for the comdirect key, which is shared
+    with the Portfolio Performance XML importer for cross-source dedupe; the
+    output is byte-identical to ``build_pdf_external_uuid("comdirect", ref)``.
+    """
+    return build_pdf_external_uuid("comdirect", ref)

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -14,7 +14,7 @@ from app.models.stock import Stock
 from app.models.transaction import TX_SOURCE_PDF, TX_TYPE_BUY, Transaction
 from app.services import chart_cache
 from app.services.comdirect_parser import ParsedTrade
-from app.services.comdirect_ref import build_comdirect_external_uuid
+from app.services.comdirect_ref import build_pdf_external_uuid
 from app.services.holdings_service import recompute_holdings
 from app.services.pdf_parser import BaseBrokerParser
 from app.services.price_service import ensure_prices_cached
@@ -119,7 +119,7 @@ class ImportService:
             return None
 
         if trade.order_ref:
-            external_uuid = build_comdirect_external_uuid(trade.order_ref)
+            external_uuid = build_pdf_external_uuid(trade.broker, trade.order_ref)
             existing = await db.execute(
                 select(Transaction.id).where(
                     Transaction.external_uuid == external_uuid
@@ -163,7 +163,7 @@ class ImportService:
             return "unknown_ticker"
 
         if trade.order_ref:
-            external_uuid = build_comdirect_external_uuid(trade.order_ref)
+            external_uuid = build_pdf_external_uuid(trade.broker, trade.order_ref)
             existing = await db.execute(
                 select(Transaction.id).where(
                     Transaction.external_uuid == external_uuid
@@ -175,8 +175,8 @@ class ImportService:
             # No stable order reference — fall back to the fuzzy same-day probe.
             if await self._find_duplicate_trade(db, stock.id, trade):
                 return "duplicate"
-            external_uuid = build_comdirect_external_uuid(
-                f"{trade.isin or trade.wkn}:{trade.date.date()}"
+            external_uuid = build_pdf_external_uuid(
+                trade.broker, f"{trade.isin or trade.wkn}:{trade.date.date()}"
             )
 
         db.add(

--- a/app/services/ing_parser.py
+++ b/app/services/ing_parser.py
@@ -1,0 +1,184 @@
+"""Parser for ING-DiBa securities settlement PDFs (``Wertpapierabrechnung``).
+
+ING trade confirmations carry the same economics as a comdirect settlement —
+security WKN/ISIN, share count, price, gross value (``Kurswert``), commission
+(``Provision``), the execution date and a stable order number — so this parser
+reuses the richer :class:`~app.services.comdirect_parser.ParsedTrade` model (and
+hence the whole preview/confirm/dedupe pipeline). Only the document layout and
+the German labels differ; see the sample extracted text below.
+
+Resolving the WKN/ISIN to a yfinance ticker is intentionally *not* done here
+(it needs a network round-trip via OpenFIGI); the router does that at preview
+time, mirroring the comdirect flow.
+
+The pypdf-extracted text looks like::
+
+    Wertpapierabrechnung Kauf
+    Ordernummer 456480204.001
+    ISIN (WKN) IE00B4L5Y983 (A0RPWH)
+    Wertpapierbezeichnung iShsIII-Core MSCI World U.ETF
+    Registered Shs USD (Acc) o.N.
+    Nominale Stück 9,00
+    Kurs EUR 107,5157
+    Ausführungstag / -zeit 23.03.2026 um 07:33:17 Uhr
+    Kurswert EUR 967,64
+    Provision EUR 7,32
+    Endbetrag zu Ihren Lasten EUR 974,96
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import re
+from decimal import Decimal
+from pathlib import Path
+
+from app.models.transaction import TX_TYPE_BUY, TX_TYPE_SELL
+from app.services.comdirect_parser import ParsedTrade, _de_decimal
+from app.services.pdf_text import extract_pages_fast, extract_pages_robust
+
+logger = logging.getLogger(__name__)
+
+# A German-formatted decimal: "1.234,56", "967,64", "107,5157", or "9".
+_DE_NUMBER = r"\d{1,3}(?:\.\d{3})*(?:,\d+)?"
+
+# "Ordernummer 456480204.001" → stable reference for idempotency.
+_ORDER_RE = re.compile(r"Ordernummer\s+([0-9][0-9.\-]*)")
+# "ISIN (WKN) IE00B4L5Y983 (A0RPWH)" → ISIN + WKN in one go.
+_ISIN_WKN_RE = re.compile(r"([A-Z]{2}[A-Z0-9]{9}[0-9])\s*\(([A-Z0-9]{6})\)")
+# "Nominale Stück 9,00" → share count ("ue" covers ASCII-transliterated PDFs).
+_SHARES_RE = re.compile(rf"St(?:ü|ue|u)ck\s+(?P<shares>{_DE_NUMBER})")
+# "Kurs EUR 107,5157" → currency + price-per-share.
+_PRICE_RE = re.compile(rf"Kurs\s+(?P<ccy>[A-Z]{{3}})\s+(?P<price>{_DE_NUMBER})")
+# "Kurswert EUR 967,64" → gross value.
+_KURSWERT_RE = re.compile(rf"Kurswert\s+[A-Z]{{3}}\s+(?P<amount>{_DE_NUMBER})")
+# "Provision EUR 7,32" → commission/fees.
+_FEES_RE = re.compile(rf"Provision\s+[A-Z]{{3}}\s+(?P<fee>{_DE_NUMBER})")
+# "Ausführungstag / -zeit 23.03.2026 um 07:33:17 Uhr" → execution date.
+_DATE_RE = re.compile(r"Ausf(?:ü|ue|u)hrungstag[^\n]*?(\d{2})\.(\d{2})\.(\d{4})")
+
+
+class IngParser:
+    """Extract a single trade from an ING-DiBa ``Wertpapierabrechnung`` PDF."""
+
+    @staticmethod
+    def matches(text: str) -> bool:
+        """Return True if *text* looks like an ING securities settlement."""
+        lowered = text.lower()
+        return "ing-diba" in lowered and "wertpapierabrechnung" in lowered
+
+    def extract_trade(self, pdf_path: Path) -> ParsedTrade | None:
+        """Read *pdf_path* and parse the contained trade, or None if absent.
+
+        Uses pypdf first (fast) and only falls back to the much slower
+        pdfplumber when the document *looks* like an ING statement but the fast
+        text didn't yield the required fields — mirroring
+        :meth:`app.services.comdirect_parser.ComdirectParser.extract_trade`.
+        """
+        try:
+            text = "\n".join(extract_pages_fast(pdf_path))
+        except Exception:  # noqa: BLE001 - pypdf failed; let pdfplumber try.
+            logger.warning("pypdf extraction failed; falling back to pdfplumber")
+            text = ""
+
+        trade = self.parse_text(text) if text else None
+        if trade is not None:
+            return trade
+        if text and not self.matches(text):
+            return None  # definitively not an ING doc — skip slow retry.
+
+        text = "\n".join(extract_pages_robust(pdf_path))
+        return self.parse_text(text)
+
+    def parse_text(self, text: str) -> ParsedTrade | None:
+        """Parse the full document text into a :class:`ParsedTrade`.
+
+        Returns None when the mandatory fields (security identifier, shares and
+        gross value) cannot be located, so the caller can fall back to another
+        parser.
+        """
+        if not self.matches(text):
+            return None
+
+        lowered = text.lower()
+        trade_type = TX_TYPE_BUY
+        if "verkauf" in lowered or "zu ihren gunsten" in lowered:
+            trade_type = TX_TYPE_SELL
+
+        shares_m = _SHARES_RE.search(text)
+        kurswert_m = _KURSWERT_RE.search(text)
+        ident_m = _ISIN_WKN_RE.search(text)
+        if shares_m is None or kurswert_m is None or ident_m is None:
+            return None
+
+        shares = _de_decimal(shares_m.group("shares"))
+        amount = _de_decimal(kurswert_m.group("amount"))
+        isin, wkn = ident_m.group(1), ident_m.group(2)
+
+        price_m = _PRICE_RE.search(text)
+        price = _de_decimal(price_m.group("price")) if price_m else None
+        currency = price_m.group("ccy") if price_m else "EUR"
+
+        fees_m = _FEES_RE.search(text)
+        fee = _de_decimal(fees_m.group("fee")) if fees_m else Decimal("0")
+
+        order_m = _ORDER_RE.search(text)
+        order_ref = order_m.group(1) if order_m else None
+
+        return ParsedTrade(
+            trade_type=trade_type,
+            name=self._extract_name(text),
+            wkn=wkn,
+            isin=isin,
+            shares=shares,
+            price=price,
+            amount=amount,
+            fee=fee,
+            # ING buy confirmations carry no withheld tax; sell-side tax
+            # breakdown is not yet modelled (no sample available).
+            tax=Decimal("0"),
+            currency=currency,
+            date=self._extract_date(text),
+            order_ref=order_ref,
+            broker="ing",
+        )
+
+    @staticmethod
+    def _extract_name(text: str) -> str | None:
+        """Pull the security name from the ``Wertpapierbezeichnung`` block.
+
+        The name starts on the ``Wertpapierbezeichnung`` line (after the label)
+        and may continue on the following line(s) until the ``Nominale`` row::
+
+            Wertpapierbezeichnung iShsIII-Core MSCI World U.ETF
+            Registered Shs USD (Acc) o.N.
+            Nominale Stück 9,00
+        """
+        lines = [line.strip() for line in text.splitlines()]
+        start = next(
+            (i for i, line in enumerate(lines) if line.startswith("Wertpapierbezeichnung")),
+            None,
+        )
+        if start is None:
+            return None
+        parts = [lines[start].removeprefix("Wertpapierbezeichnung").strip()]
+        for line in lines[start + 1 :]:
+            if not line or line.startswith("Nominale"):
+                break
+            parts.append(line)
+        name = " ".join(p for p in parts if p).strip()
+        return name or None
+
+    @staticmethod
+    def _extract_date(text: str) -> datetime.datetime:
+        """Parse the ``Ausführungstag`` as a UTC datetime, defaulting to now.
+
+        The time-of-day ING prints is intentionally dropped so the date-only
+        value matches comdirect's convention and the fuzzy same-day dedupe.
+        """
+        m = _DATE_RE.search(text)
+        if m is None:
+            return datetime.datetime.now(datetime.UTC)
+        day, month, year = (int(g) for g in m.groups())
+        return datetime.datetime(year, month, day, tzinfo=datetime.UTC)

--- a/app/templates/import_pdf.html
+++ b/app/templates/import_pdf.html
@@ -130,6 +130,7 @@
       <input type="hidden" name="wkn" value="{{ trade.wkn | default('', true) }}">
       <input type="hidden" name="isin" value="{{ trade.isin | default('', true) }}">
       <input type="hidden" name="order_ref" value="{{ trade.order_ref | default('', true) }}">
+      <input type="hidden" name="broker" value="{{ trade.broker | default('comdirect', true) }}">
       <div class="field">
         <label for="ticker">Ticker</label>
         <input type="text" id="ticker" name="ticker" value="{{ ticker | default('', true) }}" required>

--- a/tests/fixtures/generate_ing_pdf.py
+++ b/tests/fixtures/generate_ing_pdf.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Generate an ING-DiBa-style ``Wertpapierabrechnung`` PDF test fixture.
+
+The layout mirrors a real ING securities settlement (the lines the IngParser
+keys on); umlauts are spelled with plain ASCII ("ue") so the minimal
+hand-rolled Helvetica font renders deterministically under pdfplumber — the
+parser's regexes accept both the umlaut and the ASCII spelling.
+
+Run from the repo root:
+    python tests/fixtures/generate_ing_pdf.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_LINES = [
+    "Wertpapierabrechnung Kauf",
+    "Ordernummer 456480204.001",
+    "ISIN (WKN) IE00B4L5Y983 (A0RPWH)",
+    "Wertpapierbezeichnung iShsIII-Core MSCI World U.ETF",
+    "Registered Shs USD (Acc) o.N.",
+    "Nominale Stueck 9,00",
+    "Kurs EUR 107,5157",
+    "Handelsplatz Direkthandel",
+    "Ausfuehrungstag / -zeit 23.03.2026 um 07:33:17 Uhr",
+    "Kurswert EUR 967,64",
+    "Provision EUR 7,32",
+    "Endbetrag zu Ihren Lasten EUR 974,96",
+    "Valuta 25.03.2026",
+    "ING-DiBa AG - 60628 Frankfurt am Main",
+]
+
+
+def create_ing_pdf(output_path: Path) -> None:
+    """Write a minimal but valid PDF containing the ING statement text."""
+    ops: list[str] = ["BT", "/F1 10 Tf", "50 770 Td"]
+    for i, line in enumerate(_LINES):
+        if i > 0:
+            ops.append("0 -15 Td")
+        escaped = line.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+        ops.append(f"({escaped}) Tj")
+    ops.append("ET")
+    content: bytes = ("\n".join(ops) + "\n").encode()
+
+    body = b"%PDF-1.4\n"
+    offsets: list[int] = []
+
+    def add(obj_bytes: bytes) -> None:
+        nonlocal body
+        offsets.append(len(body))
+        body += obj_bytes
+
+    add(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    add(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+    add(
+        b"3 0 obj\n"
+        b"<< /Type /Page /Parent 2 0 R "
+        b"/Resources << /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> "
+        b"/MediaBox [0 0 612 792] /Contents 4 0 R >>\n"
+        b"endobj\n"
+    )
+    stream_header = f"4 0 obj\n<< /Length {len(content)} >>\nstream\n".encode()
+    add(stream_header + content + b"endstream\nendobj\n")
+
+    xref_offset = len(body)
+    xref = b"xref\n0 5\n0000000000 65535 f \n"
+    for off in offsets:
+        xref += f"{off:010d} 00000 n \n".encode()
+
+    trailer = (
+        f"trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n"
+    ).encode()
+
+    output_path.write_bytes(body + xref + trailer)
+    print(f"Written: {output_path}")
+
+
+if __name__ == "__main__":
+    dest = Path(__file__).parent / "sample_ing_kauf.pdf"
+    create_ing_pdf(dest)

--- a/tests/fixtures/sample_ing_kauf.pdf
+++ b/tests/fixtures/sample_ing_kauf.pdf
@@ -1,0 +1,58 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 634 >>
+stream
+BT
+/F1 10 Tf
+50 770 Td
+(Wertpapierabrechnung Kauf) Tj
+0 -15 Td
+(Ordernummer 456480204.001) Tj
+0 -15 Td
+(ISIN \(WKN\) IE00B4L5Y983 \(A0RPWH\)) Tj
+0 -15 Td
+(Wertpapierbezeichnung iShsIII-Core MSCI World U.ETF) Tj
+0 -15 Td
+(Registered Shs USD \(Acc\) o.N.) Tj
+0 -15 Td
+(Nominale Stueck 9,00) Tj
+0 -15 Td
+(Kurs EUR 107,5157) Tj
+0 -15 Td
+(Handelsplatz Direkthandel) Tj
+0 -15 Td
+(Ausfuehrungstag / -zeit 23.03.2026 um 07:33:17 Uhr) Tj
+0 -15 Td
+(Kurswert EUR 967,64) Tj
+0 -15 Td
+(Provision EUR 7,32) Tj
+0 -15 Td
+(Endbetrag zu Ihren Lasten EUR 974,96) Tj
+0 -15 Td
+(Valuta 25.03.2026) Tj
+0 -15 Td
+(ING-DiBa AG - 60628 Frankfurt am Main) Tj
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000290 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+974
+%%EOF

--- a/tests/test_ing_parser.py
+++ b/tests/test_ing_parser.py
@@ -1,0 +1,178 @@
+"""Tests for the IngParser and its ImportService integration."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import ing_parser as ing_mod
+from app.services.import_service import ImportService
+from app.services.ing_parser import IngParser
+from tests.test_comdirect_parser import _make_db
+
+
+@pytest.fixture(autouse=True)
+def _stub_price_warmup():
+    """Keep import_trade unit tests offline: the post-import price-cache warmup
+    would otherwise call yfinance for each freshly created ticker."""
+    with patch(
+        "app.services.import_service.ensure_prices_cached",
+        new=AsyncMock(return_value=[]),
+    ):
+        yield
+
+
+FIXTURE_PDF = Path(__file__).parent / "fixtures" / "sample_ing_kauf.pdf"
+
+# A faithful copy of the text pypdf extracts from an ING buy settlement, used to
+# exercise parse_text without a PDF round-trip.
+KAUF_TEXT = """\
+Wertpapierabrechnung Kauf
+Ordernummer 456480204.001
+ISIN (WKN) IE00B4L5Y983 (A0RPWH)
+Wertpapierbezeichnung iShsIII-Core MSCI World U.ETF
+Registered Shs USD (Acc) o.N.
+Nominale Stück 9,00
+Kurs EUR 107,5157
+Handelsplatz Direkthandel
+Ausführungstag / -zeit 23.03.2026 um 07:33:17 Uhr
+Kurswert EUR 967,64
+Provision EUR 7,32
+Endbetrag zu Ihren Lasten EUR 974,96
+Valuta 25.03.2026
+ING-DiBa AG · 60628 Frankfurt am Main
+"""
+
+
+# ---------------------------------------------------------------------------
+# IngParser – pure unit tests (no DB required)
+# ---------------------------------------------------------------------------
+
+
+def test_matches_recognises_ing_settlement() -> None:
+    assert IngParser.matches(KAUF_TEXT) is True
+
+
+def test_matches_rejects_unrelated_pdf() -> None:
+    assert IngParser.matches("AAPL 10.0\nMSFT 5.5") is False
+    # ING-branded but not a securities settlement → not our format.
+    assert IngParser.matches("ING-DiBa AG\nKontoauszug") is False
+
+
+def test_parse_text_extracts_all_fields() -> None:
+    trade = IngParser().parse_text(KAUF_TEXT)
+    assert trade is not None
+    assert trade.trade_type == "BUY"
+    assert trade.name == "iShsIII-Core MSCI World U.ETF Registered Shs USD (Acc) o.N."
+    assert trade.wkn == "A0RPWH"
+    assert trade.isin == "IE00B4L5Y983"
+    assert trade.shares == Decimal("9.00")
+    assert trade.price == Decimal("107.5157")
+    assert trade.amount == Decimal("967.64")
+    assert trade.fee == Decimal("7.32")
+    assert trade.tax == Decimal("0")
+    assert trade.currency == "EUR"
+    assert trade.date == datetime.datetime(2026, 3, 23, tzinfo=datetime.UTC)
+    assert trade.order_ref == "456480204.001"
+    assert trade.broker == "ing"
+
+
+def test_extract_trade_from_fixture_pdf() -> None:
+    trade = IngParser().extract_trade(FIXTURE_PDF)
+    assert trade is not None
+    assert trade.wkn == "A0RPWH"
+    assert trade.isin == "IE00B4L5Y983"
+    assert trade.shares == Decimal("9.00")
+    assert trade.amount == Decimal("967.64")
+    assert trade.fee == Decimal("7.32")
+    assert trade.broker == "ing"
+
+
+def test_parse_text_detects_sell() -> None:
+    sell_text = KAUF_TEXT.replace("Kauf", "Verkauf").replace(
+        "zu Ihren Lasten", "zu Ihren Gunsten"
+    )
+    trade = IngParser().parse_text(sell_text)
+    assert trade is not None
+    assert trade.trade_type == "SELL"
+
+
+def test_parse_text_returns_none_for_non_ing() -> None:
+    assert IngParser().parse_text("AAPL 10.0\nMSFT 5.5") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_trade – fast (pypdf) path with pdfplumber fallback
+# ---------------------------------------------------------------------------
+
+
+def test_extract_trade_uses_fast_path_without_pdfplumber(monkeypatch) -> None:
+    """When pypdf yields parseable text, pdfplumber must not run."""
+    fast = MagicMock(return_value=[KAUF_TEXT])
+    robust = MagicMock(side_effect=AssertionError("pdfplumber should not be called"))
+    monkeypatch.setattr(ing_mod, "extract_pages_fast", fast)
+    monkeypatch.setattr(ing_mod, "extract_pages_robust", robust)
+
+    trade = IngParser().extract_trade(Path("ignored.pdf"))
+
+    assert trade is not None and trade.wkn == "A0RPWH"
+    fast.assert_called_once()
+
+
+def test_extract_trade_skips_fallback_for_non_ing(monkeypatch) -> None:
+    """A non-ING PDF must not pay the slow pdfplumber path."""
+    fast = MagicMock(return_value=["AAPL 10.0\nMSFT 5.5"])
+    robust = MagicMock(side_effect=AssertionError("pdfplumber should not be called"))
+    monkeypatch.setattr(ing_mod, "extract_pages_fast", fast)
+    monkeypatch.setattr(ing_mod, "extract_pages_robust", robust)
+
+    assert IngParser().extract_trade(Path("ignored.pdf")) is None
+
+
+# ---------------------------------------------------------------------------
+# ImportService.import_trade – ING dedupe key namespacing
+# ---------------------------------------------------------------------------
+
+
+def _ing_trade():
+    return IngParser().parse_text(KAUF_TEXT)
+
+
+@pytest.mark.asyncio
+async def test_import_trade_writes_ing_namespaced_key() -> None:
+    db = _make_db({"IWDA.AS": 7})
+
+    status = await ImportService().import_trade(_ing_trade(), "IWDA.AS", db)
+
+    assert status == "created"
+    added = [
+        c.args[0]
+        for c in db.add.call_args_list
+        if c.args[0].__class__.__name__ == "Transaction"
+    ]
+    assert len(added) == 1
+    assert added[0].external_uuid == "pdf:ing:456480204.001"
+    assert added[0].amount == Decimal("967.64")
+    assert added[0].fee == Decimal("7.32")
+
+
+@pytest.mark.asyncio
+async def test_import_trade_skips_duplicate_by_exact_key() -> None:
+    db = _make_db(
+        {"IWDA.AS": 7},
+        existing_external_uuids={"pdf:ing:456480204.001"},
+    )
+
+    status = await ImportService().import_trade(_ing_trade(), "IWDA.AS", db)
+
+    assert status == "duplicate"
+    added = [
+        c.args[0]
+        for c in db.add.call_args_list
+        if c.args[0].__class__.__name__ == "Transaction"
+    ]
+    assert added == []


### PR DESCRIPTION
## Summary

Extends the PDF import with a new broker format: **ING-DiBa** securities
settlements (`Wertpapierabrechnung`). Previously these fell through to the
generic holdings parser and yielded nothing.

ING confirmations carry the same economics as a comdirect trade, so the new
`IngParser` returns the existing `ParsedTrade` and reuses the entire
preview → confirm → batch → dedupe pipeline.

## Changes

- **`app/services/ing_parser.py`** (new) — parses ISIN/WKN, shares, price,
  gross `Kurswert`, `Provision` (fees), `Ordernummer` and `Ausführungstag`.
  Same fast-pypdf-then-pdfplumber strategy as `ComdirectParser`.
- **`ParsedTrade.broker`** — new field; dedupe keys are now namespaced per
  broker (`pdf:ing:{ref}` vs `pdf:comdirect:{ref}`).
- **`build_pdf_external_uuid(broker, ref)`** — generalises the comdirect key
  builder; the comdirect/XML cross-source dedupe contract is unchanged
  (byte-identical output for `broker="comdirect"`).
- **Router** tries comdirect → ING → generic; the confirm-trade form carries
  the broker through manual confirmation.

## Testing

- `tests/test_ing_parser.py` (new) — field extraction, buy/sell detection,
  fast/fallback path, and `pdf:ing:` dedupe-key namespacing.
- `tests/fixtures/generate_ing_pdf.py` + `sample_ing_kauf.pdf` fixture.
- Verified end-to-end against the real ING sample PDF.
- Full suite: only the 2 pre-existing `test_portfolio_page.py` failures remain
  (present on master, unrelated).

## Out of scope

- ING Verkauf (sell) tax breakdown — handled defensively (tax=0) but unverified;
  no sell sample available yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)