### PR TITLE
fix: parse real comdirect Dividendengutschrift table layout

### DIFF
--- a/app/services/comdirect_dividend_parser.py
+++ b/app/services/comdirect_dividend_parser.py
@@ -33,20 +33,39 @@ _WKN_RE = re.compile(r"^[A-Z0-9]{6}$")
 # A German-formatted decimal: "1.234,56", "940,32", "117,5406", or "8".
 _DE_NUMBER = r"\d{1,3}(?:\.\d{3})*(?:,\d+)?"
 
-# "Referenz-Nr. : 1AINA2WQGJM0064Z" → stable reference for idempotency.
-_REF_RE = re.compile(r"Referenz-Nr\.\s*:\s*([A-Z0-9]+)")
+# "Referenz-Nr. : 1AINA2WQGJM0064Z" or "Referenz-Nr. 1AINA2WQGJM0064Z" (no colon,
+# as printed in the "Information zur steuerlichen Behandlung..." footnote).
+_REF_RE = re.compile(r"Referenz-Nr\.\s*:?\s*([A-Z0-9]+)")
 # "Depotbestand : 10" or "Depotbestand 10" → shares held on dividend date.
 _SHARES_RE = re.compile(rf"Depotbestand\s*:?\s*(?P<shares>{_DE_NUMBER})")
-# "Verrechnung über Konto ... EUR 123,45" → net amount (EUR).
+# "STK 10,000 ..." → fallback share count when Depotbestand is just a column
+# header with no value glued to it (real Dividendengutschrift layout).
+_STK_QTY_RE = re.compile(rf"\bSTK\s+(?P<qty>{_DE_NUMBER})")
+# "Verrechnung über Konto ... EUR 123,45" → net amount (EUR), single-line form.
 _AMOUNT_RE = re.compile(
     rf"Verrechnung\s+(?:ü|ue)ber\s+Konto[^\n]*?(?P<amount>{_DE_NUMBER})\s*$", re.MULTILINE
 )
+# Table form: "Verrechnung über Konto (IBAN) Valuta Zu Ihren Gunsten vor Steuern"
+# header followed by a data row "<IBAN> <ccy> <date> EUR <amount>" on the next line.
+_AMOUNT_TABLE_RE = re.compile(
+    rf"Verrechnung\s+(?:ü|ue)ber\s+Konto.*?\n[^\n]*?EUR\s+(?P<amount>{_DE_NUMBER})\s*$",
+    re.MULTILINE | re.DOTALL,
+)
 # "Quellensteuer USD 0,15 ..." or "Quellensteuer EUR 10,00" → withheld tax (currency and amount).
 _TAX_RE = re.compile(rf"Quellensteuer\s+(?P<ccy>[A-Z]{{3}})\s+(?P<tax>{_DE_NUMBER})", re.MULTILINE)
-# "Devisenkurs ... 1,0950" → FX rate (when tax is in non-EUR currency).
-_FX_RATE_RE = re.compile(rf"Devisenkurs\s*:\s*(?P<rate>{_DE_NUMBER})")
-# "Valuta: 12.03.2026" or "Valuta 12.03.2026" → settlement date.
+# "Devisenkurs ... 1,0950" or "Devisenkurs: EUR/USD 1,198000" → FX rate (when tax
+# is in non-EUR currency); the currency pair is only present on some layouts.
+_FX_RATE_RE = re.compile(
+    rf"Devisenkurs\s*:?\s*(?:[A-Z]{{3}}/[A-Z]{{3}}\s+)?(?P<rate>{_DE_NUMBER})"
+)
+# "Valuta: 12.03.2026" or "Valuta 12.03.2026" → settlement date, single-line form.
 _VALUTA_RE = re.compile(r"Valuta\s*:?\s*(\d{2})\.(\d{2})\.(\d{4})")
+# Table form: "Valuta" is just a column header; the date sits in the
+# "Verrechnung über Konto" data row instead ("<IBAN> <ccy> <date> EUR <amount>").
+_VALUTA_TABLE_RE = re.compile(
+    r"Verrechnung\s+(?:ü|ue)ber\s+Konto.*?\n[^\n]*?(\d{2})\.(\d{2})\.(\d{4})",
+    re.MULTILINE | re.DOTALL,
+)
 # Extract the descriptor (e.g., "Quartalsdividende") after "zahlbar ab <date>".
 _DESCRIPTOR_RE = re.compile(r"zahlbar\s+ab\s+\d{2}\.\d{2}\.\d{4}\s+(.+?)(?:\s*$|$)", re.MULTILINE)
 
@@ -96,14 +115,20 @@ class ComdirectDividendParser:
             return None
 
         # Extract mandatory fields.
-        amount_m = _AMOUNT_RE.search(text)
+        amount_m = _AMOUNT_RE.search(text) or _AMOUNT_TABLE_RE.search(text)
         if amount_m is None:
             return None
         amount = _de_decimal(amount_m.group("amount"))
 
-        # Extract shares (Depotbestand) — used for display but doesn't affect position.
+        # Extract shares — used for display but doesn't affect position. Prefer
+        # "Depotbestand : N"; fall back to the "STK N" quantity when
+        # Depotbestand is just a column header with no value glued to it.
         shares_m = _SHARES_RE.search(text)
-        shares = _de_decimal(shares_m.group("shares")) if shares_m else Decimal("0")
+        if shares_m:
+            shares = _de_decimal(shares_m.group("shares"))
+        else:
+            qty_m = _STK_QTY_RE.search(text)
+            shares = _de_decimal(qty_m.group("qty")) if qty_m else Decimal("0")
 
         # Extract tax (Quellensteuer) and FX rate if needed.
         tax = Decimal("0")
@@ -201,7 +226,7 @@ class ComdirectDividendParser:
     @staticmethod
     def _extract_valuta_date(text: str) -> datetime.datetime:
         """Parse the ``Valuta`` date as a UTC datetime, defaulting to now."""
-        m = _VALUTA_RE.search(text)
+        m = _VALUTA_RE.search(text) or _VALUTA_TABLE_RE.search(text)
         if m is None:
             return datetime.datetime.now(datetime.UTC)
         day, month, year = (int(g) for g in m.groups())

--- a/tests/test_comdirect_dividend_parser.py
+++ b/tests/test_comdirect_dividend_parser.py
@@ -26,6 +26,59 @@ def _stub_price_warmup():
         yield
 
 
+# Real comdirect Dividendengutschrift layout (pdfplumber/"robust" extraction):
+# the security identifier trails the name instead of leading it, "Depotbestand"
+# is a bare column header, and "Verrechnung ueber Konto" / "Valuta" are table
+# headers whose values live in the *next* line rather than the same line.
+REAL_LAYOUT_USD_DIVIDEND_TEXT = """\
+DD762/11/09
+12345 Musterstadt
+Depotnr.:
+BLZ:
+10289 010
+Herrn
+Max Mustermann
+30.01.2026
+Gutschrift faelliger Wertpapier-Ertraege
+Dividendengutschrift
+Depotbestand Wertpapier-Bezeichnung WKN/ISIN
+per 30.12.2025 Stryker Corp. 864952
+STK 10,000 Registered Shares DL -,10 US8636671013
+Emissionsland: VEREINIGTE STAATEN
+USD 0,88 Dividende pro Stueck fuer Geschaeftsjahr 01.01.25 bis 31.12.25
+zahlbar ab 30.01.2026 Quartalsdividende
+Abrechnung Dividendengutschrift
+Bruttobetrag: USD 8,80
+15,000 % Quellensteuer USD 1,32 -
+Ausmachender Betrag USD 7,48
+zum Devisenkurs: EUR/USD 1,198000 EUR 6,24
+Verrechnung ueber Konto (IBAN) Valuta Zu Ihren Gunsten vor Steuern
+DE17 0897 00 EUR 03.02.2026 EUR 6,24
+Information zur steuerlichen Behandlung dieses Geschaeftsvorganges und den auf
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung
+(Referenz-Nr. 1AINA2WQGJM0064Z).
+Ihre comdirect
+*Diese Abrechnung wird von der Bank nicht unterschrieben
+"""
+
+
+def test_parse_text_real_layout_extracts_all_fields() -> None:
+    """Regression test for the actual comdirect Dividendengutschrift layout,
+    where 'Verrechnung ueber Konto' / 'Valuta' are table headers and the
+    amount/date live on the following data row instead of the same line."""
+    trade = ComdirectDividendParser().parse_text(REAL_LAYOUT_USD_DIVIDEND_TEXT)
+    assert trade is not None
+    assert trade.trade_type == TX_TYPE_DIVIDEND
+    assert trade.wkn == "864952"
+    assert trade.isin == "US8636671013"
+    assert trade.shares == Decimal("10.000")
+    assert trade.amount == Decimal("6.24")
+    assert trade.currency == "EUR"
+    assert trade.date == datetime.datetime(2026, 2, 3, tzinfo=datetime.UTC)
+    assert trade.order_ref == "1AINA2WQGJM0064Z"
+    assert trade.tax == Decimal("1.32") * Decimal("1.198000")
+
+
 FIXTURE_PDF_USD = Path(__file__).parent / "fixtures" / "sample_comdirect_dividend_usd.pdf"
 FIXTURE_PDF_EUR = Path(__file__).parent / "fixtures" / "sample_comdirect_dividend_eur.pdf"
 


### PR DESCRIPTION
## Summary
- The comdirect dividend parser merged in #150 was tested only against a synthetic fixture whose layout doesn't match real comdirect PDFs, causing every real Dividendengutschrift import to fail with "No holdings found".
- Real PDFs render "Verrechnung ueber Konto" / "Valuta" as table headers, with the amount and settlement date on the *next* line rather than the same line — the amount regex required a same-line match and always failed.
- Also fixes the reference-number regex (real footnote has no colon: `Referenz-Nr. XXX` vs `Referenz-Nr. : XXX`) and the FX-rate regex (real layout has an `EUR/USD` currency pair before the rate).
- Added a regression test built from the actual (anonymized) real-document text.

## Test plan
- [x] `pytest tests/test_comdirect_dividend_parser.py` — 17 passed, including new real-layout regression test
- [x] Full suite: `pytest` — 273 passed
- [x] `ruff check` — clean
- [x] Manually verified `parse_text` against the user's real extracted PDF text — correctly extracts WKN 864952 / ISIN US8636671013, 10 shares, EUR 6.24 net amount, EUR 1.58 tax, date 2026-02-03, dedup ref 1AINA2WQGJM0064Z