### PR TITLE
refactor(import): replace ING natural-key heuristic with order-number dedup

### DIFF
--- a/app/services/comdirect_ref.py
+++ b/app/services/comdirect_ref.py
@@ -1,33 +1,57 @@
-"""Shared comdirect order-reference helpers.
+"""Shared order-reference helpers for broker PDF/XML cross-source deduplication.
 
-The comdirect *Ordernummer* is the only stable identifier shared between the
-two import paths for the same trade:
-
-* the comdirect settlement **PDF** (parsed by :mod:`app.services.comdirect_parser`),
-  which reads ``Ordernummer : 000512215771-001``; and
-* the Portfolio Performance **XML** export, whose ``ComdirectPDFExtractor``
-  writes the same number into the transaction *note* as
-  ``Ord.-Nr.: 072324316214-001 | R.-Nr.: <rechnungsnr>``.
-
-Deriving the same ``external_uuid`` from this reference on both sides lets the
+Both ING and comdirect settlement PDFs carry a stable *Ordernummer* that
+Portfolio Performance copies verbatim into the XML transaction note.  Deriving
+the same ``external_uuid`` from this reference on both sides lets the
 ``uq_transaction_external_uuid`` constraint dedupe a trade across sources,
 regardless of which file is imported first.  This module is the single source
 of truth for both the parsing and the key format, so the two importers can
 never drift apart.
+
+ING format (PDF text and PP XML note):
+    ``Ordernummer 456480204.001``
+
+Comdirect formats:
+    PDF:     ``Ordernummer : 000512215771-001``
+    PP note: ``Ord.-Nr.: 072324316214-001 | R.-Nr.: <rechnungsnr>``
 """
 
 from __future__ import annotations
 
-import datetime
 import re
-from decimal import ROUND_HALF_UP, Decimal
 
-# Modern PP note prefix, e.g. "Ord.-Nr.: 072324316214-001 | R.-Nr.: 1234567".
+# "Ordernummer 456480204.001" — used in ING PDF text and PP XML notes alike.
+_ING_ORDER_RE = re.compile(r"Ordernummer\s+([0-9][0-9.\-]*)")
+
+# Modern comdirect PP note prefix, e.g. "Ord.-Nr.: 072324316214-001 | R.-Nr.: 1234567".
 # The reference is digits and dashes and stops before the " | R.-Nr.:" segment.
 # The legacy " / "-separated "Order-Nr.: 71871368321 / 001" form has no
 # cross-source PDF counterpart and deliberately does not match (returns None):
 # "Order-Nr." has no dot after "Ord", so the anchored pattern never fires.
 _ORDER_REF_RE = re.compile(r"^Ord\.-Nr\.:\s*([0-9][0-9-]*)")
+
+
+def parse_ing_order_ref(note: str | None) -> str | None:
+    """Extract the ING Ordernummer from a PDF text line or PP XML note.
+
+    Matches both ``"Ordernummer 456480204.001"`` (PDF) and the same string
+    when PP copies it verbatim into the XML ``<note>`` element.  Returns the
+    reference (e.g. ``"456480204.001"``) or ``None`` when *note* is absent or
+    does not match.
+    """
+    if not note:
+        return None
+    m = _ING_ORDER_RE.search(note)
+    return m.group(1) if m else None
+
+
+def build_ing_external_uuid(ref: str) -> str:
+    """Return the shared ``external_uuid`` key for an ING order *ref*.
+
+    Single source of truth for the ING cross-source key; output is
+    byte-identical to ``build_pdf_external_uuid("ing", ref)``.
+    """
+    return build_pdf_external_uuid("ing", ref)
 
 
 def parse_comdirect_order_ref(note: str | None) -> str | None:
@@ -63,36 +87,3 @@ def build_comdirect_external_uuid(ref: str) -> str:
     output is byte-identical to ``build_pdf_external_uuid("comdirect", ref)``.
     """
     return build_pdf_external_uuid("comdirect", ref)
-
-
-# Portfolio Performance auto-text for a savings-plan-generated trade, e.g.
-# "Generiert von Sparplan 'iShares EM' am 16.02.2025, 11:12". These carry no
-# order number (unlike comdirect notes), so the order-number bridge cannot link
-# them to the matching ING PDF — the natural key below is used instead.
-_SPARPLAN_NOTE_RE = re.compile(r"Generiert von Sparplan")
-
-
-def is_sparplan_note(note: str | None) -> bool:
-    """Return True if *note* is Portfolio Performance's savings-plan auto-text."""
-    return bool(note and _SPARPLAN_NOTE_RE.search(note))
-
-
-def build_natural_trade_uuid(
-    isin: str,
-    trade_date: datetime.datetime,
-    total: Decimal,
-    ttype: str,
-) -> str:
-    """Return a deterministic cross-source key from a trade's natural identity.
-
-    Used when no order number bridges the two sources (e.g. an ING Sparplan: the
-    PDF has an ``Ordernummer`` but the Portfolio Performance transaction, being
-    PP-generated, does not). Both importers can compute this same key from values
-    that are identical for the same real trade — ISIN, the calendar trade date,
-    the fee-inclusive total (PP's ``amount`` == the ING ``Endbetrag`` ==
-    ``Kurswert + Provision``) and the trade type — so the
-    ``uq_transaction_external_uuid`` constraint dedupes them regardless of import
-    order. ``total`` is rendered as integer cents so formatting can never differ.
-    """
-    cents = int((total * 100).to_integral_value(rounding=ROUND_HALF_UP))
-    return f"nat:{isin.upper()}:{trade_date.date().isoformat()}:{cents}:{ttype.upper()}"

--- a/app/services/import_service.py
+++ b/app/services/import_service.py
@@ -14,7 +14,7 @@ from app.models.stock import Stock
 from app.models.transaction import TX_SOURCE_PDF, TX_TYPE_BUY, Transaction
 from app.services import chart_cache
 from app.services.comdirect_parser import ParsedTrade
-from app.services.comdirect_ref import build_natural_trade_uuid, build_pdf_external_uuid
+from app.services.comdirect_ref import build_pdf_external_uuid
 from app.services.holdings_service import recompute_holdings
 from app.services.pdf_parser import BaseBrokerParser
 from app.services.price_service import ensure_prices_cached
@@ -185,30 +185,12 @@ class ImportService:
     ) -> tuple[str, bool]:
         """Return ``(external_uuid_to_store, already_exists)`` for *trade*.
 
-        The cross-source key is broker-specific:
-
-        * **ING** trades bridge on the *natural key* (ISIN + date + fee-inclusive
-          total + type). The matching Portfolio Performance transaction is
-          PP-generated from a savings plan and carries no order number, so an
-          order-number key could never link them; the natural key can. We also
-          treat a legacy ``pdf:ing:{order_ref}`` row (written before this bridge
-          existed) as a duplicate, so re-imports of already-stored ING PDFs stay
-          idempotent.
-        * **comdirect** (and any ING without an ISIN) keep the order-number key,
-          falling back to the fuzzy same-day probe when no order ref is present.
+        The cross-source key is derived from the stable order number shared
+        between the broker PDF and the Portfolio Performance XML note.  ING and
+        comdirect both follow the same strategy: ``pdf:{broker}:{order_ref}``
+        when an order number is available, falling back to the fuzzy same-day
+        probe when it is not.
         """
-        if trade.broker == "ing" and trade.isin:
-            external_uuid = build_natural_trade_uuid(
-                trade.isin, trade.date, trade.amount + trade.fee, trade.trade_type
-            )
-            if await self._uuid_exists(db, external_uuid):
-                return external_uuid, True
-            if trade.order_ref:
-                legacy = build_pdf_external_uuid(trade.broker, trade.order_ref)
-                if await self._uuid_exists(db, legacy):
-                    return external_uuid, True
-            return external_uuid, False
-
         if trade.order_ref:
             external_uuid = build_pdf_external_uuid(trade.broker, trade.order_ref)
             return external_uuid, await self._uuid_exists(db, external_uuid)

--- a/app/services/transaction_import_service.py
+++ b/app/services/transaction_import_service.py
@@ -12,9 +12,9 @@ from app.models.stock import ASSET_TYPE_STOCK, Stock
 from app.models.transaction import TX_SOURCE_XML, Transaction
 from app.services.comdirect_ref import (
     build_comdirect_external_uuid,
-    build_natural_trade_uuid,
-    is_sparplan_note,
+    build_ing_external_uuid,
     parse_comdirect_order_ref,
+    parse_ing_order_ref,
 )
 from app.services.portfolio_performance_importer import (
     ParsedTransaction,
@@ -123,25 +123,15 @@ class TransactionImportService:
             return False
 
         # Prefer a cross-source key over PP's random per-export uuid, so an XML
-        # row dedupes against a prior PDF import of the same trade:
-        #  * comdirect notes carry the Ordernummer → shared order-number key;
-        #  * PP savings-plan ("Sparplan") trades are PP-generated and carry no
-        #    order number, but the matching ING PDF does — they instead bridge on
-        #    the natural key (ISIN + date + fee-inclusive total + type), the same
-        #    one app.services.import_service derives from the ING PDF.
-        # Everything else keeps its PP uuid, which is stable across XML re-imports.
-        ref = parse_comdirect_order_ref(tx.note)
-        if ref:
-            external_uuid = build_comdirect_external_uuid(ref)
-        elif (
-            is_sparplan_note(tx.note)
-            and mapped_type in {"BUY", "SELL"}
-            and tx.security is not None
-            and tx.security.isin
-        ):
-            external_uuid = build_natural_trade_uuid(
-                tx.security.isin, tx.date, tx.amount, mapped_type
-            )
+        # row dedupes against a prior PDF import of the same trade.  PP copies
+        # the ING/comdirect order number verbatim into the <note> element, so
+        # both PDF and XML sides can independently derive the same stable key.
+        ing_ref = parse_ing_order_ref(tx.note)
+        cmd_ref = parse_comdirect_order_ref(tx.note)
+        if ing_ref:
+            external_uuid = build_ing_external_uuid(ing_ref)
+        elif cmd_ref:
+            external_uuid = build_comdirect_external_uuid(cmd_ref)
         else:
             external_uuid = tx.uuid
 

--- a/tests/test_comdirect_ref.py
+++ b/tests/test_comdirect_ref.py
@@ -1,17 +1,14 @@
-"""Tests for the shared comdirect order-reference helpers."""
+"""Tests for the shared broker order-reference helpers."""
 
 from __future__ import annotations
-
-import datetime
-from decimal import Decimal
 
 import pytest
 
 from app.services.comdirect_ref import (
     build_comdirect_external_uuid,
-    build_natural_trade_uuid,
-    is_sparplan_note,
+    build_ing_external_uuid,
     parse_comdirect_order_ref,
+    parse_ing_order_ref,
 )
 
 
@@ -56,35 +53,30 @@ def test_roundtrip_note_to_key() -> None:
 @pytest.mark.parametrize(
     ("note", "expected"),
     [
-        ("Generiert von Sparplan 'iShares EM' am 16.02.2025, 11:12", True),
-        ("Generiert von Sparplan 'Core World'", True),
-        # comdirect / unrelated / empty notes are not savings-plan notes.
-        ("Ord.-Nr.: 072324316214-001 | R.-Nr.: 9988776655", False),
-        ("Purchase via Sparplan", False),
-        ("", False),
-        (None, False),
+        # ING PDF text / PP XML note — both use the same format.
+        ("Ordernummer 456480204.001", "456480204.001"),
+        ("Ordernummer 463890395.001", "463890395.001"),
+        # Leading/trailing whitespace is tolerated.
+        ("  Ordernummer 123456789.001  ", "123456789.001"),
+        # Not an ING note.
+        (None, None),
+        ("", None),
+        ("Dividend Payment", None),
+        # Comdirect PP note must not match.
+        ("Ord.-Nr.: 072324316214-001 | R.-Nr.: 9988776655", None),
     ],
 )
-def test_is_sparplan_note(note: str | None, expected: bool) -> None:
-    assert is_sparplan_note(note) is expected
+def test_parse_ing_order_ref(note: str | None, expected: str | None) -> None:
+    assert parse_ing_order_ref(note) == expected
 
 
-def test_build_natural_trade_uuid() -> None:
-    key = build_natural_trade_uuid(
-        "IE00B4L5Y983",
-        datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
-        Decimal("25.00"),
-        "BUY",
-    )
-    assert key == "nat:IE00B4L5Y983:2025-01-02:2500:BUY"
+def test_build_ing_external_uuid() -> None:
+    assert build_ing_external_uuid("456480204.001") == "pdf:ing:456480204.001"
 
 
-def test_build_natural_trade_uuid_rounds_to_cents() -> None:
-    # 967.64 + 7.32 = 974.96 → 97496 cents; lowercase isin/type are normalised.
-    key = build_natural_trade_uuid(
-        "ie00b4l5y983",
-        datetime.datetime(2026, 3, 23),
-        Decimal("974.96"),
-        "buy",
-    )
-    assert key == "nat:IE00B4L5Y983:2026-03-23:97496:BUY"
+def test_ing_roundtrip_note_to_key() -> None:
+    """An ING XML note maps to the same key the PDF importer builds."""
+    note = "Ordernummer 463890395.001"
+    ref = parse_ing_order_ref(note)
+    assert ref is not None
+    assert build_ing_external_uuid(ref) == "pdf:ing:463890395.001"

--- a/tests/test_ing_parser.py
+++ b/tests/test_ing_parser.py
@@ -134,11 +134,10 @@ def test_extract_trade_skips_fallback_for_non_ing(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# ImportService.import_trade – ING natural-key cross-source dedupe
+# ImportService.import_trade – ING order-number cross-source dedupe
 # ---------------------------------------------------------------------------
 
-# total = Kurswert 967.64 + Provision 7.32 = 974.96 → 97496 cents.
-NAT_KEY = "nat:IE00B4L5Y983:2026-03-23:97496:BUY"
+ORDER_KEY = "pdf:ing:456480204.001"
 
 
 def _ing_trade():
@@ -146,10 +145,9 @@ def _ing_trade():
 
 
 @pytest.mark.asyncio
-async def test_import_trade_writes_natural_key() -> None:
-    """ING trades are keyed by the natural id (ISIN+date+total+type) so they
-    bridge against the matching PP/XML Sparplan transaction, which carries no
-    order number."""
+async def test_import_trade_writes_order_ref_key() -> None:
+    """ING trades are keyed by pdf:ing:{order_ref}, bridging against the
+    matching PP/XML transaction whose note carries the same Ordernummer."""
     db = _make_db({"IWDA.AS": 7})
 
     status = await ImportService().import_trade(_ing_trade(), "IWDA.AS", db)
@@ -161,36 +159,16 @@ async def test_import_trade_writes_natural_key() -> None:
         if c.args[0].__class__.__name__ == "Transaction"
     ]
     assert len(added) == 1
-    assert added[0].external_uuid == NAT_KEY
+    assert added[0].external_uuid == ORDER_KEY
     assert added[0].amount == Decimal("967.64")
     assert added[0].fee == Decimal("7.32")
 
 
 @pytest.mark.asyncio
-async def test_import_trade_skips_duplicate_by_natural_key() -> None:
-    """A trade already present under the natural key (e.g. imported earlier from
-    a PP/XML Sparplan export) is detected as a duplicate."""
-    db = _make_db({"IWDA.AS": 7}, existing_external_uuids={NAT_KEY})
-
-    status = await ImportService().import_trade(_ing_trade(), "IWDA.AS", db)
-
-    assert status == "duplicate"
-    added = [
-        c.args[0]
-        for c in db.add.call_args_list
-        if c.args[0].__class__.__name__ == "Transaction"
-    ]
-    assert added == []
-
-
-@pytest.mark.asyncio
-async def test_import_trade_skips_duplicate_by_legacy_pdf_key() -> None:
-    """Re-importing an ING PDF stored under the first-release pdf:ing:{ref} key
-    still dedupes via the back-compat order-ref probe."""
-    db = _make_db(
-        {"IWDA.AS": 7},
-        existing_external_uuids={"pdf:ing:456480204.001"},
-    )
+async def test_import_trade_skips_duplicate_by_order_ref_key() -> None:
+    """A trade already present under the order-ref key (e.g. imported earlier
+    from a PP/XML export) is detected as a duplicate."""
+    db = _make_db({"IWDA.AS": 7}, existing_external_uuids={ORDER_KEY})
 
     status = await ImportService().import_trade(_ing_trade(), "IWDA.AS", db)
 

--- a/tests/test_transaction_import_service.py
+++ b/tests/test_transaction_import_service.py
@@ -365,8 +365,11 @@ async def test_legacy_order_form_falls_back_to_pp_uuid() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Savings-plan (ING ↔ PP) natural-key bridge
+# ING order-number bridge (ING PDF ↔ PP XML)
 # ---------------------------------------------------------------------------
+
+_ING_ORDER_NOTE = "Ordernummer 463890395.001"
+_ING_ORDER_KEY = "pdf:ing:463890395.001"
 
 _ING_SECURITY = SecurityInfo(
     uuid="sec-ing",
@@ -375,54 +378,33 @@ _ING_SECURITY = SecurityInfo(
     ticker="EUNL.DE",
     currency="EUR",
 )
-_SPARPLAN_NOTE = "Generiert von Sparplan 'iShares EM' am 16.02.2025, 11:12"
-# date 2025-01-02, total 25.00 → 2500 cents.
-_ING_NAT_KEY = "nat:IE00B4L5Y983:2025-01-02:2500:BUY"
 
 
 @pytest.mark.asyncio
-async def test_sparplan_note_yields_natural_key() -> None:
-    """A PP-generated Sparplan trade (no order number) is keyed by the natural
-    id the ING PDF will compute, not PP's random uuid."""
+async def test_ing_order_note_yields_ing_key() -> None:
+    """An ING PP note with 'Ordernummer ...' is keyed by pdf:ing:{ref},
+    not PP's random uuid."""
     db = _make_db(existing_tickers={"EUNL.DE": 5})
     result = _result(
-        [
-            _tx(
-                uuid="pp-random-uuid",
-                type="BUY",
-                amount="25.00",
-                note=_SPARPLAN_NOTE,
-                security=_ING_SECURITY,
-                date=datetime(2025, 1, 2),
-            )
-        ]
+        [_tx(uuid="pp-random-uuid", type="BUY", note=_ING_ORDER_NOTE, security=_ING_SECURITY)]
     )
 
     summary = await TransactionImportService().import_xml_result(result, db)
 
     assert summary.created == 1
-    assert _added_tx(db).external_uuid == _ING_NAT_KEY
+    assert _added_tx(db).external_uuid == _ING_ORDER_KEY
 
 
 @pytest.mark.asyncio
-async def test_sparplan_skipped_when_ing_pdf_already_imported() -> None:
-    """An XML Sparplan row imported after the matching ING PDF dedupes via the
-    shared natural key."""
+async def test_xml_skipped_when_ing_pdf_already_imported_by_order_ref() -> None:
+    """An XML row imported after the matching ING PDF dedupes via the shared
+    order-number key."""
     db = _make_db(
-        existing_uuids={_ING_NAT_KEY},
+        existing_uuids={_ING_ORDER_KEY},
         existing_tickers={"EUNL.DE": 5},
     )
     result = _result(
-        [
-            _tx(
-                uuid="pp-random-uuid",
-                type="BUY",
-                amount="25.00",
-                note=_SPARPLAN_NOTE,
-                security=_ING_SECURITY,
-                date=datetime(2025, 1, 2),
-            )
-        ]
+        [_tx(uuid="pp-random-uuid", type="BUY", note=_ING_ORDER_NOTE, security=_ING_SECURITY)]
     )
 
     summary = await TransactionImportService().import_xml_result(result, db)
@@ -430,29 +412,6 @@ async def test_sparplan_skipped_when_ing_pdf_already_imported() -> None:
     assert summary.created == 0
     assert summary.skipped_existing == 1
     db.add.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_sparplan_without_isin_falls_back_to_pp_uuid() -> None:
-    """No ISIN ⇒ no natural key can be built ⇒ keep PP's uuid."""
-    db = _make_db(existing_tickers={"EUNL.DE": 5})
-    security = SecurityInfo(uuid="sec-x", name="No ISIN ETF", isin=None, ticker="EUNL.DE")
-    result = _result(
-        [
-            _tx(
-                uuid="pp-uuid-z",
-                type="BUY",
-                note=_SPARPLAN_NOTE,
-                security=security,
-                date=datetime(2025, 1, 2),
-            )
-        ]
-    )
-
-    summary = await TransactionImportService().import_xml_result(result, db)
-
-    assert summary.created == 1
-    assert _added_tx(db).external_uuid == "pp-uuid-z"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes the heuristic natural-key (`nat:{isin}:{date}:{cents}:{type}`) dedup for ING PDF imports
- Removes the Sparplan bridge in the XML importer (the `is_sparplan_note` / `build_natural_trade_uuid` path)
- Adds `parse_ing_order_ref` / `build_ing_external_uuid` to `comdirect_ref.py` — parses `Ordernummer 463890395.001` from both ING PDF text and PP XML notes, producing `pdf:ing:{ref}` keys
- ING dedup now works identically to comdirect: stable order number → shared key across PDF and XML imports

## Test plan

- [ ] All 45 tests in `test_comdirect_ref`, `test_ing_parser`, `test_transaction_import_service` pass
- [ ] Importing an ING PDF creates `external_uuid = pdf:ing:{order_ref}`
- [ ] Re-importing the same PDF is a no-op (duplicate detected by order ref)
- [ ] Importing the matching PP XML (note: `Ordernummer …`) after the PDF is also skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)