### PR TITLE
feat(api): dashboard endpoints for portfolio value and Bitcoin

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.config import Settings, get_settings
 from app.database import build_engine, build_session_factory, close_db, init_db
 from app.routers import (
     admin,
+    dashboard,
     health,
     holdings,
     htmx,
@@ -133,6 +134,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Routers
     # ------------------------------------------------------------------
     app.include_router(health.router)
+    app.include_router(dashboard.router)
     app.include_router(portfolio.router)
     app.include_router(stocks.router)
     app.include_router(holdings.router, prefix="/api/v1")

--- a/app/routers/dashboard.py
+++ b/app/routers/dashboard.py
@@ -1,0 +1,62 @@
+"""Lightweight JSON endpoints for the Raspberry Pi touch screen dashboard."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_async_session
+from app.schemas.dashboard import DashboardBitcoinValue, DashboardPortfolioValue
+from app.services.portfolio_service import PortfolioService
+
+router = APIRouter(prefix="/api/v1/portfolio", tags=["dashboard"])
+
+_DB = Depends(get_async_session)
+
+
+@router.get("/value", response_model=DashboardPortfolioValue)
+async def get_portfolio_value(db: AsyncSession = _DB) -> DashboardPortfolioValue:
+    """Return the current total portfolio value in EUR."""
+    summary = await PortfolioService().get_summary(db)
+    return DashboardPortfolioValue(
+        total_value=summary.total_value,
+        currency="EUR",
+        as_of=datetime.datetime.now(datetime.timezone.utc),
+    )
+
+
+@router.get("/bitcoin", response_model=DashboardBitcoinValue)
+async def get_bitcoin_value(db: AsyncSession = _DB) -> DashboardBitcoinValue:
+    """Return the current BTC holding's price, value, and portfolio share."""
+    summary = await PortfolioService().get_summary(db)
+    btc = next(
+        (
+            h
+            for h in summary.holdings
+            if h.asset_type == "CRYPTO" and h.ticker.upper().startswith("BTC")
+        ),
+        None,
+    )
+    if btc is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No Bitcoin holding found",
+        )
+
+    percentage: Decimal | None = None
+    if btc.current_value is not None and summary.total_value:
+        percentage = (btc.current_value / summary.total_value * 100).quantize(
+            Decimal("0.01")
+        )
+
+    return DashboardBitcoinValue(
+        ticker=btc.ticker,
+        name=btc.name,
+        quantity=btc.quantity,
+        current_price=btc.current_price,
+        current_value=btc.current_value,
+        percentage_of_portfolio=percentage,
+    )

--- a/app/schemas/dashboard.py
+++ b/app/schemas/dashboard.py
@@ -1,0 +1,23 @@
+"""Pydantic schemas for the dashboard REST API endpoints."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class DashboardPortfolioValue(BaseModel):
+    total_value: Decimal | None
+    currency: str
+    as_of: datetime.datetime
+
+
+class DashboardBitcoinValue(BaseModel):
+    ticker: str
+    name: str
+    quantity: Decimal
+    current_price: Decimal | None
+    current_value: Decimal | None
+    percentage_of_portfolio: Decimal | None

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,133 @@
+"""Tests for GET /api/v1/portfolio/value and /api/v1/portfolio/bitcoin."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+from app.schemas.holdings import HoldingSummaryItem, PortfolioSummary
+from app.services import chart_cache
+
+
+def _btc_holding() -> HoldingSummaryItem:
+    return HoldingSummaryItem(
+        id=1,
+        ticker="BTC-EUR",
+        name="Bitcoin",
+        asset_type="CRYPTO",
+        quantity=Decimal("0.5"),
+        current_price=Decimal("45000.00"),
+        current_value=Decimal("22500.00"),
+    )
+
+
+def _stock_holding() -> HoldingSummaryItem:
+    return HoldingSummaryItem(
+        id=2,
+        ticker="AAPL",
+        name="Apple Inc.",
+        asset_type="STOCK",
+        quantity=Decimal("10"),
+        current_price=Decimal("180.00"),
+        current_value=Decimal("1800.00"),
+    )
+
+
+def _seed_cache(holdings: list[HoldingSummaryItem], total_value: Decimal | None) -> None:
+    chart_cache.set("summary", PortfolioSummary(holdings=holdings, total_value=total_value))
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/portfolio/value
+# ---------------------------------------------------------------------------
+
+
+async def test_portfolio_value_no_holdings(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    _seed_cache([], None)
+
+    response = await client.get("/api/v1/portfolio/value")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_value"] is None
+    assert data["currency"] == "EUR"
+    assert "as_of" in data
+
+
+async def test_portfolio_value_with_holdings(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    _seed_cache([_btc_holding(), _stock_holding()], Decimal("24300.00"))
+
+    response = await client.get("/api/v1/portfolio/value")
+    assert response.status_code == 200
+    data = response.json()
+    assert Decimal(data["total_value"]) == Decimal("24300.00")
+    assert data["currency"] == "EUR"
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/portfolio/bitcoin
+# ---------------------------------------------------------------------------
+
+
+async def test_bitcoin_not_found(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    _seed_cache([_stock_holding()], Decimal("1800.00"))
+
+    response = await client.get("/api/v1/portfolio/bitcoin")
+    assert response.status_code == 404
+    assert "Bitcoin" in response.json()["detail"]
+
+
+async def test_bitcoin_returns_correct_fields(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    _seed_cache([_btc_holding(), _stock_holding()], Decimal("24300.00"))
+
+    response = await client.get("/api/v1/portfolio/bitcoin")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ticker"] == "BTC-EUR"
+    assert data["name"] == "Bitcoin"
+    assert Decimal(data["quantity"]) == Decimal("0.5")
+    assert Decimal(data["current_price"]) == Decimal("45000.00")
+    assert Decimal(data["current_value"]) == Decimal("22500.00")
+
+
+async def test_bitcoin_percentage_of_portfolio(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    _seed_cache([_btc_holding(), _stock_holding()], Decimal("24300.00"))
+
+    response = await client.get("/api/v1/portfolio/bitcoin")
+    data = response.json()
+    expected = (Decimal("22500.00") / Decimal("24300.00") * 100).quantize(Decimal("0.01"))
+    assert Decimal(data["percentage_of_portfolio"]) == expected
+
+
+async def test_bitcoin_no_price_no_percentage(
+    client: AsyncClient, mock_session: MagicMock
+) -> None:
+    unpriced_btc = HoldingSummaryItem(
+        id=1,
+        ticker="BTC-EUR",
+        name="Bitcoin",
+        asset_type="CRYPTO",
+        quantity=Decimal("0.5"),
+        current_price=None,
+        current_value=None,
+    )
+    _seed_cache([unpriced_btc], None)
+
+    response = await client.get("/api/v1/portfolio/bitcoin")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current_price"] is None
+    assert data["current_value"] is None
+    assert data["percentage_of_portfolio"] is None


### PR DESCRIPTION
## Summary

Implements issue #146 — two lightweight JSON endpoints for the Raspberry Pi touch screen dashboard:

- **`GET /api/v1/portfolio/value`** — returns total portfolio value in EUR with an `as_of` UTC timestamp
- **`GET /api/v1/portfolio/bitcoin`** — returns BTC ticker, quantity, current price/value, and `percentage_of_portfolio`; returns 404 if no BTC holding is found

## Implementation notes

- New router `app/routers/dashboard.py` with prefix `/api/v1/portfolio`, registered in `app/main.py`
- New Pydantic schemas in `app/schemas/dashboard.py` (`DashboardPortfolioValue`, `DashboardBitcoinValue`)
- Both endpoints call `PortfolioService.get_summary()`, which already has a 5-minute in-memory cache — no extra DB load
- Bitcoin is identified by `asset_type == "CRYPTO"` and `ticker.upper().startswith("BTC")`
- CORS is already handled globally via the `allowed_hosts` middleware in `create_app()`

## Test plan

- [x] 6 new tests in `tests/test_dashboard.py` covering empty portfolio, value with holdings, BTC not found (404), correct fields, percentage calculation, and no-price edge case
- [x] All 6 pass; pre-existing failures in `test_portfolio_page.py` are unrelated to this change

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)