### PR TITLE
feat(import): bridge ING PDF and Portfolio Performance XML for dedup

### DIFF
--- a/app/services/comdirect_ref.py
+++ b/app/services/comdirect_ref.py
@@ -18,7 +18,9 @@ never drift apart.
 
 from __future__ import annotations
 
+import datetime
 import re
+from decimal import ROUND_HALF_UP, Decimal
 
 # Modern PP note prefix, e.g. "Ord.-Nr.: 072324316214-001 | R.-Nr.: 1234567".
 # The reference is digits and dashes and stops before the " | R.-Nr.:" segment.
@@ -61,3 +63,36 @@ def build_comdirect_external_uuid(ref: str) -> str:
     output is byte-identical to ``build_pdf_external_uuid("comdirect", ref)``.
     """
     return build_pdf_external_uuid("comdirect", ref)
+
+
+# Portfolio Performance auto-text for a savings-plan-generated trade, e.g.
+# "Generiert von Sparplan 'iShares EM' am 16.02.2025, 11:12". These carry no
+# order number (unlike comdirect notes), so the order-number bridge cannot link
+# them to the matching ING PDF — the natural key below is used instead.
+_SPARPLAN_NOTE_RE = re.compile(r"Generiert von Sparplan")
+
+
+def is_sparplan_note(note: str | None) -> bool:
+    """Return True if *note* is Portfolio Performance's savings-plan auto-text."""
+    return bool(note and _SPARPLAN_NOTE_RE.search(note))
+
+
+def build_natural_trade_uuid(
+    isin: str,
+    trade_date: datetime.datetime,
+    total: Decimal,
+    ttype: str,
+) -> str:
+    """Return a deterministic cross-source key from a trade's natural identity.
+
+    Used when no order number bridges the two sources (e.g. an ING Sparplan: the
+    PDF has an ``Ordernummer`` but the Portfolio Performance transaction, being
+    PP-generated, does not). Both importers can compute this same key from values
+    that are identical for the same real trade — ISIN, the calendar trade date,
+    the fee-inclusive total (PP's ``amount`` == the ING ``Endbetrag`` ==
+    ``Kurswert + Provision``) and the trade type — so the
+    ``uq_transaction_external_uuid`` constraint dedupes them regardless of import
+    order. ``total`` is rendered as integer cents so formatting can never differ.
+    """
+    cents = int((total * 100).to_integral_value(rounding=ROUND_HALF_UP))
+    return f"nat:{isin.upper()}:{trade_date.date().isoformat()}:{cents}:{ttype.upper()}"

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -14,7 +14,7 @@ from app.models.stock import Stock
 from app.models.transaction import TX_SOURCE_PDF, TX_TYPE_BUY, Transaction
 from app.services import chart_cache
 from app.services.comdirect_parser import ParsedTrade
-from app.services.comdirect_ref import build_pdf_external_uuid
+from app.services.comdirect_ref import build_natural_trade_uuid, build_pdf_external_uuid
 from app.services.holdings_service import recompute_holdings
 from app.services.pdf_parser import BaseBrokerParser
 from app.services.price_service import ensure_prices_cached
@@ -117,16 +117,8 @@ class ImportService:
         stock = await self._get_stock(db, ticker)
         if stock is None:
             return None
-
-        if trade.order_ref:
-            external_uuid = build_pdf_external_uuid(trade.broker, trade.order_ref)
-            existing = await db.execute(
-                select(Transaction.id).where(
-                    Transaction.external_uuid == external_uuid
-                )
-            )
-            return existing.scalar_one_or_none() is not None
-        return await self._find_duplicate_trade(db, stock.id, trade)
+        _, is_duplicate = await self._resolve_trade_dedup(db, stock, trade)
+        return is_duplicate
 
     async def import_trade(
         self,
@@ -145,14 +137,10 @@ class ImportService:
 
         Duplicate protection runs across *all* sources, not just prior PDF
         imports: the same purchase may already be in the database from a
-        Portfolio Performance XML import. When the trade carries a comdirect
-        ``order_ref`` we build the shared ``pdf:comdirect:{ref}`` key (the same
-        one the XML importer derives from the note's *Ordernummer*) and look it
-        up exactly — so an XML-first then PDF-second import dedupes
-        deterministically without tripping the unique constraint, and two
-        genuinely distinct same-day trades keep distinct keys. Only when no
-        order ref is available do we fall back to the fuzzy same-day probe in
-        :meth:`_find_duplicate_trade`.
+        Portfolio Performance XML import. The cross-source key depends on the
+        broker — see :meth:`_resolve_trade_dedup` — and the
+        ``uq_transaction_external_uuid`` constraint dedupes deterministically
+        regardless of which file is imported first.
 
         Returns ``"created"`` when a new transaction was inserted,
         ``"duplicate"`` when a matching one already exists, or
@@ -162,22 +150,9 @@ class ImportService:
         if stock is None:
             return "unknown_ticker"
 
-        if trade.order_ref:
-            external_uuid = build_pdf_external_uuid(trade.broker, trade.order_ref)
-            existing = await db.execute(
-                select(Transaction.id).where(
-                    Transaction.external_uuid == external_uuid
-                )
-            )
-            if existing.scalar_one_or_none() is not None:
-                return "duplicate"
-        else:
-            # No stable order reference — fall back to the fuzzy same-day probe.
-            if await self._find_duplicate_trade(db, stock.id, trade):
-                return "duplicate"
-            external_uuid = build_pdf_external_uuid(
-                trade.broker, f"{trade.isin or trade.wkn}:{trade.date.date()}"
-            )
+        external_uuid, is_duplicate = await self._resolve_trade_dedup(db, stock, trade)
+        if is_duplicate:
+            return "duplicate"
 
         db.add(
             Transaction(
@@ -201,6 +176,55 @@ class ImportService:
         # main page reflects the new quantities instead of stale cache.
         chart_cache.invalidate()
         return "created"
+
+    async def _resolve_trade_dedup(
+        self,
+        db: AsyncSession,
+        stock: Stock,
+        trade: ParsedTrade,
+    ) -> tuple[str, bool]:
+        """Return ``(external_uuid_to_store, already_exists)`` for *trade*.
+
+        The cross-source key is broker-specific:
+
+        * **ING** trades bridge on the *natural key* (ISIN + date + fee-inclusive
+          total + type). The matching Portfolio Performance transaction is
+          PP-generated from a savings plan and carries no order number, so an
+          order-number key could never link them; the natural key can. We also
+          treat a legacy ``pdf:ing:{order_ref}`` row (written before this bridge
+          existed) as a duplicate, so re-imports of already-stored ING PDFs stay
+          idempotent.
+        * **comdirect** (and any ING without an ISIN) keep the order-number key,
+          falling back to the fuzzy same-day probe when no order ref is present.
+        """
+        if trade.broker == "ing" and trade.isin:
+            external_uuid = build_natural_trade_uuid(
+                trade.isin, trade.date, trade.amount + trade.fee, trade.trade_type
+            )
+            if await self._uuid_exists(db, external_uuid):
+                return external_uuid, True
+            if trade.order_ref:
+                legacy = build_pdf_external_uuid(trade.broker, trade.order_ref)
+                if await self._uuid_exists(db, legacy):
+                    return external_uuid, True
+            return external_uuid, False
+
+        if trade.order_ref:
+            external_uuid = build_pdf_external_uuid(trade.broker, trade.order_ref)
+            return external_uuid, await self._uuid_exists(db, external_uuid)
+
+        # No stable order reference — fall back to the fuzzy same-day probe.
+        external_uuid = build_pdf_external_uuid(
+            trade.broker, f"{trade.isin or trade.wkn}:{trade.date.date()}"
+        )
+        is_duplicate = await self._find_duplicate_trade(db, stock.id, trade)
+        return external_uuid, is_duplicate
+
+    async def _uuid_exists(self, db: AsyncSession, external_uuid: str) -> bool:
+        existing = await db.execute(
+            select(Transaction.id).where(Transaction.external_uuid == external_uuid)
+        )
+        return existing.scalar_one_or_none() is not None
 
     async def _find_duplicate_trade(
         self,

--- a/app/services/transaction_import_service.py
+++ b/app/services/transaction_import_service.py
@@ -12,6 +12,8 @@ from app.models.stock import ASSET_TYPE_STOCK, Stock
 from app.models.transaction import TX_SOURCE_XML, Transaction
 from app.services.comdirect_ref import (
     build_comdirect_external_uuid,
+    build_natural_trade_uuid,
+    is_sparplan_note,
     parse_comdirect_order_ref,
 )
 from app.services.portfolio_performance_importer import (
@@ -120,12 +122,28 @@ class TransactionImportService:
             )
             return False
 
-        # Prefer the cross-source comdirect key (derived from the Ordernummer in
-        # the note) over PP's random per-export uuid, so an XML row dedupes
-        # against a prior PDF import of the same trade. Non-comdirect rows keep
-        # their PP uuid, which is stable across XML re-imports.
+        # Prefer a cross-source key over PP's random per-export uuid, so an XML
+        # row dedupes against a prior PDF import of the same trade:
+        #  * comdirect notes carry the Ordernummer → shared order-number key;
+        #  * PP savings-plan ("Sparplan") trades are PP-generated and carry no
+        #    order number, but the matching ING PDF does — they instead bridge on
+        #    the natural key (ISIN + date + fee-inclusive total + type), the same
+        #    one app.services.import_service derives from the ING PDF.
+        # Everything else keeps its PP uuid, which is stable across XML re-imports.
         ref = parse_comdirect_order_ref(tx.note)
-        external_uuid = build_comdirect_external_uuid(ref) if ref else tx.uuid
+        if ref:
+            external_uuid = build_comdirect_external_uuid(ref)
+        elif (
+            is_sparplan_note(tx.note)
+            and mapped_type in {"BUY", "SELL"}
+            and tx.security is not None
+            and tx.security.isin
+        ):
+            external_uuid = build_natural_trade_uuid(
+                tx.security.isin, tx.date, tx.amount, mapped_type
+            )
+        else:
+            external_uuid = tx.uuid
 
         if external_uuid in seen_uuids:
             summary.skipped_existing += 1

--- a/tests/test_comdirect_ref.py
+++ b/tests/test_comdirect_ref.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import datetime
+from decimal import Decimal
+
 import pytest
 
 from app.services.comdirect_ref import (
     build_comdirect_external_uuid,
+    build_natural_trade_uuid,
+    is_sparplan_note,
     parse_comdirect_order_ref,
 )
 
@@ -46,3 +51,40 @@ def test_roundtrip_note_to_key() -> None:
     ref = parse_comdirect_order_ref(note)
     assert ref is not None
     assert build_comdirect_external_uuid(ref) == "pdf:comdirect:000512215771-001"
+
+
+@pytest.mark.parametrize(
+    ("note", "expected"),
+    [
+        ("Generiert von Sparplan 'iShares EM' am 16.02.2025, 11:12", True),
+        ("Generiert von Sparplan 'Core World'", True),
+        # comdirect / unrelated / empty notes are not savings-plan notes.
+        ("Ord.-Nr.: 072324316214-001 | R.-Nr.: 9988776655", False),
+        ("Purchase via Sparplan", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_sparplan_note(note: str | None, expected: bool) -> None:
+    assert is_sparplan_note(note) is expected
+
+
+def test_build_natural_trade_uuid() -> None:
+    key = build_natural_trade_uuid(
+        "IE00B4L5Y983",
+        datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
+        Decimal("25.00"),
+        "BUY",
+    )
+    assert key == "nat:IE00B4L5Y983:2025-01-02:2500:BUY"
+
+
+def test_build_natural_trade_uuid_rounds_to_cents() -> None:
+    # 967.64 + 7.32 = 974.96 → 97496 cents; lowercase isin/type are normalised.
+    key = build_natural_trade_uuid(
+        "ie00b4l5y983",
+        datetime.datetime(2026, 3, 23),
+        Decimal("974.96"),
+        "buy",
+    )
+    assert key == "nat:IE00B4L5Y983:2026-03-23:97496:BUY"

--- a/tests/test_ing_parser.py
+++ b/tests/test_ing_parser.py
@@ -134,8 +134,11 @@ def test_extract_trade_skips_fallback_for_non_ing(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# ImportService.import_trade – ING dedupe key namespacing
+# ImportService.import_trade – ING natural-key cross-source dedupe
 # ---------------------------------------------------------------------------
+
+# total = Kurswert 967.64 + Provision 7.32 = 974.96 → 97496 cents.
+NAT_KEY = "nat:IE00B4L5Y983:2026-03-23:97496:BUY"
 
 
 def _ing_trade():
@@ -143,7 +146,10 @@ def _ing_trade():
 
 
 @pytest.mark.asyncio
-async def test_import_trade_writes_ing_namespaced_key() -> None:
+async def test_import_trade_writes_natural_key() -> None:
+    """ING trades are keyed by the natural id (ISIN+date+total+type) so they
+    bridge against the matching PP/XML Sparplan transaction, which carries no
+    order number."""
     db = _make_db({"IWDA.AS": 7})
 
     status = await ImportService().import_trade(_ing_trade(), "IWDA.AS", db)
@@ -155,13 +161,32 @@ async def test_import_trade_writes_ing_namespaced_key() -> None:
         if c.args[0].__class__.__name__ == "Transaction"
     ]
     assert len(added) == 1
-    assert added[0].external_uuid == "pdf:ing:456480204.001"
+    assert added[0].external_uuid == NAT_KEY
     assert added[0].amount == Decimal("967.64")
     assert added[0].fee == Decimal("7.32")
 
 
 @pytest.mark.asyncio
-async def test_import_trade_skips_duplicate_by_exact_key() -> None:
+async def test_import_trade_skips_duplicate_by_natural_key() -> None:
+    """A trade already present under the natural key (e.g. imported earlier from
+    a PP/XML Sparplan export) is detected as a duplicate."""
+    db = _make_db({"IWDA.AS": 7}, existing_external_uuids={NAT_KEY})
+
+    status = await ImportService().import_trade(_ing_trade(), "IWDA.AS", db)
+
+    assert status == "duplicate"
+    added = [
+        c.args[0]
+        for c in db.add.call_args_list
+        if c.args[0].__class__.__name__ == "Transaction"
+    ]
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_import_trade_skips_duplicate_by_legacy_pdf_key() -> None:
+    """Re-importing an ING PDF stored under the first-release pdf:ing:{ref} key
+    still dedupes via the back-compat order-ref probe."""
     db = _make_db(
         {"IWDA.AS": 7},
         existing_external_uuids={"pdf:ing:456480204.001"},

--- a/tests/test_transaction_import_service.py
+++ b/tests/test_transaction_import_service.py
@@ -43,6 +43,7 @@ def _tx(
     note: str | None = None,
     security: SecurityInfo | None | object = _DEFAULT,
     units: list[Unit] | None = None,
+    date: datetime = datetime(2024, 1, 1),
 ) -> ParsedTransaction:
     sec: SecurityInfo | None = (
         _security() if security is _DEFAULT else security  # type: ignore[assignment]
@@ -50,7 +51,7 @@ def _tx(
     return ParsedTransaction(
         kind=kind,  # type: ignore[arg-type]
         uuid=uuid,
-        date=datetime(2024, 1, 1),
+        date=date,
         type=type,
         amount=Decimal(amount),
         currency=currency,
@@ -361,6 +362,97 @@ async def test_legacy_order_form_falls_back_to_pp_uuid() -> None:
 
     assert summary.created == 1
     assert _added_tx(db).external_uuid == "pp-uuid-y"
+
+
+# ---------------------------------------------------------------------------
+# Savings-plan (ING ↔ PP) natural-key bridge
+# ---------------------------------------------------------------------------
+
+_ING_SECURITY = SecurityInfo(
+    uuid="sec-ing",
+    name="iShsIII-Core MSCI World U.ETF",
+    isin="IE00B4L5Y983",
+    ticker="EUNL.DE",
+    currency="EUR",
+)
+_SPARPLAN_NOTE = "Generiert von Sparplan 'iShares EM' am 16.02.2025, 11:12"
+# date 2025-01-02, total 25.00 → 2500 cents.
+_ING_NAT_KEY = "nat:IE00B4L5Y983:2025-01-02:2500:BUY"
+
+
+@pytest.mark.asyncio
+async def test_sparplan_note_yields_natural_key() -> None:
+    """A PP-generated Sparplan trade (no order number) is keyed by the natural
+    id the ING PDF will compute, not PP's random uuid."""
+    db = _make_db(existing_tickers={"EUNL.DE": 5})
+    result = _result(
+        [
+            _tx(
+                uuid="pp-random-uuid",
+                type="BUY",
+                amount="25.00",
+                note=_SPARPLAN_NOTE,
+                security=_ING_SECURITY,
+                date=datetime(2025, 1, 2),
+            )
+        ]
+    )
+
+    summary = await TransactionImportService().import_xml_result(result, db)
+
+    assert summary.created == 1
+    assert _added_tx(db).external_uuid == _ING_NAT_KEY
+
+
+@pytest.mark.asyncio
+async def test_sparplan_skipped_when_ing_pdf_already_imported() -> None:
+    """An XML Sparplan row imported after the matching ING PDF dedupes via the
+    shared natural key."""
+    db = _make_db(
+        existing_uuids={_ING_NAT_KEY},
+        existing_tickers={"EUNL.DE": 5},
+    )
+    result = _result(
+        [
+            _tx(
+                uuid="pp-random-uuid",
+                type="BUY",
+                amount="25.00",
+                note=_SPARPLAN_NOTE,
+                security=_ING_SECURITY,
+                date=datetime(2025, 1, 2),
+            )
+        ]
+    )
+
+    summary = await TransactionImportService().import_xml_result(result, db)
+
+    assert summary.created == 0
+    assert summary.skipped_existing == 1
+    db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sparplan_without_isin_falls_back_to_pp_uuid() -> None:
+    """No ISIN ⇒ no natural key can be built ⇒ keep PP's uuid."""
+    db = _make_db(existing_tickers={"EUNL.DE": 5})
+    security = SecurityInfo(uuid="sec-x", name="No ISIN ETF", isin=None, ticker="EUNL.DE")
+    result = _result(
+        [
+            _tx(
+                uuid="pp-uuid-z",
+                type="BUY",
+                note=_SPARPLAN_NOTE,
+                security=security,
+                date=datetime(2025, 1, 2),
+            )
+        ]
+    )
+
+    summary = await TransactionImportService().import_xml_result(result, db)
+
+    assert summary.created == 1
+    assert _added_tx(db).external_uuid == "pp-uuid-z"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

comdirect's cross-source dedup (the same trade imported from a Portfolio Performance XML export *and* the broker PDF collapses to one row) does **not** work for ING.

The comdirect bridge is a shared `external_uuid` both sides derive from the **Ordernummer**. But ING trades enter Portfolio Performance as **savings-plan (Sparplan) entries generated by PP itself**, so their note is:

```
Generiert von Sparplan 'iShares EM' am 16.02.2025, 11:12
```

— no order number. The ING PDF has one, the PP transaction doesn't, so they can never share an order-number key → importing both creates a **duplicate**.

## Fix

A deterministic **natural-key** `external_uuid` that both importers compute independently from values that are identical for the same trade:

```
nat:{ISIN}:{YYYY-MM-DD}:{total_cents}:{TYPE}     e.g. nat:IE00B4L5Y983:2025-01-02:2500:BUY
```

The anchor is the fee-inclusive total: PP's `<amount>` (2500 = 25.00, incl. fee) equals the ING `Endbetrag` = `Kurswert + Provision`. So both sides produce the same key and the existing `uq_transaction_external_uuid` constraint dedupes — **in either import order**.

## Changes

- **`comdirect_ref.py`** — `is_sparplan_note()` + `build_natural_trade_uuid()`.
- **`import_service.py`** — ING trades key on the natural id via a shared `_resolve_trade_dedup` helper; back-compat probe still catches the first-release `pdf:ing:{ref}` rows. comdirect path unchanged.
- **`transaction_import_service.py`** — a Sparplan BUY/SELL with a resolvable ISIN derives the same natural key instead of PP's random uuid.

## Testing

- `test_comdirect_ref.py` — `is_sparplan_note` + `build_natural_trade_uuid` (incl. cent rounding, isin/type normalisation).
- `test_ing_parser.py` — ING trade now keyed `nat:…`; dedup via natural key and via legacy `pdf:ing:` key.
- `test_transaction_import_service.py` — Sparplan note → natural key; XML skipped when the ING PDF was already imported; no-ISIN falls back to PP uuid.
- Full suite: only the 2 pre-existing `test_portfolio_page.py` flakes remain.

## Note / follow-up

One load-bearing assumption still to confirm against a real ING **Sparplan** Abrechnung PDF (only a regular `Kauf` sample was available): that `Kurswert + Provision` equals PP's `<amount>` to the cent and the `Ausführungstag` is the same calendar day as PP's `<date>`. Also: PP/XML Sparplan rows imported *before* this change won't retroactively bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)