### PR TITLE
perf(openfigi): add in-memory cache for ticker resolution

### DIFF
--- a/app/services/openfigi_lookup.py
+++ b/app/services/openfigi_lookup.py
@@ -81,6 +81,9 @@ _PREFERRED_EXCHCODES = [
 ]
 
 
+_cache: dict[tuple[str, str], str | None] = {}
+
+
 def _build_yfinance_ticker(ticker: str, exch_code: str) -> str:
     """Append the appropriate yfinance exchange suffix for the given exchCode."""
     suffix = _EXCHCODE_TO_SUFFIX.get(exch_code, "")
@@ -91,6 +94,11 @@ async def _resolve_via_openfigi(
     id_type: str, id_value: str, api_key: str
 ) -> str | None:
     """Post one id to OpenFIGI and return the preferred yfinance ticker."""
+    cache_key = (id_type, id_value)
+    if cache_key in _cache:
+        logger.debug("OpenFIGI cache hit for %s %s", id_type, id_value)
+        return _cache[cache_key]
+
     headers: dict[str, str] = {"Content-Type": "application/json"}
     if api_key:
         headers["X-OPENFIGI-APIKEY"] = api_key
@@ -117,9 +125,11 @@ async def _resolve_via_openfigi(
     try:
         results: list[dict[str, Any]] = data[0]["data"]
     except (KeyError, IndexError, TypeError):
+        _cache[cache_key] = None
         return None
 
     if not results:
+        _cache[cache_key] = None
         return None
 
     by_exch: dict[str, dict[str, Any]] = {}
@@ -139,6 +149,7 @@ async def _resolve_via_openfigi(
 
     ticker = chosen.get("ticker")
     if not ticker:
+        _cache[cache_key] = None
         return None
 
     exch_code = str(chosen.get("exchCode", ""))
@@ -151,6 +162,7 @@ async def _resolve_via_openfigi(
         exch_code,
         yf_ticker,
     )
+    _cache[cache_key] = yf_ticker
     return yf_ticker
 
 

--- a/tests/test_openfigi_lookup.py
+++ b/tests/test_openfigi_lookup.py
@@ -6,9 +6,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import app.services.openfigi_lookup as _openfigi_module
 from app.services.openfigi_lookup import resolve_wkn
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _clear_openfigi_cache():
+    _openfigi_module._cache.clear()
+    yield
+    _openfigi_module._cache.clear()
 
 
 def _mock_response(json_data: object, status_code: int = 200) -> MagicMock:


### PR DESCRIPTION
## Summary
- Adds a module-level `_cache` dict to avoid redundant OpenFIGI API calls for the same `(id_type, id_value)` pair
- Both successful and failed lookups are cached (including `None` results)
- Test fixture added to clear the cache between test runs

## Test plan
- [ ] `pytest tests/test_openfigi_lookup.py` — all 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)