### PR TITLE
feat: warn on duplicates in single-PDF import preview

### DIFF
--- a/app/routers/import_pdf.py
+++ b/app/routers/import_pdf.py
@@ -93,13 +93,15 @@ async def import_pdf_preview(
 
     # Single-file path — existing flow, untouched.
     if len(files) == 1:
-        return await _handle_single_file(request, files[0])
+        return await _handle_single_file(request, files[0], db)
 
     # Multi-file batch path.
     return await _handle_batch(request, files, db)
 
 
-async def _handle_single_file(request: Request, file: UploadFile) -> HTMLResponse:
+async def _handle_single_file(
+    request: Request, file: UploadFile, db: AsyncSession
+) -> HTMLResponse:
     """Original single-file flow: comdirect trade or generic holdings preview."""
     contents = await file.read()
 
@@ -121,7 +123,7 @@ async def _handle_single_file(request: Request, file: UploadFile) -> HTMLRespons
             trade is not None,
         )
         if trade is not None:
-            return await _preview_comdirect(request, trade)
+            return await _preview_comdirect(request, trade, db)
         t0 = time.perf_counter()
         pairs = _parser.extract(tmp_path)
         logger.info(
@@ -225,7 +227,9 @@ async def _handle_batch(
     )
 
 
-async def _preview_comdirect(request: Request, trade: ParsedTrade) -> HTMLResponse:
+async def _preview_comdirect(
+    request: Request, trade: ParsedTrade, db: AsyncSession
+) -> HTMLResponse:
     """Resolve the WKN/ISIN to a ticker and render the rich trade preview."""
     key = getattr(getattr(request.app.state, "settings", None), "openfigi_api_key", "")
     ticker: str | None = None
@@ -253,10 +257,19 @@ async def _preview_comdirect(request: Request, trade: ParsedTrade) -> HTMLRespon
         "set" if key else "unset",
     )
 
+    is_duplicate: bool | None = None
+    if ticker is not None:
+        is_duplicate = await _service.check_is_duplicate(trade, ticker, db)
+
     return _render(
         request,
         "import_pdf.html",
-        {"step": "preview_trade", "trade": trade, "ticker": ticker},
+        {
+            "step": "preview_trade",
+            "trade": trade,
+            "ticker": ticker,
+            "is_duplicate": is_duplicate,
+        },
     )
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -289,6 +289,15 @@
       margin-bottom: 1rem;
       font-size: 0.9rem;
     }
+    .warning {
+      color: var(--accent);
+      background: rgba(212, 146, 74, 0.08);
+      border: 1px solid rgba(212, 146, 74, 0.25);
+      border-radius: var(--radius-sm);
+      padding: 0.7rem 1rem;
+      margin-bottom: 1rem;
+      font-size: 0.9rem;
+    }
 
     /* ── Ticker hints ────────────────────────────────────────── */
     .ticker-hint {

--- a/app/templates/import_pdf.html
+++ b/app/templates/import_pdf.html
@@ -104,6 +104,12 @@
       Could not resolve a ticker from WKN {{ trade.wkn }} / ISIN {{ trade.isin }}.
       Enter the tracked ticker manually to import this trade.
     </div>
+    {% elif is_duplicate == true %}
+    <div class="warning">
+      This looks like a duplicate — a matching {{ trade.trade_type }} transaction
+      for {{ ticker }} on {{ trade.date.date() }} may already be in your
+      portfolio. Confirming will skip it rather than import it twice.
+    </div>
     {% endif %}
     <table class="table-striped">
       <tbody>

--- a/tests/test_import_pdf.py
+++ b/tests/test_import_pdf.py
@@ -76,6 +76,52 @@ async def test_import_pdf_post_valid_pdf_shows_all_tickers(client: AsyncClient) 
 
 
 # ---------------------------------------------------------------------------
+# POST /import/pdf  — single comdirect trade preview (duplicate check)
+# ---------------------------------------------------------------------------
+
+FIXTURE_PDF_COMDIRECT_KAUF = Path(__file__).parent / "fixtures" / "sample_comdirect_kauf.pdf"
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_post_single_trade_flags_duplicate(client: AsyncClient) -> None:
+    """The single-file preview must warn upfront when the trade already exists,
+    mirroring the batch-upload preview's duplicate check."""
+    pdf_bytes = FIXTURE_PDF_COMDIRECT_KAUF.read_bytes()
+
+    with patch(
+        "app.routers.import_pdf.resolve_wkn", new=AsyncMock(return_value="SAP")
+    ), patch(
+        "app.routers.import_pdf._service.check_is_duplicate", new=AsyncMock(return_value=True)
+    ):
+        response = await client.post(
+            "/import/pdf",
+            files=[("files", ("kauf.pdf", pdf_bytes, "application/pdf"))],
+        )
+
+    assert response.status_code == 200
+    assert "duplicate" in response.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_import_pdf_post_single_trade_no_warning_when_new(client: AsyncClient) -> None:
+    """A non-duplicate trade must not show the duplicate warning."""
+    pdf_bytes = FIXTURE_PDF_COMDIRECT_KAUF.read_bytes()
+
+    with patch(
+        "app.routers.import_pdf.resolve_wkn", new=AsyncMock(return_value="SAP")
+    ), patch(
+        "app.routers.import_pdf._service.check_is_duplicate", new=AsyncMock(return_value=False)
+    ):
+        response = await client.post(
+            "/import/pdf",
+            files=[("files", ("kauf.pdf", pdf_bytes, "application/pdf"))],
+        )
+
+    assert response.status_code == 200
+    assert "looks like a duplicate" not in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
 # POST /import/pdf/confirm  — commit step
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- The batch PDF upload flow checks for duplicate transactions (`check_is_duplicate`) before showing its preview table, but the single-file comdirect trade preview (`preview_trade` step) skipped this check — a duplicate was only reported *after* clicking Confirm.
- `_preview_comdirect` now runs the same `check_is_duplicate` lookup once the ticker is resolved, and the preview page shows a warning banner (reusing the same amber accent styling as the batch view's "Duplicate" badge) when it matches an existing transaction.
- No change to actual import behavior — `import_trade` already skipped duplicates on confirm; this only adds the earlier warning.

## Test plan
- [x] `pytest tests/test_import_pdf.py` — 16 passed, including 2 new tests covering the duplicate-warning banner (shown/hidden)
- [x] Full suite: `pytest` — 275 passed
- [x] `ruff check` on changed files — clean (pre-existing lint issues elsewhere untouched)